### PR TITLE
tweak: spawn 1 traitor per 10 players

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -17,7 +17,7 @@
 	/// Hard limit on traitors if scaling is turned off.
 	var/traitors_possible = 4
 	/// How much the amount of players get divided by to determine the number of traitors.
-	var/const/traitor_scaling_coeff = 5
+	var/const/traitor_scaling_coeff = 10
 
 /datum/game_mode/traitor/announce()
 	to_chat(world, "<B>The current game mode is - Traitor!</B>")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Меняет скейлинг трейторов с 1 на 5 игроков до 1 на 10 игроков

## Почему это хорошо для игры

Меньше хаоса

## Тестирование
С игроками потестим 🃏 

## Changelog

:cl:
tweak: Спавн 1 трейтора на 10 игроков вместо 5
/:cl: