### PR TITLE
SpaceRuin - Convoy Ambush

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
@@ -197,12 +197,6 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered)
-"hv" = (
-/obj/structure/shuttle/engine/router,
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/template_noop,
-/area/template_noop)
 "hV" = (
 /obj/machinery/door/poddoor,
 /obj/machinery/door_control{
@@ -856,11 +850,9 @@
 /obj/structure/closet/cardboard,
 /obj/item/reagent_containers/food/snacks/chinese/rice,
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
-/obj/item/stack/spacecash/c500,
 /obj/item/reagent_containers/food/pill/methamphetamine,
 /obj/item/reagent_containers/food/pill/methamphetamine,
 /obj/item/reagent_containers/food/pill/methamphetamine,
-/obj/item/stack/spacecash/c10,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "blackfull"
 	},
@@ -1234,10 +1226,8 @@
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
 /obj/item/reagent_containers/food/snacks/chinese/rice,
-/obj/item/stack/spacecash/c200,
 /obj/item/reagent_containers/food/pill/methamphetamine,
 /obj/item/reagent_containers/food/pill/methamphetamine,
-/obj/item/stack/spacecash/c50,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -4893,7 +4883,7 @@ Up
 KZ
 HV
 kt
-hv
+kt
 tZ
 bf
 TA

--- a/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
@@ -69,9 +69,8 @@
 	},
 /area/ruin/space/unpowered/unpowered_structures)
 "cn" = (
-/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
-	name = "Syndicate Commando"
-	},
+/obj/structure/closet/crate/secure,
+/obj/item/stack/ore/plasma,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -146,12 +145,6 @@
 /obj/effect/landmark/burnturf,
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered/unpowered_structures)
-"ei" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
-	wander = 0
-	},
-/turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "ew" = (
 /obj/structure/shuttle/engine/propulsion/burst{
@@ -237,16 +230,12 @@
 /obj/item/chair{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
-	wander = 0
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
+	name = "Syndicate Commando"
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
-/area/ruin/space/unpowered/unpowered_structures)
-"jz" = (
-/obj/machinery/porta_turret/syndicate,
-/turf/simulated/wall/mineral/plastitanium/interior,
 /area/ruin/space/unpowered/unpowered_structures)
 "jP" = (
 /obj/item/shard{
@@ -448,7 +437,6 @@
 	req_access_txt = "3"
 	},
 /obj/item/gun/energy/laser/retro/old,
-/obj/item/gun/energy/laser/retro/old,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -550,8 +538,12 @@
 /turf/template_noop,
 /area/template_noop)
 "wu" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	dir = 8
+/obj/item/stack/ore/silver{
+	amount = 25
+	},
+/obj/structure/closet/crate,
+/obj/item/stack/ore/gold{
+	amount = 25
 	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
@@ -691,9 +683,7 @@
 /turf/template_noop,
 /area/template_noop)
 "Da" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "150"
-	},
+/obj/machinery/door/airlock/external,
 /obj/structure/fans/tiny,
 /turf/simulated/floor,
 /area/ruin/space/powered)
@@ -723,19 +713,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered)
-"DC" = (
-/obj/structure/closet/crate,
-/obj/item/stack/ore/silver{
-	amount = 25
-	},
-/obj/effect/turf_decal/delivery,
-/obj/item/stack/ore/gold{
-	amount = 25
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "dark"
-	},
-/area/ruin/space/unpowered/unpowered_structures)
 "DT" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -778,15 +755,8 @@
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
 /obj/item/reagent_containers/food/snacks/chinese/rice,
-/obj/item/reagent_containers/food/pill/methamphetamine,
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "blackfull"
-	},
-/area/ruin/space/unpowered/unpowered_structures)
-"FS" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate/secure,
-/obj/item/stack/ore/plasma,
+/obj/item/stack/spacecash/c20,
+/obj/item/stack/spacecash/c10,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "blackfull"
 	},
@@ -892,9 +862,6 @@
 /area/ruin/space/unpowered/unpowered_structures)
 "IZ" = (
 /obj/effect/decal/cleanable/blood,
-/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
-	name = "Syndicate Commando"
-	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "darkbluecornersalt"
 	},
