### PR TITLE
Fix: awaymission baseturf

### DIFF
--- a/_maps/map_files220/RandomZLevels/gate_lizard.dmm
+++ b/_maps/map_files220/RandomZLevels/gate_lizard.dmm
@@ -69,13 +69,9 @@
 	},
 /area/awaymission/jungle_planet/outside)
 "aga" = (
-/obj/structure/cable,
-/obj/effect/spawner/random_spawners/dirt_often,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgrey"
-	},
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/floor/beach/away/sand,
+/area/awaymission/jungle_planet/outside/river)
 "agV" = (
 /obj/item/shard{
 	icon_state = "small"
@@ -93,10 +89,6 @@
 /obj/item/stack/medical/bruise_pack,
 /obj/item/stack/medical/bruise_pack,
 /obj/item/clothing/mask/surgical,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -436,11 +428,6 @@
 	},
 /obj/item/broken_bottle{
 	pixel_x = 12
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
 	},
 /obj/machinery/light/directional/west,
 /obj/effect/spawner/random_spawners/dirt_often,
@@ -1090,25 +1077,9 @@
 	},
 /area/awaymission/jungle_planet/inside/complex)
 "bty" = (
-/obj/machinery/door/airlock/command{
-	locked = 1;
-	name = "command";
-	req_access = list(271);
-	id_tag = "commanddoor"
-	},
-/obj/machinery/door/firedoor/closed,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id_tag = "Command";
-	requires_power = 0
-	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/outside/cave/small)
 "btH" = (
 /obj/structure/sign/directions/security{
 	pixel_y = -3;
@@ -2319,13 +2290,9 @@
 	},
 /area/awaymission/jungle_planet/outside/river)
 "cTt" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/random_spawners/dirt_maybe,
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/beach/sand,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/outside/river)
 "cUf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2386,11 +2353,6 @@
 "cWA" = (
 /obj/effect/decal/nanotrasen_logo{
 	icon_state = "logo6"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /obj/item/newspaper,
@@ -2770,11 +2732,6 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside)
 "dxa" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4641,14 +4598,8 @@
 	},
 /area/awaymission/jungle_planet/outside/river)
 "fQm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/random_spawners/dirt_often,
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
+/turf/simulated/wall/indestructible,
+/area/awaymission/jungle_planet/inside)
 "fQG" = (
 /turf/simulated/floor/indestructible/grass,
 /area/awaymission/jungle_planet/outside/river)
@@ -4913,19 +4864,9 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside/complex)
 "gnq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet)
 "gnw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5905,12 +5846,12 @@
 	},
 /area/awaymission/jungle_planet/inside/complex)
 "hvt" = (
+/obj/structure/cable,
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/obj/item/circuitboard/pacman/super,
+/obj/machinery/constructable_frame,
 /turf/simulated/floor/engine,
 /area/awaymission/jungle_planet/inside/complex)
 "hvL" = (
@@ -6798,11 +6739,6 @@
 	icon_state = "darkgrey"
 	},
 /area/awaymission/jungle_planet/inside)
-"ixP" = (
-/obj/structure/cable,
-/obj/effect/spawner/random_spawners/dirt_often,
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
 "iyF" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/plating/asteroid/ancient{
@@ -6826,11 +6762,6 @@
 	req_access = list(271)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside/complex)
 "iAY" = (
@@ -7093,11 +7024,6 @@
 "iPQ" = (
 /obj/effect/spawner/random_spawners/blood_often,
 /obj/item/ammo_casing/caseless/arrow,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/spawner/random_spawners/dirt_frequent,
 /obj/item/storage/firstaid/regular/empty,
 /turf/simulated/floor/plasteel{
@@ -7945,15 +7871,9 @@
 	},
 /area/awaymission/jungle_planet/outside/river)
 "jOl" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/random_spawners/dirt_maybe,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/outside/cave)
 "jOs" = (
 /obj/item/stack/cable_coil{
 	pixel_y = -11;
@@ -8521,11 +8441,6 @@
 /area/awaymission/jungle_planet/inside/complex)
 "kxM" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -9033,11 +8948,6 @@
 	},
 /obj/machinery/door/firedoor/closed,
 /obj/item/airlock_electronics,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside/complex)
 "lbV" = (
@@ -9639,14 +9549,9 @@
 /turf/simulated/floor/indestructible/grass,
 /area/awaymission/jungle_planet/outside)
 "lNR" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_often,
