### PR TITLE
FIx: SpaceRuins atmos

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/convoy_ambush.dmm
@@ -154,7 +154,6 @@
 /area/ruin/space/unpowered/unpowered_structures)
 "eJ" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/effect/landmark/damageturf,
@@ -163,7 +162,8 @@
 	},
 /area/ruin/space/unpowered/unpowered_structures)
 "fL" = (
-/turf/simulated/floor/plasteel/stairs{
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "stairs";
 	dir = 8
 	},
 /area/ruin/space/unpowered/unpowered_structures)
@@ -253,7 +253,8 @@
 	},
 /area/ruin/space/unpowered/unpowered_structures)
 "kd" = (
-/turf/simulated/floor/plasteel/stairs{
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "stairs";
 	dir = 8
 	},
 /area/ruin/space/powered)
@@ -340,7 +341,7 @@
 	color = "#FF0000";
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "nV" = (
 /obj/item/flashlight,
@@ -357,7 +358,7 @@
 /area/template_noop)
 "oq" = (
 /obj/effect/spawner/window/plastitanium,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "oE" = (
 /obj/item/stack/sheet/mineral/plastitanium,
@@ -903,7 +904,6 @@
 /area/ruin/space/unpowered/unpowered_structures)
 "KY" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/structure/closet,
@@ -1057,7 +1057,7 @@
 	color = "#FF0000";
 	dir = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "RP" = (
 /turf/simulated/wall/mineral/titanium/nodiagonal,
@@ -1086,7 +1086,7 @@
 	color = "#FF0000";
 	dir = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "Sn" = (
 /obj/structure/closet/walllocker/emerglocker/west,
@@ -1160,7 +1160,6 @@
 "TU" = (
 /obj/structure/lattice,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /turf/template_noop,
@@ -1242,7 +1241,6 @@
 /area/ruin/space/unpowered/unpowered_structures)
 "YG" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/structure/lattice,

--- a/_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm
@@ -43,10 +43,7 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/requires_power_space)
 "aY" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/mineral/plastitanium,
@@ -191,17 +188,13 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/requires_power_space)
 "ez" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel/freezer,
 /area/ruin/space/powered/requires_power_space)
 "eC" = (
 /obj/machinery/atmospherics/portable/canister,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
@@ -238,7 +231,6 @@
 	name = "tesla coil"
 	},
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -256,7 +248,6 @@
 /area/ruin/space/powered/requires_power_space)
 "eT" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/glass,
@@ -312,7 +303,6 @@
 /area/ruin/space/powered/requires_power_space)
 "hn" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line{
@@ -396,7 +386,6 @@
 /area/ruin/space/powered/requires_power_space)
 "iL" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/structure/closet/crate/secure/weapon{
@@ -571,7 +560,6 @@
 /area/ruin/space/powered/requires_power_space)
 "lm" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/item/trash/spentcasing{
@@ -581,10 +569,7 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/requires_power_space)
 "lt" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/structure/mirror{
 	dir = 4;
 	pixel_y = 33;
@@ -699,7 +684,6 @@
 /area/ruin/space/powered/requires_power_space)
 "ol" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /turf/simulated/floor/mineral/plastitanium,
@@ -738,7 +722,6 @@
 /area/ruin/space/powered/requires_power_space)
 "pj" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/structure/computerframe{
@@ -770,7 +753,6 @@
 /area/ruin/space/powered/requires_power_space)
 "pB" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line{
@@ -793,10 +775,7 @@
 /turf/simulated/floor,
 /area/ruin/space/powered/requires_power_space)
 "pO" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/structure/closet/crate/can,
 /obj/item/trash/syndi_cakes,
 /obj/item/trash/raisins,
@@ -895,7 +874,6 @@
 /area/ruin/space/powered/requires_power_space)
 "tE" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -968,7 +946,6 @@
 /area/ruin/space/powered/requires_power_space)
 "vk" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/machinery/economy/vending/medical/syndicate_access,
@@ -1046,7 +1023,6 @@
 /area/ruin/space/powered/requires_power_space)
 "xG" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/item/paper/crumpled,
@@ -1091,7 +1067,6 @@
 /area/ruin/space/powered/requires_power_space)
 "zq" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/blood/splatter,
@@ -1161,7 +1136,6 @@
 /area/ruin/space/powered/requires_power_space)
 "AV" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump,
@@ -1223,7 +1197,6 @@
 "ET" = (
 /obj/machinery/atmospherics/portable/canister,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -1372,10 +1345,7 @@
 /turf/simulated/floor,
 /area/ruin/space/powered/requires_power_space)
 "Je" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/effect/spawner/random_spawners/dirt_often,
 /obj/item/trash/spentcasing{
 	icon_state = "r-casing";
@@ -1391,7 +1361,6 @@
 /area/ruin/space/powered/requires_power_space)
 "JH" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /obj/structure/dispenser/oxygen,
@@ -1596,7 +1565,6 @@
 /area/ruin/space/powered/requires_power_space)
 "QS" = (
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /obj/machinery/suit_storage_unit/syndicate{

--- a/_maps/map_files220/RandomRuins/SpaceRuins/mechtransport_new.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/mechtransport_new.dmm
@@ -21,7 +21,6 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -98,7 +97,6 @@
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -160,7 +158,6 @@
 /obj/structure/table,
 /obj/item/crowbar,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -270,11 +267,11 @@
 /area/ruin/space/powered)
 "gU" = (
 /obj/machinery/door_control{
-	pixel_y = -30;
-	id = "sleft_mech"
+	pixel_y = -24;
+	id = "sleft_mech";
+	pixel_x = 8
 	},
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -326,7 +323,6 @@
 /area/ruin/space/powered)
 "ib" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -337,8 +333,9 @@
 /area/ruin/space/powered)
 "io" = (
 /obj/machinery/door_control{
-	pixel_y = 30;
-	id = "sright_mech"
+	pixel_y = 24;
+	id = "sright_mech";
+	pixel_x = -8
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
@@ -374,7 +371,6 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/gloves/color/black,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
@@ -382,7 +378,6 @@
 "iU" = (
 /obj/item/kirbyplants,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -442,11 +437,6 @@
 /area/ruin/space/powered)
 "kD" = (
 /obj/structure/table,
-/obj/machinery/door_control{
-	id = "shang1_mech";
-	pixel_x = 6;
-	pixel_y = -2
-	},
 /obj/item/hand_labeler{
 	pixel_y = 9
 	},
@@ -508,7 +498,7 @@
 	lethal = 1
 	},
 /obj/effect/dummy/lighting_obj,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/powered)
 "ly" = (
 /obj/effect/turf_decal/arrows{
@@ -563,7 +553,6 @@
 	dir = 1
 	},
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -625,7 +614,6 @@
 /area/ruin/space/powered)
 "nV" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /obj/structure/table,
@@ -667,9 +655,7 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/ruin/space/powered)
 "oL" = (
-/obj/machinery/light_construct{
-	icon_state = "tube-broken"
-	},
+/obj/machinery/light_construct,
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
 "oY" = (
@@ -734,11 +720,11 @@
 /area/ruin/space/powered)
 "qB" = (
 /obj/machinery/door_control{
-	pixel_y = -30;
-	id = "sright_mech"
+	pixel_y = -24;
+	id = "sright_mech";
+	pixel_x = -8
 	},
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /mob/living/simple_animal/hostile/scavengers/laser,
@@ -784,10 +770,7 @@
 "rs" = (
 /obj/structure/rack/gunrack,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "rJ" = (
@@ -836,7 +819,6 @@
 /area/ruin/space/powered)
 "sw" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/turf_decal/box,
@@ -851,7 +833,6 @@
 /area/ruin/space/powered)
 "sP" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -992,7 +973,6 @@
 "vL" = (
 /obj/machinery/economy/vending/snack/free,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -1157,7 +1137,6 @@
 "yU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -1167,8 +1146,12 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/powered)
 "zy" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/machinery/computer{
+	icon_state = "entertainment_console";
+	pixel_y = 32;
+	icon_screen = "entertainment_console_broken";
+	icon_keyboard = null;
+	density = 0
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
@@ -1190,9 +1173,7 @@
 	},
 /area/ruin/space/powered)
 "zM" = (
-/obj/machinery/light_construct{
-	icon_state = "tube-broken"
-	},
+/obj/machinery/light_construct,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/scavengers/meele,
 /turf/simulated/floor/mineral/titanium,
@@ -1203,8 +1184,9 @@
 /area/ruin/space/powered)
 "Ae" = (
 /obj/machinery/door_control{
-	pixel_y = 30;
-	id = "shang1_mech"
+	pixel_y = 24;
+	id = "shang1_mech";
+	pixel_x = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/scavengers/gun,
@@ -1237,7 +1219,6 @@
 "AR" = (
 /obj/item/flag,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1302,7 +1283,6 @@
 /area/ruin/space/powered)
 "Cm" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1322,13 +1302,12 @@
 	},
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "Cw" = (
-/turf/simulated/floor/mineral/plastitanium/red,
+/turf/simulated/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/powered)
 "Cy" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -1367,7 +1346,12 @@
 	welded = 1
 	},
 /obj/structure/fans/tiny,
-/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden{
+	layer = 3.11
+	},
+/obj/structure/barricade/wooden/crude{
+	layer = 3.11
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "CZ" = (
@@ -1388,20 +1372,24 @@
 /area/ruin/space/powered)
 "Do" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/door_control{
 	id = "hang1_mech";
-	pixel_y = 32
+	pixel_y = 24;
+	pixel_x = -6
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
 "DE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/machinery/computer{
+	icon_state = "entertainment_console";
+	pixel_y = 32;
+	icon_screen = "entertainment_console_broken";
+	icon_keyboard = null;
+	density = 0
 	},
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
@@ -1420,16 +1408,16 @@
 /turf/simulated/floor/mineral/titanium/yellow,
 /area/ruin/space/powered)
 "Eb" = (
-/obj/machinery/door_control{
-	id = "shang2_mech";
-	pixel_x = 30
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plasmareinforced{
+	dir = 1
 	},
-/turf/simulated/floor/mineral/titanium,
+/obj/structure/fans/tiny/invisible,
+/turf/simulated/floor/plating/airless,
 /area/ruin/space/powered)
 "Ec" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1493,9 +1481,7 @@
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
 "Ft" = (
-/obj/machinery/light_construct{
-	icon_state = "tube-broken"
-	},
+/obj/machinery/light_construct,
 /turf/simulated/floor/carpet/purple,
 /area/ruin/space/powered)
 "Fu" = (
@@ -1511,7 +1497,6 @@
 	id = "bwindows_mech"
 	},
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -1555,7 +1540,6 @@
 /area/ruin/space/powered)
 "FK" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -1563,7 +1547,6 @@
 /area/ruin/space/powered)
 "FS" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/structure/table,
@@ -1596,11 +1579,18 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/ruin/space/powered)
 "Gu" = (
-/obj/machinery/light_construct{
-	icon_state = "tube-broken";
-	dir = 8
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "shang2_mech"
 	},
-/turf/simulated/wall/indestructible/whiteshuttle/nodiagonal,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "shang2_mech";
+	pixel_y = 24
+	},
+/turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
 "GF" = (
 /turf/simulated/floor/plating,
@@ -1713,7 +1703,6 @@
 "Iw" = (
 /obj/structure/table,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium/blue,
@@ -1771,7 +1760,6 @@
 "Jq" = (
 /obj/item/kirbyplants,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -1867,7 +1855,8 @@
 "Lo" = (
 /obj/machinery/door_control{
 	id = "shang3_mech";
-	pixel_x = -30
+	pixel_x = -24;
+	pixel_y = -8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/titanium,
@@ -1898,7 +1887,12 @@
 /turf/simulated/floor/mineral/titanium/purple,
 /area/ruin/space/powered)
 "LC" = (
-/turf/template_noop,
+/obj/machinery/door_control{
+	id = "shang1_mech";
+	pixel_y = -24;
+	pixel_x = 8
+	},
+/turf/simulated/floor/mineral/titanium/yellow,
 /area/ruin/space/powered)
 "LF" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1976,13 +1970,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "Ng" = (
-/obj/machinery/light_construct{
-	icon_state = "tube-broken"
-	},
-/obj/machinery/door_control{
-	id = "shang1_mech";
-	pixel_y = -30
-	},
+/obj/machinery/light_construct,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "Nl" = (
@@ -2002,7 +1990,6 @@
 /area/ruin/space/powered)
 "Nn" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /turf/simulated/floor/mineral/titanium,
@@ -2025,7 +2012,6 @@
 /area/ruin/space/powered)
 "Oh" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2142,7 +2128,6 @@
 	desc = "It's a flag."
 	},
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2232,7 +2217,6 @@
 /area/ruin/space/powered)
 "Sq" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/structure/chair/comfy/black{
@@ -2256,7 +2240,9 @@
 /area/ruin/space/powered)
 "SH" = (
 /obj/effect/spawner/window/plastitanium,
-/obj/structure/barricade/wooden/crude,
+/obj/structure/barricade/wooden/crude{
+	layer = 3.11
+	},
 /turf/simulated/floor/plating,
 /area/ruin/space/powered)
 "SL" = (
@@ -2315,7 +2301,6 @@
 "TR" = (
 /obj/item/kirbyplants,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2331,7 +2316,6 @@
 "TZ" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -2346,8 +2330,9 @@
 /area/ruin/space/powered)
 "Uj" = (
 /obj/machinery/door_control{
-	pixel_y = 30;
-	id = "sleft_mech"
+	pixel_y = 24;
+	id = "sleft_mech";
+	pixel_x = 8
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/ruin/space/powered)
@@ -2405,7 +2390,6 @@
 /area/ruin/space/powered)
 "UY" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
@@ -2468,7 +2452,7 @@
 /area/ruin/space/powered)
 "VO" = (
 /obj/effect/landmark/damageturf,
-/turf/simulated/floor/mineral/plastitanium/red,
+/turf/simulated/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/powered)
 "VQ" = (
 /obj/effect/turf_decal/caution/stand_clear{
@@ -2491,7 +2475,6 @@
 	},
 /obj/effect/landmark/burnturf,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /turf/simulated/floor/mineral/titanium/yellow,
@@ -2519,7 +2502,6 @@
 /area/ruin/space/powered)
 "Wu" = (
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 8
 	},
 /obj/machinery/atmospherics/portable/scrubber,
@@ -2535,9 +2517,7 @@
 /obj/item/mecha_modkit/voice/nanotrasen,
 /obj/item/toy/figure/mech/mauler,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light_construct{
-	icon_state = "tube-broken"
-	},
+/obj/machinery/light_construct,
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
 /turf/simulated/floor/mineral/titanium,
@@ -2566,7 +2546,6 @@
 "Xy" = (
 /obj/effect/landmark/burnturf,
 /obj/machinery/light_construct{
-	icon_state = "tube-broken";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -2885,7 +2864,7 @@ Sb
 qU
 Vk
 qU
-tv
+Sb
 DE
 dk
 sD
@@ -2908,7 +2887,7 @@ qU
 qU
 qU
 qU
-bf
+ze
 OB
 zI
 qU
@@ -2963,7 +2942,7 @@ ce
 ce
 ce
 qU
-bf
+ze
 Vk
 qU
 qU
@@ -2986,7 +2965,7 @@ Md
 sh
 HB
 HB
-nk
+LC
 Kb
 Ae
 lf
@@ -3171,7 +3150,7 @@ oL
 Kb
 LV
 Hs
-qv
+Eb
 Vo
 cd
 qU
@@ -3226,7 +3205,7 @@ lS
 Sb
 bw
 cZ
-qv
+Eb
 Vo
 qU
 qU
@@ -3281,7 +3260,7 @@ lS
 Sb
 Kl
 tm
-qv
+Eb
 Vo
 cd
 Ah
@@ -3327,7 +3306,7 @@ qU
 qU
 Kb
 TZ
-Eb
+AC
 AC
 AC
 lS
@@ -3336,7 +3315,7 @@ nV
 Kb
 fK
 oh
-qv
+Eb
 Vo
 qU
 qU
@@ -3383,7 +3362,7 @@ Kb
 Kb
 Kb
 Kb
-Js
+Gu
 Js
 LF
 Kb
@@ -3391,7 +3370,7 @@ Kb
 Kb
 VY
 lR
-qv
+Eb
 zF
 an
 an
@@ -3596,8 +3575,8 @@ Kb
 Sb
 Yn
 Sb
-Gu
-Gu
+Kb
+Kb
 Kb
 Kb
 Kb
@@ -3611,7 +3590,7 @@ Kb
 Kb
 Xy
 Ry
-qv
+Eb
 zF
 an
 an
@@ -3666,7 +3645,7 @@ FS
 Kb
 HO
 xG
-qv
+Eb
 Vo
 cd
 Ah
@@ -3721,7 +3700,7 @@ lS
 Sb
 eR
 GF
-qv
+Eb
 Vo
 qU
 Vk
@@ -3776,7 +3755,7 @@ lS
 Sb
 Lj
 AT
-qv
+Eb
 Vo
 cd
 KW
@@ -3831,7 +3810,7 @@ zM
 Kb
 UH
 AS
-qv
+Eb
 Vo
 qU
 qU
@@ -4095,7 +4074,7 @@ Sb
 qU
 Vk
 qU
-tv
+Sb
 zy
 Jr
 sD
@@ -4118,7 +4097,7 @@ ys
 il
 Vk
 qU
-LC
+qU
 qU
 qU
 qU

--- a/_maps/map_files220/RandomRuins/SpaceRuins/voxraiders_1.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/voxraiders_1.dmm
@@ -9,10 +9,7 @@
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered/unpowered_structures)
 "bG" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/rack_parts,
 /turf/simulated/floor/plasteel/airless{
@@ -84,10 +81,7 @@
 	},
 /area/ruin/space/powered)
 "id" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/item/clothing/under/solgov,
@@ -144,7 +138,6 @@
 "lr" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -170,10 +163,7 @@
 	},
 /area/ruin/space/powered)
 "nz" = (
-/obj/machinery/light_construct{
-	icon_state = "bulb-broken";
-	dir = 2
-	},
+/obj/machinery/light_construct,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/airless,
 /area/ruin/space/unpowered/unpowered_structures)
