### PR TITLE
[MAP] Добавляем зоопарк на дельту, мелкие правки на Коробке

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -58399,7 +58399,7 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/blueshield)
 "isv" = (
-/obj/structure/statue/bananium/clown,
+/obj/structure/statue/bananium/clown/unique,
 /turf/simulated/floor/wood,
 /area/station/service/clown)
 "isD" = (
@@ -63509,6 +63509,9 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/item/toy/figure/crew/mime{
+	pixel_x = -5
 	},
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
@@ -76216,6 +76219,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
+"pfm" = (
+/obj/machinery/light/directional/south,
+/mob/living/simple_animal/hostile/retaliate/carp/koi{
+	name = "Лупа"
+	},
+/turf/simulated/floor/beach/water{
+	icon_state = "seadeep"
+	},
+/area/station/command/bridge)
 "pfB" = (
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/space_heater,
@@ -86233,7 +86245,7 @@
 	},
 /area/station/engineering/atmos)
 "sRW" = (
-/obj/structure/statue/tranquillite/mime,
+/obj/structure/statue/tranquillite/mime/unique,
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
 "sRY" = (
@@ -87511,7 +87523,9 @@
 /area/station/hallway/secondary/exit)
 "tnR" = (
 /obj/machinery/light/directional/south,
-/mob/living/simple_animal/hostile/retaliate/carp/koi,
+/mob/living/simple_animal/hostile/retaliate/carp/koi{
+	name = "Пупа"
+	},
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
 	},
@@ -90463,6 +90477,9 @@
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/item/toy/figure/crew/clown{
+	pixel_x = 5
 	},
 /turf/simulated/floor/wood,
 /area/station/service/clown)
@@ -130829,7 +130846,7 @@ onE
 tqr
 kto
 uAb
-tnR
+pfm
 lsh
 cFQ
 fki

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -590,6 +590,8 @@
 	},
 /area/station/hallway/secondary/entry)
 "afm" = (
+/mob/living/simple_animal/pet/cat/birman/Crusher,
+/obj/effect/spawner/lootdrop/trash,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -2698,6 +2700,7 @@
 "arH" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/lizard/croco/Gena,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -4104,6 +4107,18 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/controlroom)
