### PR TITLE
Feat: Actualization of the Cyberiad, part 1

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -775,15 +775,14 @@
 /area/station/security/main)
 "aeC" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/hos{
-	pixel_x = -4;
-	pixel_y = -6
-	},
+/obj/item/reagent_containers/food/drinks/mug/hos,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/lighter/zippo/hos,
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/carpet,
 /area/station/command/office/hos)
 "aeD" = (
@@ -2335,6 +2334,7 @@
 	name = "east bump";
 	pixel_x = 24
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3297,8 +3297,19 @@
 /area/station/security/warden)
 "aoz" = (
 /obj/structure/table/reinforced,
-/obj/item/crowbar,
-/obj/item/radio,
+/obj/item/radio/security{
+	pixel_x = -8
+	},
+/obj/item/radio/security{
+	pixel_x = -4
+	},
+/obj/item/radio/security,
+/obj/item/radio/security{
+	pixel_x = 4
+	},
+/obj/item/radio/security{
+	pixel_x = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -3524,11 +3535,13 @@
 /obj/item/book/manual/wiki/sop_legal,
 /obj/item/paper/armory,
 /obj/item/clipboard,
+/obj/item/stamp/warden,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
 /area/station/security/warden)
 "aph" = (
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkred"
 	},
@@ -3663,6 +3676,7 @@
 	c_tag = "Brig Security Equipment South";
 	dir = 4
 	},
+/obj/item/crowbar/red,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -5865,7 +5879,6 @@
 /turf/space,
 /area/space/nearstation)
 "axp" = (
-/obj/structure/bookcase/sop,
 /obj/machinery/requests_console{
 	department = "Internal Affairs Office";
 	name = "Internal Affairs Requests Console";
@@ -5874,6 +5887,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -6392,7 +6406,6 @@
 	dir = 4;
 	id = "IAA";
 	pixel_x = -24;
-	pixel_y = 6;
 	req_one_access_txt = "38"
 	},
 /obj/machinery/economy/vending/lawdrobe,
@@ -7248,8 +7261,8 @@
 	id = "magistrateofficedoor";
 	name = "Office Door";
 	normaldoorcontrol = 1;
-	pixel_x = 25;
-	pixel_y = -4;
+	pixel_x = 24;
+	pixel_y = -6;
 	req_one_access_txt = "74"
 	},
 /turf/simulated/floor/carpet,