@@ -463,11 +453,6 @@
 	icon_state = "Dark"
 	},
 /area/ruin/space/unpowered/unpowered_structures)
-"QA" = (
-/obj/effect/spawner/window/shuttle,
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating/airless,
-/area/ruin/space/unpowered/unpowered_structures)
 "QV" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 2
@@ -509,7 +494,6 @@
 	dir = 8
 	},
 /obj/machinery/light_construct{
-	icon_state = "bulb-broken";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -685,7 +669,7 @@ ye
 "}
 (6,1,1) = {"
 ye
-QA
+CQ
 OC
 CI
 il
@@ -703,7 +687,7 @@ ye
 "}
 (7,1,1) = {"
 ye
-QA
+CQ
 CQ
 Eh
 JI

--- a/_maps/map_files220/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/whiteship.dmm
@@ -368,7 +368,7 @@
 /obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/shuttle/abandoned)
 "hR" = (
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фикс космических тайлов с активным атмосом на некоторых косморуинах: whiteship, convoy_ambush, voxraiders_1, mechtransport_new. Фикс положения кнопок на руине mechtransport_new. Фикс лампочек на некоторых руинах.

## Почему это хорошо для игры

Меньше нагрузки - меньше нагрузки.

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Что это?

## Changelog

:cl:
fix: убрал ненужные тайлы с активным атмосом на картах whiteship, convoy_ambush, voxraiders_1, mechtransport_new; починил лампочки там же.

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