+"awV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/mob/living/simple_animal/mothroach{
+	name = "Сеньйор";
+	desc = "Мотылёк. Обожает светочи. Знает всю атмосферику, но из-за своего скверного характера не расскажет, даже если бы мог говорить."
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/control)
 "awW" = (
 /obj/effect/decal/cleanable/fungus,
 /obj/effect/spawner/random_spawners/wall_rusted_always,
@@ -5535,7 +5550,9 @@
 	},
 /area/station/supply/storage)
 "aCP" = (
-/mob/living/simple_animal/bot/cleanbot,
+/mob/living/simple_animal/bot/cleanbot{
+	name = "D.E.N."
+	},
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -10346,9 +10363,7 @@
 /area/station/engineering/atmos)
 "aVV" = (
 /obj/structure/flora/ausbushes/grassybush,
-/mob/living/simple_animal/pig{
-	name = "Саня"
-	},
+/mob/living/simple_animal/pig/Sanya,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "aVX" = (
@@ -25880,10 +25895,10 @@
 /area/station/command/office/captain)
 "bVa" = (
 /obj/machinery/light/directional/west,
-/obj/structure/toilet{
+/obj/effect/landmark/start/captain,
+/obj/structure/toilet/material/captain{
 	dir = 4
 	},
-/obj/effect/landmark/start/captain,
 /turf/simulated/floor/plasteel/white,
 /area/station/command/office/captain/bedroom)
 "bVb" = (
@@ -32926,6 +32941,8 @@
 /area/station/service/library)
 "cvr" = (
 /obj/machinery/newscaster/directional/east,
+/mob/living/simple_animal/pet/dog/bullterrier/Genn,
+/obj/structure/bed/dogbed,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "cvs" = (
@@ -33900,6 +33917,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/mob/living/simple_animal/turtle,
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
 	},
@@ -37815,6 +37833,14 @@
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
+"cRv" = (
+/obj/effect/spawner/random_spawners/blood_maybe,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/maintenance/old_kitchen)
 "cRy" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -40983,6 +41009,11 @@
 	icon_state = "darkgreen"
 	},
 /area/station/medical/virology/lab)
+"dhb" = (
+/obj/machinery/door/airlock,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "dhe" = (
 /obj/effect/spawner/window/reinforced/polarized{
 	id = "CMO"
@@ -42019,6 +42050,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/mob/living/simple_animal/mouse/hamster/Representative,
+/obj/structure/bed/dogbed/pet,
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
 "dng" = (
@@ -46060,6 +46093,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/mob/living/simple_animal/pet/dog/security/detective,
+/obj/structure/bed/dogbed,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -47533,6 +47568,8 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/mob/living/simple_animal/pet/cat/black/Salem,
+/obj/structure/bed/dogbed/pet,
 /turf/simulated/floor/plasteel/grimy,
 /area/station/service/chapel/office)
 "dTp" = (
@@ -48354,6 +48391,8 @@
 	network = list("Research","SS13");
 	pixel_y = -22
 	},
+/mob/living/simple_animal/mouse/rat/white/Brain,
+/obj/structure/bed/dogbed/pet,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -49515,6 +49554,7 @@
 /area/station/public/fitness)
 "ekU" = (
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -49576,7 +49616,11 @@
 	dir = 1;
 	layer = 2.9
 	},
-/mob/living/simple_animal/crab/Coffee,
+/mob/living/simple_animal/crab/Coffee{
+	desc = "Master of the GYM";
+	name = "Billy Crabington";
+	real_name = "Billy Crabington"
+	},
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
 	},
@@ -51762,6 +51806,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
+"fhp" = (
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/wood,
+/area/station/maintenance/electrical_shop)
 "fhC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52501,6 +52549,7 @@
 	},
 /obj/structure/chair/sofa/left,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/moth,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "fwQ" = (
@@ -52624,6 +52673,7 @@
 "fyS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/directional/south,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "greenblue"
 	},
@@ -56617,6 +56667,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"gZU" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/maintenance/fore)
 "haa" = (
 /obj/structure/sink/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -56734,6 +56791,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/starboard2)
 "hcm" = (
@@ -56779,6 +56837,14 @@
 "hcH" = (
 /turf/simulated/wall,
 /area/station/security/permasolitary)
+"hcY" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "chapel"
+	},
+/area/station/maintenance/starboard2)
 "hda" = (
 /obj/effect/turf_decal/stripes/white/line{
 	color = "lightblue"
@@ -60174,6 +60240,10 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/prison/cell_block)
+"irV" = (
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/wood,
+/area/station/maintenance/abandonedbar)
 "isc" = (
 /obj/structure/statue/delta/se,
 /obj/effect/turf_decal/siding/yellow{
@@ -61731,9 +61801,7 @@
 /area/station/maintenance/starboard2)
 "iXn" = (
 /obj/structure/flora/ausbushes/palebush,
-/mob/living/simple_animal/chicken/clucky{
-	name = "Коммандор Клакки"
-	},
+/mob/living/simple_animal/cock/Clucky,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "iXL" = (
@@ -63054,6 +63122,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandoned_garden)
 "jym" = (
@@ -63187,6 +63256,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/se)
+"jBp" = (
+/mob/living/simple_animal/mouse/rat/irish/Remi,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/security/permabrig)
 "jCv" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -63657,6 +63732,7 @@
 	network = list("Research","SS13")
 	},
 /obj/machinery/alarm/directional/west,
+/mob/living/simple_animal/goose/Scientist,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -64157,6 +64233,7 @@
 	},
 /obj/structure/chair/sofa/left,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/moth,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken"
 	},
@@ -64581,6 +64658,10 @@
 /obj/item/cane,
 /turf/simulated/floor/carpet,
 /area/station/medical/psych)
+"kcd" = (
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plating,
+/area/station/maintenance/old_kitchen)
 "kcj" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel{
@@ -66248,6 +66329,7 @@
 /obj/machinery/hologram/holopad{
 	pixel_x = 16
 	},
+/mob/living/simple_animal/pet/cat/Floppa,
 /turf/simulated/floor/carpet/blue,
 /area/station/command/office/blueshield)
 "kMr" = (
@@ -70551,6 +70633,7 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -71547,6 +71630,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"mTK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/transparent/glass/reinforced,
+/area/station/maintenance/starboard2)
 "mTQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72814,6 +72910,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/mob/living/simple_animal/possum/Poppy,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -74017,6 +74114,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos/control)
+"nKZ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/maintenance/starboard)
 "nLi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -75258,6 +75362,7 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/structure/chair/sofa/right,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/moth,
 /turf/simulated/floor/wood,
 /area/station/maintenance/starboard2)
 "oir" = (
@@ -78600,6 +78705,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -79505,6 +79611,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central/ne)
+"pLe" = (
+/mob/living/simple_animal/mouse/rat/Ratatui,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/security/permabrig)
 "pLr" = (
 /obj/effect/spawner/window/reinforced,
 /obj/structure/cable{
@@ -81520,6 +81632,7 @@
 /area/station/maintenance/apmaint)
 "qFp" = (
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -83936,6 +84049,8 @@
 /area/station/maintenance/port)
 "ryK" = (
 /obj/machinery/alarm/directional/east,
+/mob/living/simple_animal/pet/sloth/paperwork,
+/obj/structure/bed/dogbed/pet,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "rza" = (
@@ -85105,6 +85220,7 @@
 "rXZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/nightshifted/south,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/abandoned_garden)
 "rYh" = (
@@ -85989,6 +86105,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"soW" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard2)
 "spc" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical{
@@ -86063,6 +86184,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/north)
+"spw" = (
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/security,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/security/main)
 "spz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -86180,9 +86308,7 @@
 /area/station/engineering/gravitygenerator)
 "srJ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/simple_animal/cow/betsy{
-	name = "Бетси"
-	},
+/mob/living/simple_animal/cow/betsy,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "srQ" = (
@@ -86475,6 +86601,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
+"swI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/abandonedbar)
 "swM" = (
 /obj/structure/disposalpipe/junction/reversed{
 	dir = 4
@@ -87196,6 +87327,7 @@
 /obj/machinery/light_switch/north{
 	pixel_x = 7
 	},
+/mob/living/simple_animal/pet/cat/spacecat/Musya,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/launch)
 "sJD" = (
@@ -87956,6 +88088,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
 "tdj" = (
@@ -88462,6 +88595,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/old_kitchen)
+"tnr" = (
+/mob/living/simple_animal/pet/dog/fox/fennec/fenya,
+/obj/structure/bed/dogbed/pet,
+/turf/simulated/floor/wood,
+/area/station/legal/magistrate)
 "tnu" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	autolink_id = "n2o_in";
@@ -88637,6 +88775,11 @@
 	icon_state = "neutralfull"
 	},
 /area/station/maintenance/virology_maint)
+"tqO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plating,
+/area/station/maintenance/old_kitchen)
 "tqS" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -91363,6 +91506,8 @@
 /area/station/maintenance/auxsolarport)
 "upW" = (
 /obj/machinery/firealarm/directional/north,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/security/warden,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -91825,6 +91970,11 @@
 /obj/machinery/mineral/stacking_unit_console,
 /turf/simulated/wall,
 /area/station/maintenance/disposal)
+"uCt" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/frog/Wednesday,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "uCE" = (
 /obj/machinery/door/window/reinforced/reversed{
 	dir = 4;
@@ -93378,6 +93528,7 @@
 	dir = 4
 	},
 /obj/structure/sink/kitchen/north,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "redyellowfull"
 	},