-/turf/simulated/floor/plating,
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/outside/abandoned)
 "lOj" = (
 /obj/structure/flora/rock/pile,
 /obj/structure/flora/grass/jungle{
@@ -9915,11 +9820,6 @@
 	},
 /area/awaymission/jungle_planet/outside/cave)
 "mfn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/camera{
 	network = list("MC-16");
 	dir = 1;
@@ -9951,17 +9851,9 @@
 /turf/simulated/floor/plating,
 /area/awaymission/jungle_planet/outside)
 "mgq" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_maybe,
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/beach/sand,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/outside/waterfall)
 "mgw" = (
 /obj/structure/railing{
 	dir = 1
@@ -11300,10 +11192,6 @@
 /turf/simulated/floor/engine/cult,
 /area/awaymission/jungle_planet/outside/cave)
 "nFV" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -12307,14 +12195,9 @@
 	},
 /area/awaymission/jungle_planet/outside/cave/pirate)
 "oQl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/spawner/random_spawners/dirt_often,
-/turf/simulated/floor/plasteel,
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/outside/cave/pirate)
 "oQC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13633,6 +13516,18 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/indestructible/grass,
 /area/awaymission/jungle_planet/inside/complex)
+"qBi" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/closet/crate/radiation,
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 30
+	},
+/turf/simulated/floor/engine,
+/area/awaymission/jungle_planet/inside/complex)
 "qCn" = (
 /mob/living/simple_animal/hostile/jungle_lizard/axeman{
 	wander = 0
@@ -14707,7 +14602,6 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/structure/cable,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel{
 	icon_state = "purple"
@@ -14799,22 +14693,9 @@
 /turf/simulated/floor/plating,
 /area/awaymission/jungle_planet/inside/complex)
 "rUY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/spawner/random_spawners/dirt_frequent,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkgrey"
-	},
-/area/awaymission/jungle_planet/inside/complex)
+/obj/effect/baseturf_helper/asteroid,
+/turf/simulated/wall/indestructible/rock/mineral,
+/area/awaymission/jungle_planet/inside)
 "rVe" = (
 /obj/item/camera_assembly,
 /obj/item/stack/cable_coil{
@@ -15054,11 +14935,6 @@
 /obj/effect/turf_decal/arrows{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside/complex)
 "snc" = (
@@ -15178,11 +15054,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/structure/railing{
 	dir = 8
@@ -15376,11 +15247,6 @@
 "sDP" = (
 /obj/structure/chair/office/dark{
 	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/effect/spawner/random_spawners/dirt_maybe,
 /turf/simulated/floor/plasteel,
@@ -15675,11 +15541,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plasteel,
@@ -16058,11 +15919,6 @@
 /area/awaymission/jungle_planet/outside)
 "tsM" = (
 /obj/item/shard,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/random_spawners/dirt_maybe,
 /turf/simulated/floor/plasteel,
@@ -16300,10 +16156,6 @@
 /area/awaymission/jungle_planet/outside/river)
 "tKK" = (
 /obj/structure/table,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/item/card/id/away/old/sec{
 	name = "MC-16 multicard";
 	desc = "A clip on ID Badge, has one of those fancy new magnetic strips built in."
@@ -16408,11 +16260,6 @@
 /obj/item/stack/cable_coil{
 	pixel_y = 10;
 	amount = 2
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside/complex)
@@ -16949,11 +16796,6 @@
 	},
 /area/awaymission/jungle_planet/outside/cave)
 "uue" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -17541,7 +17383,6 @@
 /obj/machinery/door_control/bolt_control{
 	pixel_x = 8;
 	desiredstate_open = 1;
-	in_use = 1;
 	id = "hang2in"
 	},
 /obj/machinery/door_control/shutter{
@@ -18837,11 +18678,6 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plasteel,
 /area/awaymission/jungle_planet/inside/complex)
@@ -18880,7 +18716,7 @@
 /area/awaymission/jungle_planet/outside/river)
 "wJh" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
-/turf/simulated/wall,
+/turf/simulated/wall/indestructible,
 /area/awaymission/jungle_planet/inside)
 "wJq" = (
 /obj/structure/flora/junglebush{
@@ -20337,10 +20173,10 @@ gZv
 gZv
 gZv
 gZv
-gZv
-gZv
-gZv
-gZv
+bty
+lNR
+mgq
+gnq
 "}
 (2,1,1) = {"
 miM
@@ -20524,10 +20360,10 @@ gZv
 gZv
 gZv
 gZv
-gZv
-gZv
-gZv
-gZv
+rUY
+oQl
+jOl
+cTt
 "}
 (3,1,1) = {"
 miM
@@ -23083,7 +22919,7 @@ gpG
 gOJ
 gOJ
 tqm
-oBh
+aga
 oBh
 oBh
 vwu
@@ -24403,7 +24239,7 @@ sXj
 sXj
 sXj
 cku
-jOl
+iRJ
 mfn
 sXj
 sXj
@@ -26653,8 +26489,8 @@ sXj
 mph
 wvP
 sXj
-cTt
-gnq
+lJK
+bFl
 cku
 bKN
 lIF
@@ -27791,7 +27627,7 @@ oHE
 weh
 uZC
 bES
-ukM
+fQm
 ukM
 jAq
 jAq
@@ -28165,7 +28001,7 @@ sdf
 jgY
 fTr
 xaS
-ukM
+fQm
 fTv
 nQO
 vgG
@@ -28715,7 +28551,7 @@ dGF
 mjF
 oSL
 btI
-fTr
+dGF
 dGF
 dGF
 aPo
@@ -28902,7 +28738,7 @@ rpw
 sTs
 mHQ
 wEF
-hEX
+uJW
 dGT
 tUX
 qma
@@ -28917,8 +28753,8 @@ wJh
 wJh
 wJh
 wJh
-ukM
-ukM
+fQm
+fQm
 mky
 tzH
 mky
@@ -29084,12 +28920,12 @@ wRw
 rUm
 hFe
 kEk
-rUY
-aga
+sKS
+dGF
 omz
 omz
 omz
-bty
+xbo
 xbo
 omz
 omz
@@ -29276,7 +29112,7 @@ fgp
 jHd
 szb
 aGh
-oQl
+sPM
 mZK
 koU
 oNz
@@ -29462,7 +29298,7 @@ tHr
 cbj
 omz
 vEO
-qFK
+lJK
 jIx
 pTC
 koU
@@ -30210,7 +30046,7 @@ wKi
 pyX
 nfW
 oTf
-mgq
+sDP
 btI
 sPM
 efM
@@ -30399,8 +30235,8 @@ bCI
 oTf
 sDP
 cWA
-fQm
-ixP
+sPM
+sPM
 jHd
 tqq
 wNr
@@ -34132,7 +33968,7 @@ gkO
 nqg
 gdv
 sPM
-hEX
+uJW
 mpQ
 sXj
 sXj
@@ -34506,7 +34342,7 @@ mre
 uJW
 uJW
 btI
-lNR
+btI
 rQp
 cku
 sVj
@@ -34713,8 +34549,8 @@ tCk
 jtW
 kZu
 kKh
-iXr
-jrS
+fYa
+hvt
 tnX
 koU
 cod
@@ -34898,8 +34734,8 @@ fMx
 fSv
 vTu
 jtW
-rSb
-hvt
+qBi
+gYy
 gYy
 gYy
 hfB
@@ -35091,7 +34927,7 @@ koU
 koU
 koU
 koU
-gFb
+dGT
 sWR
 pHo
 trH


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавил бейзруф на все зоны, что бы не было предательских разгерм.
Заменил пару стен, подвинул уран ближе к генераторам.
Убрал пару сбивающих с толку проводов.

## Почему это хорошо для игры

Дырок в планете не должно быть 

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Локалка, работает 

## Changelog

:cl:
fix: Больше нельзя сделать разгерму на карте gate_lizard
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