@@ -1096,10 +1063,10 @@
 /turf/simulated/wall/mineral/titanium/nodiagonal,
 /area/ruin/space/unpowered/unpowered_structures)
 "RV" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
+	name = "Syndicate Commando"
 	},
-/turf/simulated/floor/mineral/plastitanium/red,
+/turf/simulated/floor/plating/asteroid/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "RY" = (
 /obj/machinery/mass_driver_frame{
@@ -1124,6 +1091,9 @@
 "Sn" = (
 /obj/structure/closet/walllocker/emerglocker/west,
 /obj/effect/mob_spawn/human/corpse/damaged,
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
+	wander = 0
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -1145,6 +1115,10 @@
 /area/ruin/space/unpowered/unpowered_structures)
 "SR" = (
 /obj/effect/decal/cleanable/blood/oil,
+/obj/structure/closet/crate,
+/obj/item/stack/ore/titanium{
+	amount = 10
+	},
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -1191,14 +1165,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"Uh" = (
-/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
-	wander = 0
-	},
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "dark"
-	},
-/area/ruin/space/unpowered/unpowered_structures)
 "Uo" = (
 /obj/item/stack/sheet/plasteel,
 /turf/template_noop,
@@ -1226,8 +1192,7 @@
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
 /obj/item/reagent_containers/food/snacks/chinese/chowmein,
 /obj/item/reagent_containers/food/snacks/chinese/rice,
-/obj/item/reagent_containers/food/pill/methamphetamine,
-/obj/item/reagent_containers/food/pill/methamphetamine,
+/obj/item/stack/spacecash/c100,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
@@ -1252,16 +1217,6 @@
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
-	},
-/area/ruin/space/unpowered/unpowered_structures)
-"Wh" = (
-/obj/effect/turf_decal/delivery,
-/obj/item/stack/ore/titanium{
-	amount = 10
-	},
-/obj/structure/closet/crate,
-/turf/simulated/floor/plasteel/airless{
-	icon_state = "blackfull"
 	},
 /area/ruin/space/unpowered/unpowered_structures)
 "Wq" = (
@@ -2459,13 +2414,13 @@ wr
 wr
 wr
 wr
-jz
+GX
 GX
 GX
 GX
 Da
 GX
-jz
+GX
 wr
 wr
 wr
@@ -2633,7 +2588,7 @@ wr
 wr
 KG
 Dt
-zU
+bA
 bA
 zU
 yO
@@ -2747,7 +2702,7 @@ wr
 wr
 KG
 OT
-zU
+bA
 bA
 zU
 yO
@@ -2844,7 +2799,7 @@ wr
 hV
 tW
 st
-Uh
+Wv
 NK
 Dq
 lY
@@ -2915,13 +2870,13 @@ wr
 wr
 wr
 wr
-jz
+GX
 GX
 GX
 GX
 Da
 GX
-jz
+GX
 wr
 wr
 wr
@@ -3017,7 +2972,7 @@ Sw
 cj
 aX
 Wv
-cn
+Wv
 cG
 Py
 wr
@@ -4758,11 +4713,11 @@ wr
 zo
 zo
 Jj
+RV
 Jj
 Jj
 Jj
 Jj
-ei
 Jj
 aZ
 Jj
@@ -4832,7 +4787,7 @@ Ra
 yr
 LF
 SR
-Wv
+cn
 fV
 RP
 wr
@@ -4873,8 +4828,8 @@ oq
 oq
 bd
 bA
-RV
-RV
+bA
+bA
 nP
 Jj
 zo
@@ -4887,9 +4842,9 @@ kt
 tZ
 bf
 TA
-vU
-Wh
-FS
+wB
+rI
+rI
 SA
 RP
 wr
@@ -4944,8 +4899,8 @@ kt
 zv
 bj
 wB
+vU
 wB
-DC
 dO
 SA
 RP
@@ -5002,7 +4957,7 @@ zv
 nI
 st
 Wv
-Uh
+Wv
 wu
 Nj
 RP

--- a/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
@@ -1,0 +1,5903 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aX" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"aZ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"bb" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -27;
+	name = "intercom"
+	},
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"bd" = (
+/obj/structure/closet/syndicate,
+/obj/item/storage/backpack/duffel/syndie,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"bf" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/shuttle/engine/router,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"bj" = (
+/obj/structure/shuttle/engine/router,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"bq" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"bA" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"bV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/turf/template_noop,
+/area/template_noop)
+"ci" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 5
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"cj" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
+	wander = 0
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"cn" = (
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
+	name = "Syndicate Commando"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"cG" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"cJ" = (
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = -10;
+	pixel_x = 16
+	},
+/turf/template_noop,
+/area/template_noop)
+"dq" = (
+/obj/machinery/light_construct/small{
+	icon_state = "bulb-broken";
+	dir = 8
+	},
+/obj/structure/closet,
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
+	},
+/obj/item/clothing/head/soft,
+/obj/item/clothing/head/soft,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"dx" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure/weapon{
+	opened = 1
+	},
+/obj/item/clothing/mask/balaclava,
+/obj/item/kitchen/knife/combat,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"dI" = (
+/obj/structure/computerframe{
+	dir = 8
+	},
+/obj/item/stack/cable_coil{
+	amount = 1
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 4
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"dO" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure,
+/obj/item/stack/ore/plasma{
+	amount = 2
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"eh" = (
+/obj/effect/landmark/burnturf,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"ei" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
+	wander = 0
+	},
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"ew" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 2
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"eJ" = (
+/obj/machinery/light_construct{
+	icon_state = "bulb-broken";
+	dir = 8
+	},
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"fL" = (
+/turf/simulated/floor/plasteel/stairs{
+	dir = 8
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"fV" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/crate/engineering,
+/obj/item/screwdriver,
+/obj/item/wrench,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"gK" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/clothing/accessory/storage,
+/obj/item/clothing/accessory/holster,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"hg" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"hv" = (
+/obj/structure/shuttle/engine/router,
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"hV" = (
+/obj/machinery/door/poddoor,
+/obj/machinery/door_control{
+	pixel_x = -30
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"ia" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"ie" = (
+/obj/item/stack/sheet/mineral/titanium,
+/turf/template_noop,
+/area/template_noop)
+"it" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"iD" = (
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "large";
+	pixel_y = 9
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = -10;
+	pixel_x = 16
+	},
+/obj/effect/landmark/burnturf,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"iU" = (
+/obj/item/chair{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
+	wander = 0
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"jz" = (
+/obj/machinery/porta_turret/syndicate,
+/turf/simulated/wall/mineral/plastitanium/interior,
+/area/ruin/space/unpowered/unpowered_structures)
+"jP" = (
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/template_noop,
+/area/template_noop)
+"jU" = (
+/obj/item/chair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"kd" = (
+/turf/simulated/floor/plasteel/stairs{
+	dir = 8
+	},
+/area/ruin/space/powered)
+"kt" = (
+/obj/structure/shuttle/engine/router,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"lG" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"lY" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"mq" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"mu" = (
+/obj/structure/lattice,
+/obj/item/rack_parts,
+/turf/template_noop,
+/area/template_noop)
+"mU" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"mZ" = (
+/obj/item/pickaxe,
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"nd" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -27;
+	name = "intercom"
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/organ/internal/beard,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"ne" = (
+/turf/simulated/wall/mineral/titanium,
+/area/ruin/space/unpowered/unpowered_structures)
+"nI" = (
+/obj/structure/closet/crate,
+/obj/item/storage/bag/ore,
+/obj/item/storage/backpack/satchel/explorer,
+/obj/item/gun/energy/plasmacutter,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"nK" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	autolink_id = "air_in";
+	on = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"nP" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 2
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ruin/space/unpowered/unpowered_structures)
+"nV" = (
+/obj/item/flashlight,
+/turf/template_noop,
+/area/template_noop)
+"nW" = (
+/turf/simulated/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/unpowered/unpowered_structures)
+"ok" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"oq" = (
+/obj/effect/spawner/window/plastitanium,
+/turf/simulated/floor,
+/area/ruin/space/unpowered/unpowered_structures)
+"oE" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/template_noop,
+/area/template_noop)
+"pv" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/ore_box,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"qa" = (
+/obj/structure/table,
+/obj/item/folder/yellow{
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 6
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"rp" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"rI" = (
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"sn" = (
+/obj/structure/disposalpipe/segment{
+	pixel_x = -1;
+	name = "Cannon Bore"
+	},
+/turf/simulated/wall/mineral/plastitanium/interior,
+/area/ruin/space/unpowered/unpowered_structures)
+"st" = (
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"tv" = (
+/obj/structure/table_frame,
+/obj/item/lighter{
+	pixel_x = 8
+	},
+/obj/effect/landmark/burnturf,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"tU" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure/weapon{
+	opened = 1
+	},
+/obj/item/gun/energy/disabler,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"tW" = (
+/obj/effect/landmark/damageturf,
+/obj/structure/closet/crate/secure/weapon{
+	req_access_txt = "3"
+	},
+/obj/item/gun/energy/laser/retro/old,
+/obj/item/gun/energy/laser/retro/old,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"tZ" = (
+/obj/structure/lattice,
+/obj/structure/shuttle/engine/router,
+/turf/template_noop,
+/area/template_noop)
+"uf" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"uW" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/cans/beer,
+/obj/item/reagent_containers/food/drinks/cans/beer{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/obj/item/deck/cards/tiny{
+	pixel_x = -10
+	},
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"vo" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"vy" = (
+/obj/structure/closet/walllocker/emerglocker/west,
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"vP" = (
+/obj/structure/table,
+/obj/machinery/door_control{
+	pixel_x = -6
+	},
+/obj/item/folder/yellow{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 5
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"vU" = (
+/obj/effect/turf_decal/delivery,
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
+	name = "Syndicate Commando"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"vV" = (
+/obj/machinery/computer{
+	dir = 2;
+	icon_keyboard = "syndie_key";
+	icon_screen = "syndinavigation"
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"wc" = (
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/template_noop,
+/area/template_noop)
+"wf" = (
+/obj/effect/decal/warning_stripes/northeast,
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"wm" = (
+/obj/machinery/door/airlock/command,
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"wr" = (
+/turf/template_noop,
+/area/template_noop)
+"wu" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"wB" = (
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"wS" = (
+/obj/machinery/door/airlock/external,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"xn" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"yr" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"yN" = (
+/obj/machinery/constructable_frame,
+/obj/item/circuitboard/pacman,
+/obj/item/stack/cable_coil{
+	amount = 5
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"yO" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"yS" = (
+/obj/machinery/door/airlock/command,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"yT" = (
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 8
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 2
+	},
+/obj/structure/closet/crate,
+/obj/item/grenade/frag,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"zo" = (
+/turf/simulated/mineral,
+/area/ruin/space/unpowered/unpowered_structures)
+"zv" = (
+/obj/machinery/door/poddoor,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"zU" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"Ad" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"Ay" = (
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"Bv" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/template_noop,
+/area/template_noop)
+"BO" = (
+/obj/structure/disposalpipe/segment{
+	pixel_x = -1;
+	name = "Cannon Bore"
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"BU" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Cd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/dock_marker{
+	name = "transport way beacon"
+	},
+/turf/template_noop,
+/area/template_noop)
+"Ci" = (
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 8;
+	autolink_id = "air_in";
+	on = 1
+	},
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"CB" = (
+/obj/structure/door_assembly/door_assembly_ext,
+/turf/template_noop,
+/area/template_noop)
+"Da" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "150"
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/floor,
+/area/ruin/space/powered)
+"De" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Dj" = (
+/obj/structure/closet/syndicate,
+/obj/item/storage/box/donkpockets,
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"Dq" = (
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Dt" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -2
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"DC" = (
+/obj/structure/closet/crate,
+/obj/item/stack/ore/silver{
+	amount = 25
+	},
+/obj/effect/turf_decal/delivery,
+/obj/item/stack/ore/gold{
+	amount = 25
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"DT" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluecornersalt";
+	dir = 4
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"EB" = (
+/obj/structure/computerframe{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 4
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"ET" = (
+/obj/item/shovel,
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Fw" = (
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/powered)
+"FF" = (
+/obj/machinery/light/small{
+	icon_state = "bulb-broken";
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/chinese/chowmein,
+/obj/item/reagent_containers/food/snacks/chinese/chowmein,
+/obj/item/reagent_containers/food/snacks/chinese/rice,
+/obj/item/reagent_containers/food/pill/methamphetamine,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"FS" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate/secure,
+/obj/item/stack/ore/plasma,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"FZ" = (
+/obj/structure/extinguisher_cabinet{
+	name = "west bump";
+	pixel_x = -27
+	},
+/obj/effect/landmark/burnturf,
+/obj/item/organ/external/arm,
+/obj/item/organ/external/hand,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"GP" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas,
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 6
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"GT" = (
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"GW" = (
+/obj/structure/computerframe{
+	dir = 8
+	},
+/obj/item/shard{
+	icon_state = "small"
+	},
+/obj/item/organ/internal/eyes,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 4
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"GX" = (
+/turf/simulated/wall/mineral/plastitanium/interior,
+/area/ruin/space/unpowered/unpowered_structures)
+"Hx" = (
+/obj/structure/computerframe{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"HA" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/chinese/rice,
+/obj/item/reagent_containers/food/snacks/chinese/chowmein,
+/obj/item/stack/spacecash/c500,
+/obj/item/reagent_containers/food/pill/methamphetamine,
+/obj/item/reagent_containers/food/pill/methamphetamine,
+/obj/item/reagent_containers/food/pill/methamphetamine,
+/obj/item/stack/spacecash/c10,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"HI" = (
+/turf/simulated/mineral/random/low_chance,
+/area/ruin/space/unpowered/unpowered_structures)
+"HV" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/obj/structure/shuttle/engine/router,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"IL" = (
+/obj/item/airlock_electronics/destroyed,
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"IM" = (
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 2
+	},
+/obj/structure/closet/crate,
+/obj/item/grenade/frag,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"IN" = (
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
+	name = "Syndicate Commando"
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"IZ" = (
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/space{
+	name = "Syndicate Commando"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluecornersalt"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Jf" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Jj" = (
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"JS" = (
+/obj/item/shard,
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"KG" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/machinery/door/poddoor{
+	id_tag = "convoy_window"
+	},
+/turf/simulated/floor,
+/area/ruin/space/unpowered/unpowered_structures)
+"KK" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure/computerframe{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"KX" = (
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"KY" = (
+/obj/machinery/light_construct{
+	icon_state = "bulb-broken";
+	dir = 8
+	},
+/obj/structure/closet,
+/obj/structure/sign/nosmoking_1{
+	pixel_x = -32
+	},
+/obj/item/clothing/head/soft,
+/obj/item/clothing/head/soft,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"KZ" = (
+/obj/structure/shuttle/engine/router,
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Lo" = (
+/obj/effect/decal/warning_stripes/east,
+/obj/structure{
+	desc = "A power generator that runs on solid plasma sheets. Rated for 80 kW max safe output.";
+	icon = 'icons/obj/power.dmi';
+	icon_state = "portgen0_0";
+	name = "\improper P.A.C.M.A.N.-type Portable Generator"
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"LF" = (
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Md" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"MV" = (
+/obj/structure/table,
+/obj/machinery/door_control{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = 8
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluealtstrip";
+	dir = 5
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Nj" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/t_scanner,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"NK" = (
+/obj/effect/landmark/damageturf,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"OT" = (
+/obj/structure/table,
+/obj/machinery/door_control{
+	pixel_x = -6;
+	id = "convoy_window"
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"Py" = (
+/obj/structure/girder/reinforced,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"PE" = (
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/powered)
+"PZ" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate,
+/turf/template_noop,
+/area/template_noop)
+"Qq" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"QK" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"QN" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/welding,
+/obj/item/weldingtool,
+/obj/item/screwdriver,
+/turf/simulated/floor/plating/asteroid/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"QV" = (
+/obj/structure/grille/broken,
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = 9
+	},
+/obj/effect/landmark/damageturf,
+/obj/effect/decal/cleanable/glass,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Ra" = (
+/obj/effect/landmark/burnturf,
+/obj/structure/shuttle/engine/router,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Ru" = (
+/obj/machinery/mass_driver_frame{
+	dir = 1;
+	name = "Kinetic Cannon";
+	anchored = 1
+	},
+/obj/structure/disposalpipe/segment{
+	pixel_x = -1;
+	name = "Cannon Bore"
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 2
+	},
+/turf/simulated/floor,
+/area/ruin/space/unpowered/unpowered_structures)
+"RP" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/ruin/space/unpowered/unpowered_structures)
+"RV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"RY" = (
+/obj/machinery/mass_driver_frame{
+	dir = 1;
+	name = "Kinetic Cannon";
+	anchored = 1
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	pixel_x = -1;
+	name = "Cannon Bore"
+	},
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 2
+	},
+/turf/simulated/floor,
+/area/ruin/space/unpowered/unpowered_structures)
+"Sn" = (
+/obj/structure/closet/walllocker/emerglocker/west,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Sw" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/mob_spawn/human/corpse/damaged,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"SA" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"SR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Tg" = (
+/obj/item/storage/fancy/cigarettes/cigpack_robust,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/organ/internal/ears,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"TA" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"TF" = (
+/obj/structure/closet/syndicate,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/gun/projectile/automatic/pistol,
+/obj/structure/window/plasmareinforced{
+	color = "#FF0000";
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"TT" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/powered)
+"TU" = (
+/obj/structure/lattice,
+/obj/machinery/light_construct{
+	icon_state = "bulb-broken";
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"Uh" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib{
+	wander = 0
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Uo" = (
+/obj/item/stack/sheet/plasteel,
+/turf/template_noop,
+/area/template_noop)
+"Up" = (
+/obj/machinery/mass_driver_frame{
+	pixel_y = -21;
+	anchored = 1
+	},
+/obj/machinery/conveyor_switch{
+	pixel_x = 10;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidfloor"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"UE" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet/cardboard,
+/obj/item/reagent_containers/food/snacks/chinese/rice,
+/obj/item/reagent_containers/food/snacks/chinese/chowmein,
+/obj/item/reagent_containers/food/snacks/chinese/chowmein,
+/obj/item/reagent_containers/food/snacks/chinese/rice,
+/obj/item/stack/spacecash/c200,
+/obj/item/reagent_containers/food/pill/methamphetamine,
+/obj/item/reagent_containers/food/pill/methamphetamine,
+/obj/item/stack/spacecash/c50,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Vm" = (
+/obj/item/rack_parts,
+/obj/effect/landmark/burnturf,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"VO" = (
+/obj/structure/table,
+/obj/item/grenade/plastic/c4,
+/obj/item/clothing/glasses/sunglasses,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered/unpowered_structures)
+"VX" = (
+/obj/item/chair,
+/obj/item/stack/cable_coil{
+	amount = 1
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Wh" = (
+/obj/effect/turf_decal/delivery,
+/obj/item/stack/ore/titanium{
+	amount = 10
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Wq" = (
+/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/atmospherics/portable/canister,
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+"Wv" = (
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Xg" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/item/organ/external/chest,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "darkbluecornersalt";
+	dir = 4
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"YG" = (
+/obj/machinery/light_construct{
+	icon_state = "bulb-broken";
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"YP" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "dark"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Ze" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "blackfull"
+	},
+/area/ruin/space/unpowered/unpowered_structures)
+"Zv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	pixel_x = -1;
+	name = "Cannon Bore"
+	},
+/turf/template_noop,
+/area/template_noop)
+"ZW" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/item/shard{
+	icon_state = "medium";
+	pixel_y = -10;
+	pixel_x = 16
+	},
+/turf/simulated/floor/plating/airless,
+/area/ruin/space/unpowered/unpowered_structures)
+
+(1,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(2,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(3,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(4,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(5,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+Cd
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+Cd
+bq
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+"}
+(6,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+"}
+(7,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+"}
+(8,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+"}
+(9,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+"}
+(10,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+"}
+(11,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+"}
+(12,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+zo
+zo
+zo
+zo
+zo
+Jj
+zo
+wr
+wr
+wr
+wr
+wr
+"}
+(13,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+zo
+zo
+zo
+Jj
+Jj
+Jj
+Jj
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(14,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+Uo
+zo
+zo
+zo
+HI
+zo
+zo
+Jj
+Jj
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(15,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+Jj
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(16,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+Jj
+Jj
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(17,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(18,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(19,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+HI
+HI
+zo
+zo
+zo
+zo
+lY
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+Qq
+bq
+wr
+wr
+wr
+zo
+zo
+wr
+wr
+wr
+wr
+nK
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(20,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+lY
+wr
+wr
+ok
+wr
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+jz
+GX
+GX
+GX
+Da
+GX
+jz
+wr
+wr
+wr
+wr
+"}
+(21,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+lY
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+BO
+Ru
+sn
+vo
+hg
+bA
+nW
+GX
+GX
+wr
+wr
+wr
+"}
+(22,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+GX
+nW
+PE
+IM
+bA
+TF
+GX
+ew
+wr
+wr
+wr
+"}
+(23,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+KG
+Dt
+zU
+bA
+zU
+yO
+ew
+wr
+wr
+wr
+"}
+(24,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+HI
+HI
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+ne
+De
+De
+De
+bV
+jP
+wr
+Hx
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+KG
+vV
+zU
+IN
+zU
+yO
+ew
+wr
+wr
+wr
+"}
+(25,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+RP
+RP
+BU
+ZW
+JS
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+KG
+OT
+zU
+bA
+zU
+yO
+ew
+wr
+wr
+wr
+"}
+(26,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+RP
+KY
+wf
+yN
+gK
+Md
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+GX
+nW
+Ay
+yT
+bA
+Dj
+GX
+ew
+wr
+wr
+wr
+"}
+(27,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+hV
+tW
+st
+Uh
+NK
+Dq
+lY
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+Zv
+RY
+sn
+Ad
+xn
+bA
+nW
+GX
+GX
+wr
+wr
+wr
+"}
+(28,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+wr
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zv
+mU
+dx
+wB
+aX
+Dq
+Dq
+PZ
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+jz
+GX
+GX
+GX
+Da
+GX
+jz
+wr
+wr
+wr
+wr
+"}
+(29,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zv
+YP
+wB
+rI
+tU
+NK
+NK
+Py
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+Ci
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(30,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zv
+Sw
+cj
+aX
+Wv
+cn
+cG
+Py
+wr
+wr
+wr
+wr
+wr
+ie
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(31,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+RP
+TT
+kd
+pv
+UE
+HA
+FF
+RP
+wr
+wr
+wr
+wr
+lY
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(32,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+RP
+RP
+yS
+RP
+RP
+RP
+RP
+Py
+wc
+wr
+wr
+ie
+cJ
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(33,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+HI
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wS
+eJ
+iU
+nd
+vy
+FZ
+TU
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(34,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+RP
+ci
+Xg
+Tg
+VX
+GT
+eh
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(35,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+ia
+ia
+vP
+dI
+GW
+tv
+bq
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(36,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+ia
+ia
+ia
+QV
+iD
+mu
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(37,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(38,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(39,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+wr
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+zo
+zo
+wr
+wr
+wr
+"}
+(40,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+"}
+(41,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+"}
+(42,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+wr
+zo
+zo
+wr
+wr
+wr
+"}
+(43,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(44,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(45,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(46,1,1) = {"
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(47,1,1) = {"
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+wr
+wr
+wr
+wr
+bq
+Cd
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+Cd
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(48,1,1) = {"
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+HI
+HI
+zo
+zo
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(49,1,1) = {"
+wr
+wr
+wr
+zo
+zo
+zo
+HI
+HI
+HI
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(50,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(51,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+Jj
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(52,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+Jj
+Jj
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(53,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+Jj
+Jj
+Jj
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(54,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+Jj
+Jj
+Jj
+Jj
+Jj
+Jj
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(55,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+Jj
+Jj
+zo
+zo
+Jj
+Jj
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(56,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+Jj
+zo
+zo
+Jj
+Jj
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(57,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+Jj
+zo
+zo
+zo
+zo
+zo
+oE
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(58,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+Jj
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(59,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+Jj
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+ne
+De
+De
+De
+De
+De
+De
+ne
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(60,1,1) = {"
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+mZ
+zo
+QN
+uW
+lG
+zo
+wr
+wr
+wr
+RP
+RP
+BU
+BU
+BU
+BU
+RP
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(61,1,1) = {"
+wr
+wr
+wr
+zo
+zo
+Jj
+Jj
+Jj
+Jj
+Jj
+ei
+Jj
+aZ
+Jj
+zo
+zo
+wr
+wr
+RP
+dq
+wf
+Lo
+KK
+Wq
+Ze
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(62,1,1) = {"
+wr
+wr
+wr
+wr
+GX
+GX
+Da
+GX
+GX
+GX
+Jj
+Jj
+KX
+QK
+QK
+zo
+wr
+kt
+hV
+Ra
+yr
+LF
+SR
+Wv
+fV
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(63,1,1) = {"
+wr
+wr
+wr
+oq
+oq
+bd
+bA
+RV
+RV
+nP
+Jj
+zo
+KX
+Up
+KZ
+HV
+kt
+hv
+tZ
+bf
+TA
+vU
+Wh
+FS
+SA
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(64,1,1) = {"
+wr
+wr
+wr
+oq
+vV
+zU
+bA
+bA
+bA
+nP
+Jj
+Jj
+KX
+QK
+QK
+wr
+wr
+kt
+zv
+bj
+wB
+wB
+DC
+dO
+SA
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(65,1,1) = {"
+wr
+wr
+wr
+oq
+oq
+VO
+rp
+it
+it
+nP
+Jj
+zo
+Jj
+zo
+wr
+wr
+wr
+wr
+zv
+nI
+st
+Wv
+Uh
+wu
+Nj
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(66,1,1) = {"
+wr
+wr
+wr
+wr
+GX
+GX
+GX
+GX
+GX
+GX
+Jj
+Jj
+Jj
+zo
+wr
+wr
+wr
+Bv
+RP
+Fw
+fL
+pv
+pv
+pv
+pv
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(67,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+ET
+Jj
+Jj
+Jj
+zo
+Jj
+Jj
+oE
+wr
+wr
+wr
+RP
+RP
+wm
+RP
+RP
+RP
+RP
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(68,1,1) = {"
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+lY
+YG
+IL
+bb
+Sn
+mq
+Jf
+wS
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(69,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+lY
+wr
+wr
+wr
+CB
+RP
+Vm
+DT
+jU
+uf
+IZ
+GP
+RP
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(70,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+ia
+ia
+MV
+EB
+EB
+qa
+ia
+ia
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(71,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+zo
+nV
+wr
+wr
+wr
+wr
+wr
+wr
+ia
+ia
+ia
+ia
+ia
+ia
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(72,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(73,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+zo
+zo
+zo
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(74,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(75,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(76,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+Cd
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+Cd
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(77,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+bq
+bq
+bq
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(78,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(79,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}
+(80,1,1) = {"
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+wr
+"}

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -629,6 +629,7 @@ active_space_ruins = [
 	"_maps/map_files220/RandomRuins/SpaceRuins/destroyed_infiltrator.dmm",
 	"_maps/map_files220/RandomRuins/SpaceRuins/transit_bar.dmm",
 	"_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm",
+	"_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm",
 
 
 	### The following ruins are based from past pre-spawned Zlevel content ###

--- a/modular_ss220/_maps220/code/RandomRuins/space_ruins.dm
+++ b/modular_ss220/_maps220/code/RandomRuins/space_ruins.dm
@@ -47,3 +47,12 @@
 	suffix = "infected_ship.dmm"
 	cost = 3
 	allow_duplicates = FALSE
+
+/datum/map_template/ruin/space/convoy_ambush
+	name = "Convoy Ambush"
+	id = "convoy_ambush"
+	description = "I've been waiting for this for twuh years!"
+	prefix = "_maps/map_files220/RandomRuins/SpaceRuins/"
+	suffix = "convoy_ambush.dmm"
+	cost = 3
+	allow_duplicates = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавление новой косморуины: засада на группу транспортных кораблей NT (port/remap caravanambush from Skyrat)
Лут: дизейблер, два списанных ретро лазергана, 760 кредитов, 3 мета по 10 u., 2 фраг гранаты, стечкин, c4, плазмакаттер.

## Почему это хорошо для игры

Больше косморуин - больше косморуин

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/139562134/eb3fc0d9-3aed-4ece-a0fd-ace8858cd4ab)

## Тестирование
Работает, молюсь на ребейз

## Changelog

:cl:
add: новая карта - convoy_ambush

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