@@ -93778,6 +93929,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
 "vmT" = (
@@ -94337,6 +94489,7 @@
 /obj/machinery/atmospherics/air_sensor{
 	autolink_id = "burn_sensor"
 	},
+/obj/effect/decal/remains/mouse/Pinkie,
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
 "vBU" = (
@@ -94344,6 +94497,10 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/science/robotics/showroom)
+"vBV" = (
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "vCk" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
@@ -96291,15 +96448,23 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "woT" = (
-/mob/living/simple_animal/pet/dog/pug,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/mob/living/simple_animal/pet/dog/pug/Frank,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"wpc" = (
+/mob/living/simple_animal/pet/slugcat/monk,
+/obj/structure/bed/dogbed/pet,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/station/science/xenobiology)
 "wpg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97549,6 +97714,7 @@
 	},
 /obj/structure/chair/sofa/right,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/moth,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "wUr" = (
@@ -98463,6 +98629,10 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/medbay2)
+"xnq" = (
+/mob/living/simple_animal/mouse/rat,
+/turf/simulated/floor/plasteel/dark,
+/area/station/maintenance/abandonedbar)
 "xnx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -98941,9 +99111,7 @@
 /area/station/hallway/primary/central/east)
 "xwU" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/mob/living/simple_animal/chicken/featherbottom{
-	name = "Галя"
-	},
+/mob/living/simple_animal/chicken/Wife,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
 "xxn" = (
@@ -99080,6 +99248,10 @@
 "xAW" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/courtroom)
+"xBs" = (
+/mob/living/simple_animal/pet/cat/white/Penny,
+/turf/simulated/floor/carpet/arcade,
+/area/station/public/arcade)
 "xBx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -99354,6 +99526,8 @@
 /obj/machinery/button/windowtint/east{
 	id = "Psych"
 	},
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/brittany/Psycho,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "xGw" = (
@@ -99381,6 +99555,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -99784,6 +99959,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/wood,
 /area/station/maintenance/old_kitchen)
 "xNC" = (
@@ -123082,7 +123258,7 @@ nyt
 drn
 cLz
 yeh
-dnH
+swI
 dcX
 yeh
 dYu
@@ -123091,7 +123267,7 @@ lTi
 lTi
 dYt
 dnH
-dnH
+swI
 dcX
 dkr
 dbz
@@ -124114,7 +124290,7 @@ uai
 lTi
 mAs
 dcX
-dnH
+swI
 yeh
 dks
 dcX
@@ -125404,7 +125580,7 @@ dja
 iFl
 lTi
 dmQ
-lTi
+irV
 dcX
 drf
 irt
@@ -125652,7 +125828,7 @@ ezh
 dhG
 cLz
 dan
-dcX
+xnq
 dcW
 dcX
 dcX
@@ -128939,7 +129115,7 @@ krP
 qDj
 krP
 lzl
-hkc
+awV
 hvv
 nKz
 ket
@@ -131210,7 +131386,7 @@ aaa
 apG
 aqy
 arr
-ars
+fhp
 atg
 auk
 apG
@@ -131480,7 +131656,7 @@ asq
 aVK
 nQL
 azb
-ayX
+gZU
 oEi
 aCl
 aCl
@@ -133867,7 +134043,7 @@ cIO
 bQx
 sau
 cIL
-cQP
+wpc
 cPe
 cTO
 cSg
@@ -135067,7 +135243,7 @@ aqI
 aoT
 aoo
 arH
-axg
+dhb
 eVT
 lmY
 aFv
@@ -135580,7 +135756,7 @@ apM
 oYb
 arC
 aoo
-azb
+uCt
 axg
 azb
 aPL
@@ -137381,7 +137557,7 @@ aqQ
 aoo
 azb
 hoG
-aor
+vBV
 tGN
 oOi
 fwQ
@@ -148307,7 +148483,7 @@ hLe
 rzk
 lCR
 dqP
-dqP
+mTK
 ooe
 dfQ
 hkN
@@ -149779,7 +149955,7 @@ tkj
 pzX
 chN
 dIv
-chJ
+tnr
 xPW
 hTV
 coR
@@ -153923,7 +154099,7 @@ hhF
 qBo
 uvQ
 hhF
-gnn
+nKZ
 kVr
 dBo
 ixf
@@ -154356,7 +154532,7 @@ aaa
 abj
 ygH
 xda
-aPe
+jBp
 aIl
 aJx
 aKR
@@ -154426,7 +154602,7 @@ ibt
 eaa
 cLr
 cIk
-cIk
+xBs
 lSa
 oNd
 taT
@@ -155384,7 +155560,7 @@ aaa
 abj
 ygH
 ngm
-aPe
+pLe
 aIp
 aJx
 aKV
@@ -155511,7 +155687,7 @@ bgs
 adA
 mfI
 eAb
-mfI
+hcY
 eAb
 bws
 aaa
@@ -156765,7 +156941,7 @@ niP
 sIu
 wOg
 pAx
-wOg
+cRv
 gAT
 sIu
 rMZ
@@ -157221,7 +157397,7 @@ uLp
 fox
 ngg
 mmw
-boI
+spw
 szk
 hXq
 jIV
@@ -158326,7 +158502,7 @@ aaa
 aaa
 bgs
 aRT
-cqI
+soW
 uKR
 xUg
 bdG
@@ -159081,7 +159257,7 @@ ipf
 qvA
 fzE
 uYi
-qno
+tqO
 wIZ
 qPD
 abj
@@ -159329,7 +159505,7 @@ maL
 maL
 ddo
 kue
-uYi
+kcd
 jQi
 azo
 iHc


### PR DESCRIPTION
## Что этот PR делает

Превращает Дельту в зоопарк, возвращает собак, котов, моль в теха.
На Гипериаде мелкие упущенные правки с статуями и карпами в аквариумах друг напротив друга. 

## Почему это хорошо для игры

Теперь на дельте у большинства пассивных отделов есть безопасные животины. Для хайпопа показали они себя отлично.

## Изображения изменений

Нет

## Тестирование

Да

## Changelog

:cl:
add: Дельта: Добавлен зоопарк.
add: Кибериада: Имена для карпов
add: Кибериада: Статуи
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
