### PR TITLE
Tweak: Stunprod weight

### DIFF
--- a/modular_ss220/balance/_balance.dm
+++ b/modular_ss220/balance/_balance.dm
@@ -1,0 +1,4 @@
+/datum/modpack/balance
+	name = "Баланс"
+	desc = "Твики баланса."
+	author = "dj-34"

--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -1,0 +1,3 @@
+#include "_balance.dm"
+
+#include "code/items/weapons.dm"

--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -1,0 +1,2 @@
+/obj/item/melee/baton/cattleprod
+	w_class = WEIGHT_CLASS_NORMAL

--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -30,8 +30,8 @@
 
 // --- MISC --- //
 #include "aesthetics_sounds/_aesthetics_sounds.dme"
-#include "bureaucracy/_bureaucracy.dme"
 #include "balance/_balance.dme"
+#include "bureaucracy/_bureaucracy.dme"
 #include "crawl_speed/_crawl_speed.dme"
 #include "discord_link/_discord_link.dme"
 #include "emotes/_emotes.dme"

--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -31,6 +31,7 @@
 // --- MISC --- //
 #include "aesthetics_sounds/_aesthetics_sounds.dme"
 #include "bureaucracy/_bureaucracy.dme"
+#include "balance/_balance.dme"
 #include "crawl_speed/_crawl_speed.dme"
 #include "discord_link/_discord_link.dme"
 #include "emotes/_emotes.dme"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Понижает вес станпрода до normal, чтобы его можно было положить в рюкзак

## Почему это хорошо для игры
Мы с старопары привыкли что его можно класть в рюкзак

## Изображения изменений
-

## Тестирование
Проверял в игре

## Changelog

:cl:
tweak: Вес станпрода понижен до normal
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
