### PR TITLE
Fix: Cyberiad vanishing closet

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -100438,11 +100438,12 @@
 	},
 /area/station/security/permabrig)
 "ydU" = (
-/obj/structure/closet/jcloset{
-	initialized = 1;
-	opened = 1
-	},
 /obj/effect/decal/cleanable/dust,
+/obj/structure/closet{
+	icon_state = "mixed";
+	opened = 1;
+	icon_opened = "generic_open"
+	},
 /obj/item/cartridge/janitor,
 /obj/item/flashlight,
 /obj/item/storage/bag/trash,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет пропадающий шкаф на Кибериаде
https://discord.com/channels/1097181193939730453/1159895097308090408
Closes https://github.com/ss220club/Paradise-SS220/issues/341

## Почему это хорошо для игры
Багы

## Изображения изменений
-

## Тестирование
В игре

## Changelog

:cl:
fix: Кибериада: Пофикшен пропадающий шкафчик
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