@@ -7724,11 +7737,11 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/pen/multi/gold,
+/obj/item/stamp/magistrate,
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "aCj" = (
 /obj/structure/table/reinforced,
-/obj/item/stamp/magistrate,
 /obj/item/paper_bin/nanotrasen,
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -8735,11 +8748,6 @@
 /area/station/legal/magistrate)
 "aFp" = (
 /obj/structure/table,
-/obj/item/folder/yellow{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/pen/multi,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8748,6 +8756,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/pen/multi,
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -8755,11 +8765,12 @@
 "aFq" = (
 /obj/structure/table,
 /obj/item/folder/blue{
-	pixel_x = 5
+	pixel_x = 10;
+	pixel_y = 4
 	},
 /obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8768,6 +8779,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/item/folder/yellow{
+	pixel_x = 14;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -12950,6 +12965,7 @@
 /obj/machinery/ai_status_display{
 	pixel_x = -32
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17219,26 +17235,27 @@
 /area/station/hallway/secondary/entry)
 "bhP" = (
 /obj/structure/table,
-/obj/item/radio/off{
-	pixel_y = 16
-	},
-/obj/item/radio/off{
-	pixel_x = -8;
-	pixel_y = 10
-	},
-/obj/item/radio/off{
-	pixel_x = 8;
-	pixel_y = 10
-	},
-/obj/item/radio/off{
-	pixel_y = 6
-	},
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
+/obj/item/radio/alternative{
+	pixel_y = 12
+	},
+/obj/item/radio/alternative{
+	pixel_y = 6
+	},
+/obj/item/radio/alternative{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/radio/alternative{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/radio/alternative,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -17290,6 +17307,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/station/service/library)
 "bid" = (
@@ -22898,11 +22916,9 @@
 	pixel_y = 2
 	},
 /obj/item/stamp/cmo,
-/obj/item/balltoy{
-	pixel_y = -14
-	},
-/obj/item/lighter/zippo/blue{
-	pixel_x = 14;
+/obj/effect/spawner/lootdrop/officetoys,
+/obj/item/lighter/zippo/cmo{
+	pixel_x = 16;
 	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -23597,6 +23613,7 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
+/obj/item/lighter/zippo/cap,
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
 "bIN" = (
@@ -25536,7 +25553,7 @@
 	},
 /area/station/science/robotics)
 "bRo" = (
-/obj/structure/closet/secure_closet/quartermaster,
+/obj/machinery/computer/card/minor/qm,
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office"
 	},
@@ -26553,7 +26570,7 @@
 	dir = 8;
 	id = "qm";
 	pixel_x = 24;
-	pixel_y = 5;
+	pixel_y = 8;
 	req_one_access_txt = "41"
 	},
 /obj/machinery/light_switch{
@@ -26562,6 +26579,11 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "bVr" = (
@@ -27154,6 +27176,11 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "bYu" = (
@@ -27288,6 +27315,10 @@
 /area/station/supply/office)
 "bYL" = (
 /obj/effect/spawner/window/reinforced,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
 "bYM" = (
@@ -29050,9 +29081,11 @@
 	},
 /area/station/science/server/coldroom)
 "ceN" = (
-/obj/item/paper/monitorkey,
-/obj/item/megaphone,
 /obj/structure/table/glass,
+/obj/item/lighter/zippo/rd,
+/obj/item/paicard,
+/obj/item/megaphone,
+/obj/item/paper/monitorkey,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkpurple"
@@ -29782,6 +29815,10 @@
 	network = list("Research","SS13")
 	},
 /obj/item/reagent_containers/food/drinks/mug/rd,
+/obj/item/taperecorder{
+	pixel_x = -3
+	},
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkpurple"
@@ -30215,13 +30252,7 @@
 	},
 /area/station/command/office/rd)
 "cjO" = (
-/obj/structure/rack,
-/obj/item/taperecorder{
-	pixel_x = -3
-	},
-/obj/item/paicard{
-	pixel_x = 4
-	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -37395,11 +37426,12 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/item/stack/tape_roll,
 /obj/machinery/camera/motion{
 	c_tag = "EVA Motion Sensor";
 	dir = 4
 	},
+/obj/item/book/manual/evaguide,
+/obj/item/stack/tape_roll,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -40371,6 +40403,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -42414,13 +42447,19 @@
 /area/station/engineering/hallway)
 "daf" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/evaguide,
 /obj/machinery/requests_console{
 	department = "EVA";
 	name = "EVA Requests Console";
 	pixel_x = -32
 	},
 /obj/effect/decal/warning_stripes/white/hollow,
+/obj/item/paper/pamphlet/gateway{
+	pixel_x = -4
+	},
+/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway{
+	pixel_x = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -43854,9 +43893,7 @@
 /area/station/engineering/atmos/control)
 "deY" = (
 /obj/structure/table/reinforced,
-/obj/item/lighter/zippo{
-	pixel_y = 3
-	},
+/obj/item/lighter/zippo/ce,
 /obj/item/storage/fancy/cigarettes{
 	pixel_x = 10;
 	pixel_y = 4
@@ -43880,6 +43917,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -46689,6 +46727,7 @@
 	pixel_y = -32
 	},
 /obj/item/taperecorder,
+/obj/item/lighter/zippo/nt_rep,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
 "dpu" = (
@@ -49224,6 +49263,26 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/equipmentstorage)
+"dVB" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "dVG" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -50664,6 +50723,7 @@
 "etL" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
 "etR" = (
@@ -50986,6 +51046,7 @@
 	name = "east bump";
 	pixel_x = 22
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -51111,6 +51172,13 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
+"eCN" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "eDs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/structure/cable{
@@ -52248,6 +52316,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "faB" = (
@@ -52911,9 +52980,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "fnX" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
+/obj/machinery/door/airlock/command/qm/glass,
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "qm"
 	},
@@ -52922,6 +52989,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
 "foi" = (
@@ -55791,6 +55859,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -55874,6 +55947,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -55993,6 +56067,7 @@
 /obj/structure/table/wood,
 /obj/machinery/light/small,
 /obj/item/reagent_containers/food/drinks/mug/novelty,
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
 "gsg" = (
@@ -58582,14 +58657,14 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/item/toy/crayon/mime{
-	pixel_x = -8;
-	pixel_y = 2
-	},
 /obj/item/pen/red{
 	pixel_x = 2;
 	pixel_y = 6
 	},
+/obj/item/stamp/mime{
+	pixel_x = -8
+	},
+/obj/item/toy/crayon/mime,
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
 "hjR" = (
@@ -59413,7 +59488,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "hyR" = (
-/obj/structure/table,
 /obj/item/toy/figure/crew/cargotech,
 /obj/item/cartridge/quartermaster,
 /obj/item/cartridge/quartermaster{
@@ -59423,6 +59497,17 @@
 /obj/item/cartridge/quartermaster{
 	pixel_x = 6;
 	pixel_y = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/toy/figure/crew/qm,
+/obj/item/coin/silver{
+	pixel_y = 5;
+	pixel_x = 3
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -62570,6 +62655,16 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detective)
+"iHd" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "iHu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63645,6 +63740,10 @@
 "jdi" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
@@ -64920,6 +65019,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"jBs" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel,
+/area/station/supply/office)
 "jBA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -66292,6 +66395,11 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -67861,6 +67969,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
 "kKD" = (
@@ -69655,7 +69773,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/cabinet,
+/obj/machinery/papershredder,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
 "ltK" = (
@@ -70932,6 +71050,13 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
+"lRp" = (
+/obj/structure/tribune{
+	dir = 8;
+	anchored = 1
+	},
+/turf/simulated/floor/carpet,
+/area/station/legal/courtroom)
 "lRt" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /obj/structure/cable{
@@ -71169,6 +71294,16 @@
 	},
 /area/station/engineering/hallway)
 "lVy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -74733,6 +74868,16 @@
 /area/station/hallway/primary/port)
 "nlc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "nlj" = (
@@ -75414,13 +75559,13 @@
 	},
 /area/station/science/hallway)
 "nxg" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -76679,12 +76824,10 @@
 /area/station/engineering/control)
 "nWW" = (
 /obj/structure/table/wood,
-/obj/item/pen/multi/fountain{
-	pixel_y = 4
-	},
 /obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 3
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
 	},
 /obj/item/radio/intercom{
 	dir = 1;
@@ -76693,6 +76836,13 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/item/lighter/zippo/hop{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/obj/item/pen/multi/fountain{
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
@@ -76834,6 +76984,7 @@
 	pixel_y = 3;
 	req_one_access_txt = "57"
 	},
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -77737,9 +77888,7 @@
 	},
 /area/station/science/hallway)
 "opY" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Quartermaster"
-	},
+/obj/machinery/door/airlock/command/qm/glass,
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "qm"
 	},
@@ -77759,6 +77908,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/qm,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
 "oqc" = (
@@ -79755,7 +79905,6 @@
 	},
 /obj/item/gun/projectile/revolver/russian,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,
-/obj/item/lighter/zippo/nt_rep,
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 /obj/item/toy/figure/crew/captain,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83129,6 +83278,11 @@
 /area/station/security/permabrig)
 "qmH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "browncorner"
@@ -84376,6 +84530,11 @@
 "qIg" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/quartermaster,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "qIl" = (
@@ -87903,6 +88062,10 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/supermatter_room)
+"sbJ" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel,
+/area/station/security/main)
 "sbP" = (
 /obj/machinery/light{
 	dir = 1
@@ -89376,7 +89539,7 @@
 /area/station/maintenance/fsmaint)
 "sBO" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/item/paper_bin/nanotrasen,
 /obj/item/pen{
 	pixel_x = 4;
 	pixel_y = 4
@@ -89573,6 +89736,21 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
+"sEe" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "sEl" = (
 /obj/structure/bed,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -90364,6 +90542,16 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
+"sTy" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "sTE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92840,6 +93028,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/small,
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -93534,22 +93723,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
 "tZo" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "west bump";
-	pixel_x = -22
-	},
 /obj/structure/table,
-/obj/item/coin/silver{
-	pixel_x = 3;
-	pixel_y = 5
+/obj/machinery/photocopier/faxmachine{
+	department = "Quartermaster's Office"
 	},
-/obj/item/toy/figure/crew/qm,
-/obj/machinery/power/apc{
+/obj/item/radio/intercom{
+	dir = 1;
 	name = "south bump";
-	pixel_y = -24
+	pixel_y = -22
 	},
-/obj/structure/cable,
+/obj/machinery/light,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "brown"
@@ -95783,6 +95966,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
+"uPU" = (
+/obj/structure/sign/vacuum/external,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "uPV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -97019,7 +97206,12 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/aft)
 "vnZ" = (
-/obj/item/kirbyplants,
+/obj/machinery/suit_storage_unit/qm/secure,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -98652,6 +98844,13 @@
 	pixel_y = 16
 	},
 /obj/structure/table,
+/obj/item/crutches,
+/obj/item/crutches{
+	pixel_x = 4
+	},
+/obj/item/crutches{
+	pixel_x = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -102457,6 +102656,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
 "xoE" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -104655,6 +104864,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"ybr" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "ybE" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -122874,7 +123093,7 @@ aaa
 bPT
 bRI
 sft
-bPT
+uPU
 sft
 bUg
 bPT
@@ -123388,7 +123607,7 @@ bKB
 bKB
 bRI
 bTr
-bKB
+bxb
 bTr
 bUg
 bKB
@@ -125701,11 +125920,11 @@ ojT
 ceE
 bYM
 bYM
-jdi
-jdi
-jdi
+ybr
+dVB
+eCN
 bYM
-jdi
+iHd
 fnX
 bYM
 bYM
@@ -126479,7 +126698,7 @@ khl
 qmH
 kKg
 hyR
-bYL
+sTy
 aaa
 aaa
 cam
@@ -126729,8 +126948,8 @@ kLn
 bKB
 bYM
 bYM
-jdi
-jdi
+ybr
+sEe
 bYM
 bYM
 vnZ
@@ -128013,7 +128232,7 @@ bDX
 bSK
 bPV
 bRN
-bBn
+jBs
 itH
 bBn
 bYJ
@@ -130799,7 +131018,7 @@ aAp
 aAp
 aKl
 aKl
-aKl
+aLR
 aKl
 qJg
 aAp
@@ -131056,7 +131275,7 @@ aAp
 aHz
 aIX
 fda
-aLR
+lRp
 pYd
 aOw
 fFz
@@ -132591,8 +132810,8 @@ ayN
 aDe
 aAM
 aCf
-aLE
 aCf
+aLE
 aFp
 aDe
 aHD
@@ -138226,7 +138445,7 @@ anA
 akv
 alp
 alG
-aoJ
+sbJ
 oHE
 aoJ
 aoR

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -13335,11 +13335,8 @@
 /turf/simulated/wall,
 /area/station/service/bar)
 "aUT" = (
-/obj/structure/window/reinforced{
+/turf/simulated/floor/plasteel/stairs{
 	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
 	},
 /area/station/public/dorms)
 "aUU" = (
@@ -13473,12 +13470,6 @@
 	},
 /area/station/command/vault)
 "aVo" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/table/wood,
 /obj/item/instrument/eguitar,
 /turf/simulated/floor/plasteel{
@@ -13486,10 +13477,8 @@
 	},
 /area/station/public/dorms)
 "aVp" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/table/wood,
+/obj/item/megaphone,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -13504,6 +13493,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/platform{
+	dir = 8;
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -13516,12 +13509,6 @@
 	},
 /area/station/service/expedition)
 "aVs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
 /turf/simulated/floor/plasteel{
@@ -13979,6 +13966,10 @@
 /obj/structure/chair/stool{
 	dir = 4
 	},
+/obj/structure/platform{
+	dir = 4;
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -14010,11 +14001,13 @@
 	},
 /area/station/public/dorms)
 "aWU" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/platform/corner{
+	dir = 8;
+	anchored = 1
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/public/dorms)
 "aWV" = (
@@ -14029,12 +14022,10 @@
 	},
 /area/station/maintenance/fsmaint)
 "aWW" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/platform/corner{
+	anchored = 1
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aXc" = (
 /obj/machinery/crema_switch{
@@ -14448,10 +14439,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 2
-	},
+/obj/machinery/economy/vending/medidrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -14917,24 +14905,34 @@
 	},
 /area/station/public/dorms)
 "aZC" = (
-/obj/effect/decal/warning_stripes/white/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/platform/corner{
+	dir = 1;
+	anchored = 1
 	},
+/turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aZD" = (
-/obj/effect/decal/warning_stripes/white,
-/obj/effect/landmark/start/assistant,
+/obj/structure/platform{
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "caution"
 	},
 /area/station/public/dorms)
 "aZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/platform{
+	dir = 8;
+	anchored = 1
+	},
+/obj/structure/chair/stool{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "rampbottom"
+	dir = 8;
+	icon_state = "caution"
 	},
 /area/station/public/dorms)
 "aZF" = (
@@ -15369,8 +15367,12 @@
 	},
 /area/station/hallway/primary/central/north)
 "bbu" = (
+/obj/structure/platform{
+	dir = 1;
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "rampbottom"
+	icon_state = "caution"
 	},
 /area/station/public/dorms)
 "bbv" = (
@@ -21037,6 +21039,10 @@
 	icon_state = "blue"
 	},
 /area/station/command/bridge)
+"bxP" = (
+/obj/machinery/door/window/classic/normal,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "bxQ" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/wood,
@@ -23036,6 +23042,8 @@
 	dir = 8
 	},
 /obj/structure/table/glass,
+/obj/item/storage/bag/chemistry,
+/obj/item/storage/bag/chemistry,
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas{
 	pixel_y = 6
@@ -23332,16 +23340,19 @@
 /area/station/medical/reception)
 "bHJ" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/cans/dr_gibb{
-	pixel_x = -4;
-	pixel_y = 7
-	},
 /obj/item/reagent_containers/food/drinks/mug/med{
-	pixel_x = 6;
+	pixel_x = 7;
 	pixel_y = -10
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/cans/dr_gibb{
+	pixel_y = -15;
+	pixel_x = -5
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
@@ -23450,9 +23461,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/item/storage/bag/chemistry,
-/obj/item/storage/bag/chemistry,
+/obj/machinery/economy/vending/chemdrobe,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellowcorner"
 	},
@@ -31864,7 +31873,7 @@
 /obj/machinery/atmospherics/portable/canister,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
 "cqa" = (
@@ -32270,7 +32279,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
 "crN" = (
@@ -53681,9 +53690,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/warden)
 "fAO" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
+/obj/structure/railing/cap/normal,
 /turf/simulated/floor/carpet/black,
 /area/station/service/bar/atrium)
 "fBj" = (
@@ -60373,7 +60380,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "hOJ" = (
-/obj/structure/closet/chefcloset,
+/obj/machinery/economy/vending/chefdrobe,
 /obj/machinery/alarm{
 	dir = 8;
 	name = "east bump";
@@ -62243,7 +62250,9 @@
 /area/station/maintenance/disposal)
 "iBD" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel{
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/public/dorms)
@@ -65281,6 +65290,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"jKA" = (
+/obj/machinery/door/window/classic/reversed,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "jKH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67371,7 +67384,7 @@
 	},
 /area/station/security/permabrig)
 "kBh" = (
-/obj/structure/railing/corner{
+/obj/structure/railing/cap/reversed{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/black,
@@ -78081,6 +78094,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
+"otX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/platform/corner{
+	dir = 4;
+	anchored = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/public/dorms)
 "oub" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/utility)
@@ -89821,7 +89846,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
 "sGl" = (
@@ -95253,6 +95278,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/platform{
+	dir = 8;
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -97155,9 +97184,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "vqm" = (
-/obj/structure/closet/gmcloset{
-	name = "formal wardrobe"
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -97166,6 +97192,7 @@
 	name = "east bump";
 	pixel_x = 22
 	},
+/obj/machinery/economy/vending/bardrobe,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/bar)
 "vqp" = (
@@ -101298,7 +101325,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
 "wQr" = (
@@ -103367,7 +103394,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
 "xFQ" = (
@@ -105286,7 +105313,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/maintenance/asmaint2)
 "ylb" = (
@@ -140922,11 +140949,11 @@ aJw
 lFe
 ckc
 aQv
-aPm
+aWW
 aWP
 aWP
 aWP
-aPm
+aWU
 aPm
 mGQ
 aOI
@@ -141179,11 +141206,11 @@ dwg
 lFe
 aPf
 aQv
-aSM
+aZD
 aVo
-aWU
-aWU
-bbv
+aZG
+aZG
+bbu
 aPm
 oKl
 aOI
@@ -141436,10 +141463,10 @@ aMI
 iHu
 aPf
 aQv
-aSM
+jKA
 aUT
+aZG
 aWT
-aZC
 bbu
 bdj
 bfq
@@ -141693,10 +141720,10 @@ aMJ
 aOg
 aFI
 aZs
-aSM
+aZD
 aVp
 iBD
-aZD
+aWT
 bbu
 bdj
 bfv
@@ -141950,10 +141977,10 @@ aFI
 aFI
 aFI
 aQE
-aSM
+bxP
 aUT
+aZG
 aWT
-aZC
 bbu
 bdj
 kGL
@@ -142207,11 +142234,11 @@ lFa
 lFa
 raG
 fzl
-aSM
+aZD
 aVs
-aWW
 aZG
-bbv
+aZG
+bbu
 aPm
 bfy
 aOI
@@ -142464,11 +142491,11 @@ aFJ
 aFJ
 aOI
 aQG
-wpY
+aZC
 aVq
 uCQ
 aZE
-wsA
+otX
 wsA
 xfi
 aOI

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -19688,10 +19688,7 @@
 	layer = 2.9
 	},
 /obj/item/extinguisher,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bsf" = (
@@ -20191,10 +20188,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "buc" = (
@@ -20697,10 +20691,7 @@
 /area/station/public/locker)
 "bwK" = (
 /obj/structure/closet/emcloset,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bwL" = (
@@ -21964,10 +21955,7 @@
 /area/space)
 "bCj" = (
 /obj/structure/closet/emcloset,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "bCm" = (
@@ -29312,10 +29300,7 @@
 /area/station/medical/ward)
 "cfP" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "cfR" = (
@@ -29594,10 +29579,7 @@
 /area/station/maintenance/asmaint2)
 "cho" = (
 /obj/structure/closet/firecloset,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "chp" = (
@@ -33784,10 +33766,7 @@
 /turf/simulated/floor/plating,
 /area/station/public/construction)
 "cxA" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "cxB" = (
@@ -36056,10 +36035,7 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -37747,10 +37723,7 @@
 /area/station/maintenance/aft)
 "cKQ" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "cKS" = (
@@ -39282,10 +39255,7 @@
 /area/station/science/hallway)
 "cQC" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "cQE" = (
@@ -45620,10 +45590,7 @@
 /area/station/engineering/atmos)
 "dlj" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "dlk" = (
@@ -45900,10 +45867,7 @@
 /area/station/maintenance/aft)
 "dmr" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "dms" = (
@@ -47958,10 +47922,7 @@
 /area/station/maintenance/apmaint)
 "dxN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "dxX" = (
@@ -51752,10 +51713,7 @@
 	},
 /area/station/security/main)
 "eNn" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "eNs" = (
@@ -51781,14 +51739,8 @@
 /area/station/service/bar/atrium)
 "eOI" = (
 /obj/structure/closet/crate/trashcart,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wirerod,
 /obj/item/wirecutters,
@@ -53085,10 +53037,7 @@
 "fqt" = (
 /obj/item/storage/bag/plasticbag,
 /obj/item/trash/fried_vox,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "fqI" = (
@@ -54457,10 +54406,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "fPq" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -54761,10 +54707,7 @@
 /area/station/hallway/primary/central/west)
 "fVy" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/storage/fancy/cigarettes/dromedaryco,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -56591,10 +56534,7 @@
 /area/station/legal/courtroom)
 "gCr" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "gCU" = (
@@ -56709,10 +56649,7 @@
 /area/station/hallway/primary/central/ne)
 "gEj" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
@@ -57418,10 +57355,7 @@
 "gPk" = (
 /obj/structure/closet,
 /obj/item/stack/spacecash/c5,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
+/obj/effect/spawner/lootdrop/trash,
 /obj/machinery/light_construct/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -61053,10 +60987,7 @@
 "iac" = (
 /obj/structure/table,
 /obj/item/wrench,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "iag" = (
@@ -64139,10 +64070,7 @@
 "jmU" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "jmZ" = (
@@ -64166,10 +64094,7 @@
 	},
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "jne" = (
@@ -69400,10 +69325,7 @@
 	},
 /area/station/security/permabrig)
 "llx" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -70097,10 +70019,7 @@
 /obj/item/stack/spacecash/c10,
 /obj/item/coin/iron,
 /obj/item/coin/iron,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
+/obj/effect/spawner/lootdrop/trash,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -70702,10 +70621,7 @@
 /area/station/medical/ward)
 "lLM" = (
 /obj/structure/closet/crate/can,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/reagent_containers/syringe/insulin,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/syringe,
@@ -71739,10 +71655,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "mcx" = (
@@ -71765,14 +71678,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "mcM" = (
-/obj/structure/closet/crate/medical,
-/obj/item/crutches,
-/obj/item/crutches{
-	pixel_x = 4
-	},
-/obj/item/crutches{
-	pixel_x = 8
-	},
+/obj/structure/closet/crate/freezer/iv_storage,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -71870,10 +71776,7 @@
 /area/station/medical/morgue)
 "meB" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/tank/internals/oxygen/yellow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -74504,7 +74407,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "neH" = (
-/obj/structure/closet/crate/freezer/iv_storage,
+/obj/structure/closet/crate/medical,
+/obj/item/crutches,
+/obj/item/crutches{
+	pixel_x = 4
+	},
+/obj/item/crutches{
+	pixel_x = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -74631,10 +74541,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/crate/can,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
+/obj/effect/spawner/lootdrop/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "nhF" = (
@@ -81693,10 +81600,7 @@
 /area/station/engineering/secure_storage)
 "pGR" = (
 /obj/structure/closet/crate/can,
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
+/obj/effect/spawner/lootdrop/trash,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -87764,10 +87668,7 @@
 /area/station/aisat/service)
 "rVK" = (
 /obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "rVQ" = (
@@ -89019,10 +88920,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "ssL" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /obj/item/clothing/gloves/color/blue,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -90097,10 +89995,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "sKQ" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/sign/poster/official/help_others{
 	pixel_y = 31
 	},
@@ -94089,10 +93984,7 @@
 "ufC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "ufN" = (
@@ -102516,10 +102408,7 @@
 /area/station/command/teleporter)
 "xlg" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/item/toy/minimeteor,
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
@@ -104862,10 +104751,7 @@
 /obj/structure/rack{
 	dir = 1
 	},
-/obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/cigbutt,/obj/item/trash/cheesie,/obj/item/trash/candy,/obj/item/trash/chips,/obj/item/trash/pistachios,/obj/item/trash/plate,/obj/item/trash/popcorn,/obj/item/trash/raisins,/obj/item/trash/sosjerky,/obj/item/trash/syndi_cakes);
-	name = "trash spawner"
-	},
+/obj/effect/spawner/lootdrop/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "ybE" = (
@@ -105281,10 +105167,7 @@
 /area/station/maintenance/aft)
 "yjF" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "yjH" = (
@@ -141335,7 +141218,7 @@ iGq
 ccJ
 uhl
 bSR
-mcM
+neH
 dvz
 vHd
 bXF
@@ -143391,7 +143274,7 @@ bOB
 uYw
 bOQ
 bIq
-neH
+mcM
 dvz
 edz
 het

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -14328,7 +14328,7 @@
 	name = "west bump";
 	pixel_x = -22
 	},
-/obj/item/storage/belt/champion,
+/obj/item/storage/belt/champion/wrestling,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "vault"
@@ -24210,13 +24210,6 @@
 	icon_state = "purple"
 	},
 /area/station/science/rnd)
-"bLs" = (
-/obj/structure/tribune{
-	dir = 8;
-	anchored = 1
-	},
-/turf/simulated/floor/carpet,
-/area/station/legal/courtroom)
 "bLx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26965,6 +26958,7 @@
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/item/screwdriver/cargo,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bXc" = (
@@ -27260,16 +27254,12 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/blueshield)
 "bYG" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
 /obj/machinery/newscaster{
 	dir = 1;
 	name = "south bump";
 	pixel_y = -28
 	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bYH" = (
@@ -63911,7 +63901,6 @@
 	c_tag = "Medbay Treatment East";
 	dir = 8
 	},
-/obj/structure/closet/crate/freezer/iv_storage,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -71776,6 +71765,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "mcM" = (
+/obj/structure/closet/crate/medical,
+/obj/item/crutches,
+/obj/item/crutches{
+	pixel_x = 4
+	},
+/obj/item/crutches{
+	pixel_x = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -74507,9 +74504,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "neH" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/plasteel,
-/area/station/supply/office)
+/obj/structure/closet/crate/freezer/iv_storage,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/sleeper)
 "neO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -83864,7 +83864,8 @@
 /obj/machinery/door_control{
 	id = "stationawaygate";
 	name = "Gateway Shutters Control";
-	pixel_x = 24
+	pixel_x = 24;
+	req_one_access_txt = "62"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -98847,13 +98848,6 @@
 	pixel_y = 16
 	},
 /obj/structure/table,
-/obj/item/crutches,
-/obj/item/crutches{
-	pixel_x = 4
-	},
-/obj/item/crutches{
-	pixel_x = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -128232,7 +128226,7 @@ bDX
 bSK
 bPV
 bRN
-neH
+bBn
 itH
 bBn
 bYJ
@@ -131018,7 +131012,7 @@ aAp
 aAp
 aKl
 aKl
-aLR
+aKl
 aKl
 qJg
 aAp
@@ -131275,7 +131269,7 @@ aAp
 aHz
 aIX
 fda
-bLs
+aLR
 pYd
 aOw
 fFz
@@ -143397,7 +143391,7 @@ bOB
 uYw
 bOQ
 bIq
-mcM
+neH
 dvz
 edz
 het

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -8583,8 +8583,8 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Fore-Port Atmospherics Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aEN" = (

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -77,6 +77,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"aau" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
@@ -3831,10 +3841,10 @@
 "apV" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
-	pixel_x = -5
+	pixel_x = -3
 	},
-/obj/item/radio{
-	pixel_x = 5
+/obj/item/radio/security{
+	pixel_x = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -24200,6 +24210,13 @@
 	icon_state = "purple"
 	},
 /area/station/science/rnd)
+"bLs" = (
+/obj/structure/tribune{
+	dir = 8;
+	anchored = 1
+	},
+/turf/simulated/floor/carpet,
+/area/station/legal/courtroom)
 "bLx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40460,17 +40477,19 @@
 /area/station/engineering/supermatter_room)
 "cTF" = (
 /obj/structure/table,
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
+	},
+/obj/item/radio/alternative{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/radio/alternative{
+	pixel_y = 4
+	},
+/obj/item/radio/alternative{
+	pixel_x = 8;
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40547,22 +40566,22 @@
 /area/station/public/storage/tools/auxiliary)
 "cTT" = (
 /obj/structure/table,
-/obj/item/radio{
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/radio,
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/item/radio/alternative{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/radio/alternative{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/radio/alternative{
+	pixel_y = 12
+	},
+/obj/item/radio/alternative,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -48429,9 +48448,8 @@
 	pixel_x = 10;
 	pixel_y = 4
 	},
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 6
+/obj/item/radio/security{
+	pixel_x = -4
 	},
 /obj/machinery/alarm{
 	dir = 1;
@@ -49263,26 +49281,6 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/equipmentstorage)
-"dVB" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "qm"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "dVG" = (
 /obj/machinery/light,
 /turf/simulated/floor/plasteel{
@@ -51172,13 +51170,6 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat/interior)
-"eCN" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "qm"
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "eDs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/structure/cable{
@@ -54039,6 +54030,16 @@
 	icon_state = "white"
 	},
 /area/station/science/xenobiology)
+"fFF" = (
+/obj/effect/spawner/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "fFO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -62180,6 +62181,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"ixy" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "ixH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -62655,16 +62666,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detective)
-"iHd" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "qm"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "iHu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -63740,6 +63741,11 @@
 "jdi" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "qm"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -65019,10 +65025,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"jBs" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/plasteel,
-/area/station/supply/office)
 "jBA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65107,6 +65109,26 @@
 	icon_state = "red"
 	},
 /area/station/security/prisonlockers)
+"jDn" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "jDB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
@@ -71050,13 +71072,6 @@
 	icon_state = "white"
 	},
 /area/station/science/toxins/mixing)
-"lRp" = (
-/obj/structure/tribune{
-	dir = 8;
-	anchored = 1
-	},
-/turf/simulated/floor/carpet,
-/area/station/legal/courtroom)
 "lRt" = (
 /obj/effect/spawner/random_barrier/possibly_welded_airlock,
 /obj/structure/cable{
@@ -72995,6 +73010,16 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
+"mzC" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "mzL" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -74481,6 +74506,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"neH" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel,
+/area/station/supply/office)
 "neO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -80123,6 +80152,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"peF" = (
+/obj/structure/sign/vacuum/external,
+/turf/simulated/wall,
+/area/station/supply/storage)
 "pfj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -82040,6 +82073,10 @@
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"pOw" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel,
+/area/station/security/main)
 "pOK" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -85224,15 +85261,14 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 5
 	},
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
-/obj/item/radio,
 /obj/item/storage/belt/utility,
 /obj/machinery/camera{
 	c_tag = "Engineering Equipment Storage Lockers";
 	network = list("SS13","Engineering")
 	},
+/obj/item/radio/alternative,
+/obj/item/radio/alternative,
+/obj/item/radio/alternative,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -88062,10 +88098,6 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/supermatter_room)
-"sbJ" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/plasteel,
-/area/station/security/main)
 "sbP" = (
 /obj/machinery/light{
 	dir = 1
@@ -89736,21 +89768,6 @@
 	icon_state = "vault"
 	},
 /area/station/command/vault)
-"sEe" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "qm"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "sEl" = (
 /obj/structure/bed,
 /obj/effect/landmark/spawner/nukedisc_respawn,
@@ -90542,16 +90559,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
-"sTy" = (
-/obj/effect/spawner/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "sTE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -95966,10 +95973,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
-"uPU" = (
-/obj/structure/sign/vacuum/external,
-/turf/simulated/wall,
-/area/station/supply/storage)
 "uPV" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -103693,6 +103696,13 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/central/south)
+"xJi" = (
+/obj/effect/spawner/window/reinforced/polarized{
+	id = "qm"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/plating,
+/area/station/supply/qm)
 "xJk" = (
 /obj/item/storage/box/monkeycubes{
 	pixel_y = 3
@@ -104864,16 +104874,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"ybr" = (
-/obj/effect/spawner/window/reinforced/polarized{
-	id = "qm"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/supply/qm)
 "ybE" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -123093,7 +123093,7 @@ aaa
 bPT
 bRI
 sft
-uPU
+peF
 sft
 bUg
 bPT
@@ -125920,11 +125920,11 @@ ojT
 ceE
 bYM
 bYM
-ybr
-dVB
-eCN
+mzC
+jDn
+xJi
 bYM
-iHd
+aau
 fnX
 bYM
 bYM
@@ -126698,7 +126698,7 @@ khl
 qmH
 kKg
 hyR
-sTy
+fFF
 aaa
 aaa
 cam
@@ -126948,8 +126948,8 @@ kLn
 bKB
 bYM
 bYM
-ybr
-sEe
+mzC
+jdi
 bYM
 bYM
 vnZ
@@ -127209,7 +127209,7 @@ bVr
 bWW
 bYG
 bzJ
-jdi
+ixy
 opY
 bYM
 bYM
@@ -128232,7 +128232,7 @@ bDX
 bSK
 bPV
 bRN
-jBs
+neH
 itH
 bBn
 bYJ
@@ -131275,7 +131275,7 @@ aAp
 aHz
 aIX
 fda
-lRp
+bLs
 pYd
 aOw
 fFz
@@ -138445,7 +138445,7 @@ anA
 akv
 alp
 alG
-sbJ
+pOw
 oHE
 aoJ
 aoR

--- a/modular_ss220/objects/code/platform.dm
+++ b/modular_ss220/objects/code/platform.dm
@@ -8,7 +8,7 @@
 	anchored = FALSE
 	climbable = TRUE
 	max_integrity = 200
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 50, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 50, BOMB = 20, RAD = 0, FIRE = 30, ACID = 30)
 	var/corner = FALSE
 	var/material_type = /obj/item/stack/sheet/metal
 	var/material_amount = 4
@@ -190,7 +190,7 @@
 	icon_state = "plasteel"
 	material_type = /obj/item/stack/sheet/plasteel
 	max_integrity = 300
-	armor = list("melee" = 20, "bullet" = 30, "laser" = 30, "energy" = 100, "bomb" = 50, "bio" = 0, "rad" = 75, "fire" = 100, "acid" = 100)
+	armor = list(MELEE = 20, BULLET = 30, LASER = 30, ENERGY = 100, BOMB = 50, RAD = 75, FIRE = 100, ACID = 100)
 
 // Platform corners
 /obj/structure/platform/corner


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
 - Добавляет портированные предметы из ПРа
 https://github.com/ss220club/Paradise-SS220/pull/218
 - Актуализация с оффами (отредактирован кабинет КМа в связи с тем что он теперь глава 💀, добавлены костыли в мед)
 - Пояс чемпиона заменен на подтип wrestling (РуПара момент)
 - Исправляет отсутствие доступа у шаттеров гейта
 - Заменены варэдитные спавнеры

## Почему это хорошо для игры
Актуализация карты

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/0bd255aa-a17f-43d0-9ec9-59ef06deecbe)

## Тестирование
Проверял в игре

## Changelog

:cl:
add: Кибериада: Добавлены портированные предметы
tweak: Кибериада: Актуализация с изменениями оффов (костыли в мед, КМ - глава)
tweak: Кибериада: Пояс чемпиона заменен на подтип рестлера
fix: Кибериада: Исправлено отсутствие доступа у шаттеров гейта
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
