### PR TITLE
Tweak: Replace syndie duffelbag (Cyberiad)

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -49750,11 +49750,13 @@
 /area/station/maintenance/asmaint2)
 "fqk" = (
 /obj/structure/table/glass/reinforced/plastitanium,
-/obj/item/storage/backpack/duffel/syndie/med/surgery_fake,
 /obj/item/instrument/bikehorn{
 	pixel_y = 12
 	},
 /obj/effect/decal/cleanable/dust,
+/obj/item/storage/firstaid/surgery{
+	icon_state = "duffel-syndimed"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Заменяет синди-дюфель в пыточной на обычный, с иконкой синди.
1000IQ мув
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Нет смысла манчить

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Changelog

:cl:
tweak: В пыточной теперь обычный дюфель со спрайтом синди вместо синди.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
