### PR TITLE
Feat: Cyberiad arrivals overhaul

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -10208,12 +10208,12 @@
 /obj/structure/sign/vacuum/external{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aMD" = (
 /obj/machinery/status_display/directional/south,
-/obj/effect/decal/warning_stripes/south,
+/obj/effect/decal/warning_stripes/southeastcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aME" = (
@@ -10705,14 +10705,14 @@
 /area/station/hallway/secondary/exit)
 "aOP" = (
 /obj/machinery/light/small/directional/west,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/hallway/secondary/entry)
 "aOQ" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aOR" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/hallway/secondary/entry)
 "aOS" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -10942,11 +10942,20 @@
 	},
 /area/station/hallway/primary/fore)
 "aPJ" = (
-/obj/effect/decal/warning_stripes/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/sign/pods{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "aPK" = (
 /obj/machinery/door/poddoor/preopen{
@@ -10985,10 +10994,13 @@
 /turf/simulated/wall,
 /area/station/maintenance/electrical)
 "aPR" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "arrival"
@@ -11003,10 +11015,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "aPT" = (
-/obj/machinery/alarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "arrival"
@@ -11048,11 +11063,14 @@
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
 	},
+/obj/effect/turf_decal/caution,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aQa" = (
-/obj/structure/sign/pods,
-/turf/simulated/wall,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/entry)
 "aQb" = (
 /obj/item/wrench,
@@ -11219,13 +11237,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -11454,27 +11472,25 @@
 /area/station/maintenance/electrical)
 "aRa" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/light/directional/north,
-/obj/machinery/camera{
-	c_tag = "Arrivals Escape Pods"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "aRd" = (
-/obj/effect/decal/warning_stripes/southeastcorner,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aRe" = (
 /obj/structure/sign/vacuum/external{
 	pixel_y = -32
 	},
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aRf" = (
@@ -11642,7 +11658,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aRV" = (
@@ -11660,7 +11675,7 @@
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "arrival"
+	icon_state = "whitecorner"
 	},
 /area/station/hallway/secondary/entry)
 "aRX" = (
@@ -11738,10 +11753,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aSo" = (
 /obj/structure/closet/wardrobe/white,
@@ -11918,18 +11930,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aTp" = (
-/obj/effect/decal/warning_stripes/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "aTt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc/cryo/east,
 /obj/structure/cable,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aTu" = (
 /turf/simulated/wall,
@@ -12220,8 +12231,9 @@
 /area/station/maintenance/electrical)
 "aUk" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "aUl" = (
 /obj/structure/closet/emcloset,
@@ -12230,17 +12242,16 @@
 /area/station/hallway/secondary/entry)
 "aUm" = (
 /obj/machinery/economy/vending/coffee,
-/obj/effect/decal/warning_stripes/southeast,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "aUn" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals North";
-	dir = 1
-	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "aUo" = (
 /obj/machinery/door/firedoor,
@@ -12419,6 +12430,7 @@
 "aUV" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/warning_stripes/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aUW" = (
@@ -12458,10 +12470,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aVe" = (
 /turf/simulated/floor/plasteel,
@@ -12656,7 +12665,7 @@
 "aVX" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "aVY" = (
 /obj/effect/spawner/window/shuttle,
@@ -13166,10 +13175,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aXr" = (
 /obj/structure/closet/walllocker/emerglocker/north,
@@ -13551,6 +13557,13 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/fsmaint)
+"aYD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "aYE" = (
 /obj/structure/chair/comfy/brown{
 	color = "#514E58";
@@ -13605,8 +13618,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aYL" = (
-/obj/machinery/light/directional/north,
 /obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/directional/east,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "aYM" = (
@@ -13905,10 +13918,8 @@
 "aZN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "arrival"
-	},
+/obj/machinery/alarm/directional/east,
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aZT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14669,10 +14680,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bcN" = (
-/obj/machinery/light/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
+/obj/machinery/light/directional/east,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/arrival/station)
 "bcO" = (
@@ -14718,13 +14729,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "bcW" = (
-/obj/machinery/alarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "whitecorner"
-	},
+/obj/machinery/status_display/directional/east,
+/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bcX" = (
 /obj/machinery/door/firedoor,
@@ -14993,12 +15001,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "bdO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "arrival"
 	},
@@ -15722,11 +15731,10 @@
 /area/station/hallway/secondary/entry)
 "bgI" = (
 /obj/item/radio/beacon,
-/obj/machinery/camera{
-	c_tag = "Arrivals South"
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
 	},
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bgJ" = (
 /obj/machinery/light/directional/north,
@@ -15794,7 +15802,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "bgR" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16045,8 +16052,10 @@
 /area/station/service/library)
 "bid" = (
 /obj/machinery/economy/vending/snack,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bih" = (
 /obj/machinery/alarm/directional/west,
@@ -16397,20 +16406,23 @@
 /area/station/hallway/secondary/exit)
 "bjS" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bjT" = (
 /obj/structure/closet/emcloset,
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bjU" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Center";
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
@@ -16748,11 +16760,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plasteel{
-	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
-	icon_state = "plaque";
-	name = "Comemmorative Plaque"
-	},
+/turf/simulated/floor/plasteel/goonplaque,
 /area/station/hallway/secondary/entry)
 "blw" = (
 /obj/structure/chair/comfy/black{
@@ -16797,12 +16805,12 @@
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "blE" = (
 /obj/machinery/status_display/directional/north,
-/obj/effect/decal/warning_stripes/north,
+/obj/effect/decal/warning_stripes/northeastcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "blJ" = (
@@ -17807,8 +17815,11 @@
 /turf/simulated/floor/carpet,
 /area/station/public/mrchangs)
 "bpX" = (
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/obj/item/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bpY" = (
 /obj/machinery/door/window/classic/reversed{
@@ -18093,7 +18104,7 @@
 	},
 /area/station/command/bridge)
 "brc" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "brd" = (
@@ -19131,10 +19142,6 @@
 "bwv" = (
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
-"bwx" = (
-/obj/structure/sign/poster/official/random/south,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "bwz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/coatrack,
@@ -20181,15 +20188,6 @@
 	icon_state = "purplefull"
 	},
 /area/station/science/rnd)
-"bBg" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Arrivals Auxiliary Docking South";
-	dir = 4
-	},
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
 "bBj" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/plasteel,
@@ -20637,7 +20635,6 @@
 /area/station/maintenance/aft)
 "bDu" = (
 /obj/machinery/light/directional/east,
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -20784,7 +20781,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/chapel)
 "bEm" = (
-/obj/machinery/alarm/directional/east,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -20792,6 +20788,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/status_display/directional/east,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bEn" = (
@@ -21297,13 +21295,19 @@
 	},
 /area/station/public/toilet/lockerroom)
 "bGl" = (
-/obj/effect/decal/warning_stripes/northeast,
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
-"bGm" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/warning_stripes/northwest,
-/turf/simulated/floor/plasteel,
+/obj/machinery/camera{
+	c_tag = "Arrivals Auxiliary Docking South"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bGo" = (
 /obj/structure/chair{
@@ -21700,7 +21704,6 @@
 /turf/simulated/wall,
 /area/station/science/robotics)
 "bIb" = (
-/obj/machinery/status_display/directional/east,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -21710,6 +21713,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bIc" = (
@@ -22275,11 +22279,11 @@
 	},
 /area/station/science/hallway)
 "bKp" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "admin_home";
-	locked = 1
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "arrival"
 	},
-/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bKs" = (
 /obj/machinery/door/airlock/maintenance,
@@ -22529,31 +22533,44 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/apmaint)
 "bLX" = (
-/obj/effect/decal/warning_stripes/southeast,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bLY" = (
-/obj/effect/decal/warning_stripes/southwest,
-/turf/simulated/floor/plasteel,
+/obj/item/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bLZ" = (
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bMa" = (
-/obj/effect/landmark/start/assistant,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/catwalk,
 /area/station/hallway/secondary/entry)
 "bMb" = (
-/obj/machinery/light/directional/south,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/effect/decal/warning_stripes/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bMc" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/decal/warning_stripes/south,
-/turf/simulated/floor/plasteel,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bMd" = (
 /obj/structure/rack,
@@ -23035,9 +23052,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bOb" = (
-/obj/structure/sign/vacuum/external,
-/obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "bOd" = (
 /obj/machinery/door/poddoor{
@@ -27974,6 +27997,7 @@
 "cjg" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
+/obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "cjh" = (
@@ -31015,6 +31039,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/research,
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
+"cve" = (
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/entry)
 "cvf" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -32378,7 +32410,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "cAo" = (
 /obj/machinery/light/small/directional/east,
@@ -33477,9 +33512,12 @@
 /turf/simulated/floor/plating,
 /area/station/public/storage/emergency/port)
 "cEL" = (
-/obj/machinery/light/small/directional/west,
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "cEM" = (
 /obj/structure/closet/walllocker/emerglocker/north,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -33653,8 +33691,7 @@
 /area/station/science/misc_lab)
 "cFJ" = (
 /obj/machinery/status_display/directional/north,
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "cFM" = (
@@ -34678,6 +34715,11 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/misc_lab)
+"cIK" = (
+/obj/effect/decal/warning_stripes/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "cIL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -40155,8 +40197,7 @@
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
 	},
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/decal/warning_stripes/northwestcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "dcf" = (
@@ -44354,7 +44395,10 @@
 /area/station/science/server)
 "dsG" = (
 /obj/machinery/firealarm/directional/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "dsH" = (
 /obj/structure/cable{
@@ -46795,6 +46839,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Vacant Office"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "ehi" = (
@@ -47153,6 +47198,11 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
+"eoP" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/entry)
 "eoR" = (
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
@@ -47497,11 +47547,13 @@
 	},
 /area/station/engineering/atmos/control)
 "euy" = (
-/obj/effect/decal/warning_stripes/southwest,
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "euD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48057,6 +48109,12 @@
 /obj/machinery/light/small/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"eGs" = (
+/obj/effect/turf_decal/bot,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/entry)
 "eGC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -53461,9 +53519,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "gGY" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/light/directional/north,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "gHg" = (
 /obj/structure/cable/yellow{
@@ -56143,6 +56202,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/bridge)
+"hCn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "hCr" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel,
@@ -57921,11 +57986,15 @@
 	},
 /area/station/hallway/primary/central/sw)
 "ikg" = (
-/obj/effect/decal/warning_stripes/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/decal/warning_stripes/northwestcorner,
+/obj/machinery/light/directional/north,
+/obj/structure/sign/pods{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "iki" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
@@ -61943,6 +62012,11 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/maintenance/asmaint)
+"jQc" = (
+/obj/effect/decal/warning_stripes/west,
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "jQi" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/icemachine{
@@ -62435,6 +62509,13 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/hallway)
+"kaE" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "kbg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64005,6 +64086,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"kGb" = (
+/obj/machinery/status_display/directional/west,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/arrival/station)
 "kGo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68480,6 +68565,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
+"mkg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "mki" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -69283,6 +69380,24 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
+"mCp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "mCw" = (
 /obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall,
@@ -69905,6 +70020,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/A)
+"mOp" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "mOz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -70060,8 +70181,11 @@
 	},
 /area/station/service/hydroponics)
 "mTi" = (
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "mTj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -70639,6 +70763,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"neF" = (
+/obj/machinery/light/directional/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/entry)
 "neH" = (
 /obj/structure/closet/crate/medical,
 /obj/item/crutches,
@@ -70878,6 +71008,11 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/controlroom)
+"niR" = (
+/obj/effect/decal/warning_stripes/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "niT" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/table,
@@ -75156,6 +75291,18 @@
 /obj/machinery/light/small/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"oLQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/secondary/entry)
 "oLS" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -76308,6 +76455,13 @@
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
+"pic" = (
+/obj/structure/chair/comfy/beige,
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/hallway/secondary/entry)
 "pij" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -76361,6 +76515,14 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plating,
 /area/station/service/janitor)
+"piQ" = (
+/obj/machinery/door/airlock/external{
+	id_tag = "admin_home";
+	locked = 1;
+	name = "Arrival Airlock"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "pjc" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -76442,6 +76604,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
+"pkf" = (
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock";
+	locked = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "pko" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -77579,6 +77748,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"pEp" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "pEu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/grille_maybe,
@@ -77996,6 +78174,15 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgery/primary)
+"pNQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "pOg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -78682,6 +78869,16 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/service/bar)
+"qaX" = (
+/obj/structure/table,
+/obj/item/paper/pamphlet,
+/obj/item/folder,
+/obj/item/pen,
+/obj/machinery/light/directional/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "qbR" = (
 /obj/effect/decal/warning_stripes/east,
 /turf/simulated/floor/wood,
@@ -78854,6 +79051,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
+"qfI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "qfJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -79760,6 +79969,18 @@
 	icon_state = "darkblue"
 	},
 /area/station/service/expedition)
+"qvr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals South";
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "qvO" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -79812,6 +80033,17 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"qwP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "qwU" = (
 /obj/structure/chair/sofa/corp,
 /obj/machinery/camera{
@@ -82911,6 +83143,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison/cell_block/A)
+"rGW" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "rHa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85048,6 +85286,13 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/exit)
+"swY" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "sxg" = (
 /obj/machinery/sleeper{
 	pixel_x = 3
@@ -85581,6 +85826,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"sEJ" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sign/poster/official/random/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "sEL" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood{
@@ -85886,6 +86139,10 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
+"sLN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "sLX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/spawner/random_spawners/oil_often,
@@ -86298,12 +86555,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "sTF" = (
@@ -86493,6 +86746,10 @@
 	icon_state = "floorgrime"
 	},
 /area/station/command/teleporter)
+"sVG" = (
+/obj/effect/spawner/window/grilled,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "sVZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -88683,6 +88940,20 @@
 	icon_state = "fancy-wood-cherry"
 	},
 /area/station/medical/psych)
+"tND" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "tNR" = (
 /obj/structure/chair{
 	dir = 8
@@ -90347,11 +90618,13 @@
 	},
 /area/station/engineering/hallway)
 "urF" = (
-/obj/effect/decal/warning_stripes/southeast,
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "arrival"
+	},
 /area/station/hallway/secondary/entry)
 "urU" = (
 /obj/structure/disposalpipe/segment{
@@ -91338,10 +91611,7 @@
 /area/station/engineering/hallway)
 "uKL" = (
 /obj/machinery/status_display/directional/south,
-/obj/effect/decal/warning_stripes/south,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
+/obj/effect/decal/warning_stripes/southwestcorner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "uKQ" = (
@@ -92279,6 +92549,15 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"vcQ" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/simulated/floor/plasteel{
+	icon_state = "grimy"
+	},
+/area/station/hallway/secondary/entry)
 "vcS" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/landmark/start/cargo_technician,
@@ -94051,9 +94330,10 @@
 "vKE" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "trade_dock";
-	locked = 1
+	locked = 1;
+	name = "Arrival Airlock"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "vKP" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -94779,7 +95059,9 @@
 /area/station/maintenance/aft)
 "vYh" = (
 /obj/item/radio/intercom/directional/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "bluecorner"
+	},
 /area/station/hallway/secondary/entry)
 "vYv" = (
 /obj/machinery/disposal,
@@ -94800,6 +95082,19 @@
 	icon_state = "blue"
 	},
 /area/station/maintenance/aft)
+"vYH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/camera{
+	c_tag = "Arrivals North"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "vYJ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -97379,6 +97674,12 @@
 	icon_state = "dark"
 	},
 /area/station/service/hydroponics)
+"xaY" = (
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "xaZ" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 0;
@@ -98558,6 +98859,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"xvP" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Auxiliary Docking South";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "xvS" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -108726,10 +109034,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aMs
+pkf
+pkf
+aMs
 aaa
 aaa
 aaa
@@ -108954,8 +109262,8 @@ aaa
 aaa
 aaa
 aSd
-aSf
-aSf
+eGs
+eGs
 aSd
 aaa
 aaa
@@ -108967,6 +109275,7 @@ aaa
 aaa
 aaa
 aaa
+aab
 aaa
 aaa
 aaa
@@ -108982,11 +109291,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aSd
+eGs
+eGs
+aSd
 aaa
 aaa
 aaa
@@ -109210,20 +109518,21 @@ aaa
 aaa
 aaa
 aaa
+aLd
+neF
+eoP
 aSd
-aSf
-aSf
-aSd
 aaa
 aaa
 aaa
-aVV
 aVV
 aVY
-aVV
+aVY
+aVY
 aVV
 aaa
 aaa
+aab
 aab
 aaa
 aaa
@@ -109239,11 +109548,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aLd
+neF
+eoP
+aSd
 aaa
 aaa
 aaa
@@ -109467,22 +109775,22 @@ aaa
 aaa
 aaa
 aaa
-aMs
-mTi
-mTi
-aMs
-aMs
+aLd
+vKE
+vKE
+aLd
+bjQ
 aaa
 aaa
-aVV
+aVY
 aYM
 jyO
 bcr
-aVV
+aVY
 aaa
 aaa
+cEL
 aab
-aab
 aaa
 aaa
 aaa
@@ -109491,17 +109799,17 @@ aaa
 aaa
 aaa
 aaa
+cEL
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aLd
+pkf
+pkf
+aLd
+bjQ
 aaa
 aaa
 aaa
@@ -109724,11 +110032,11 @@ aaa
 aaa
 aaa
 aaa
-aMs
-aMd
+aLd
+gGY
 aSf
 euy
-aMs
+aLd
 aaa
 aaa
 aVV
@@ -109738,7 +110046,7 @@ bcN
 aVV
 aaa
 aaa
-bjQ
+aMs
 aab
 aaa
 aaa
@@ -109748,17 +110056,17 @@ aaa
 aaa
 aaa
 aaa
+aMs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aLd
+gGY
+aSf
+euy
+aLd
 aaa
 aaa
 aaa
@@ -109981,11 +110289,11 @@ aaa
 aMs
 aMs
 aMs
-aMs
+aLd
 gGY
-aRd
+aSf
 urF
-aMs
+aLd
 aaa
 aVV
 aVV
@@ -109996,7 +110304,7 @@ aVV
 aVV
 aaa
 aLd
-aMs
+aLd
 aSd
 aSd
 aLd
@@ -110005,17 +110313,17 @@ aaa
 aaa
 aaa
 aaa
+aMs
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-bjQ
-aaa
-aaa
-aaa
-aaa
+aLd
+gGY
+aSf
+urF
+aLd
 aaa
 aaa
 aaa
@@ -110239,16 +110547,16 @@ aJP
 aRm
 aOP
 aMs
-aMd
+swY
 aMB
 aSd
 aSd
 aSd
 aVV
 aXr
+kGb
 jyO
-jyO
-jyO
+kGb
 aXs
 aVV
 aSd
@@ -110262,18 +110570,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aMs
 aaa
 aaa
 aaa
 aaa
 aaa
 aLd
-aaa
-aaa
-aaa
-aaa
-aaa
+gGY
+aMB
+aSd
+aSd
+aSd
 aaa
 aaa
 aaa
@@ -110494,24 +110802,24 @@ aJS
 aLb
 aMp
 aNt
-aOQ
+bMa
 aPZ
+kaE
+bLZ
+aRU
+cve
+aRU
+aVX
+aXs
+aYZ
+aYZ
+aYZ
+aXs
+aVX
+aRU
+aQa
+aRU
 aMd
-aSf
-aRU
-aOQ
-aRU
-aVX
-aXs
-aYZ
-aYZ
-aYZ
-aXs
-aVX
-aRU
-aOQ
-aRU
-aSf
 boL
 aSd
 aaa
@@ -110519,18 +110827,18 @@ aaa
 aaa
 aaa
 aaa
-bjQ
+aLd
 aaa
 aaa
 aaa
 aaa
 aaa
-aSd
-aaa
-aaa
-aaa
-aaa
-aaa
+aLd
+sEJ
+bLZ
+piQ
+cve
+piQ
 aaa
 aaa
 aaa
@@ -110752,7 +111060,7 @@ aJP
 aJP
 aRm
 aOR
-aQa
+aMs
 ikg
 uKL
 aSd
@@ -110769,26 +111077,26 @@ aSd
 aSd
 aSd
 cFJ
-bMg
+boL
 aSd
 aaa
 aaa
 aaa
 aaa
 aaa
-aLd
+sVG
 aaa
 aaa
 aaa
 aaa
 aaa
 aSd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gGY
+bLZ
+piQ
+cve
+piQ
+bPN
 aaa
 aaa
 aaa
@@ -111011,9 +111319,9 @@ aMs
 aMs
 aLd
 aRa
-aME
-aTo
-aUl
+rGW
+mOp
+mTi
 aSd
 aVV
 aXu
@@ -111024,27 +111332,27 @@ bes
 aVV
 aSd
 bid
-aTo
-bmS
-bsh
+mOp
+sLN
+bMg
 aSd
 aaa
 aaa
 aaa
 aaa
 aaa
-aSd
+sVG
 aaa
 aaa
 aaa
 aaa
 aaa
 aSd
+gGY
+uKL
 aSd
 aSd
 aSd
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -111267,7 +111575,7 @@ aJR
 aRV
 aOP
 aMs
-aPJ
+vYH
 aSf
 aSf
 aUk
@@ -111290,17 +111598,17 @@ aaa
 aaa
 aaa
 aaa
-aSd
+sVG
 aaa
 aaa
 aaa
 aaa
 aaa
 aSd
-bGm
-bLY
-bKp
-aaa
+pNQ
+rGW
+mTi
+aSd
 aaa
 aaa
 aaa
@@ -111522,9 +111830,9 @@ aJV
 aLf
 aMt
 aNy
-aOQ
+bMa
 aPZ
-aPJ
+bMb
 aSf
 aSf
 aUn
@@ -111540,14 +111848,14 @@ aSd
 bjT
 aSf
 aSf
-bsh
+qvr
 aSd
 aaa
 aaa
 aaa
 aaa
 aaa
-aSd
+sVG
 aaa
 aaa
 aaa
@@ -111555,9 +111863,9 @@ aaa
 aaa
 aSd
 bGl
-bLX
+aRd
 bKp
-bPN
+aSd
 aaa
 aaa
 aaa
@@ -111780,7 +112088,7 @@ aJR
 aJR
 aRV
 aOR
-aQa
+aMs
 aPJ
 aRd
 aTp
@@ -111797,25 +112105,25 @@ aSd
 bjS
 aTp
 brc
-bsh
-aSd
-aaa
-aaa
-aaa
-aaa
-aaa
-aMs
-aaa
-aaa
-aaa
-aaa
-aaa
-aSd
-bKp
-bKp
 bOb
+aSd
 aaa
 aaa
+aaa
+aaa
+aaa
+sVG
+aaa
+aaa
+aaa
+aaa
+aaa
+aSd
+mkg
+aMD
+aSd
+aSd
+aSd
 aaa
 aaa
 aaa
@@ -112054,25 +112362,25 @@ aSd
 aSd
 aSd
 blE
-bsh
+qwP
 aSd
 aaa
 aaa
 aaa
 aaa
 aaa
-aMs
+sVG
 aaa
 aaa
 aaa
 aaa
 aaa
 aSd
-aMd
+qfI
 bLZ
-aSd
-aaa
-aaa
+pkf
+cve
+pkf
 aaa
 aaa
 aaa
@@ -112296,9 +112604,9 @@ mxz
 aKa
 aGn
 aPR
-aSf
+bLZ
 aRU
-aOQ
+cve
 aRU
 aVX
 aXs
@@ -112308,28 +112616,28 @@ jyO
 aXs
 aVX
 aRU
-aOQ
+aQa
 aRU
-aSf
-bsh
+aMd
+qwP
 aSd
 aaa
 aaa
 bvf
 aaa
 aaa
-aMs
+aLd
 aaa
 aaa
 bCi
 aaa
 aaa
-aSd
-aMd
+aLd
+tND
 bLZ
-aSd
-aaa
-aaa
+pkf
+cve
+pkf
 aaa
 aaa
 aaa
@@ -112569,24 +112877,24 @@ aSd
 aSd
 dce
 bdO
-aSd
-aab
+aLd
+dOd
 aSd
 bvl
 aSd
-aab
+dOd
 aMs
-aab
+dOd
 aSd
 bDC
 aSd
-aaa
+dOd
+aLd
+qfI
+aRe
 aSd
-aMd
-bLZ
 aSd
-aaa
-aaa
+aSd
 aaa
 aaa
 aaa
@@ -112810,7 +113118,7 @@ pTK
 sar
 aGn
 aPY
-aME
+aSf
 bLY
 aSd
 aUZ
@@ -112824,9 +113132,9 @@ aVV
 aUZ
 aSd
 bpX
-bmS
+aSf
 bgR
-aLd
+aMs
 aSd
 aSd
 aOQ
@@ -112838,11 +113146,11 @@ aSd
 aOQ
 aSd
 aSd
+aMs
+qfI
+aSf
+bLY
 aSd
-aMd
-bMa
-bjQ
-aaa
 aaa
 aaa
 aaa
@@ -113068,7 +113376,7 @@ iOQ
 aGn
 aPY
 aSf
-bLZ
+cIK
 aLd
 aLd
 aLd
@@ -113080,7 +113388,7 @@ aSd
 aLd
 aLd
 aLd
-aMd
+niR
 aSf
 bsl
 aMs
@@ -113094,12 +113402,12 @@ aUl
 aSd
 bDC
 aSd
-bBg
-aTo
-bmS
-bMb
+bwO
+aMs
+oLQ
+aSf
+xaY
 aLd
-aaa
 aaa
 aaa
 aaa
@@ -113323,12 +113631,12 @@ aII
 aNA
 oGl
 aGn
-aPY
+mCp
 aSf
 aME
 aUo
 aUV
-aTo
+jQc
 edY
 aTo
 aTo
@@ -113343,20 +113651,20 @@ aSj
 bgG
 aME
 aTo
-aSf
-lko
+aTo
+bLX
 bmS
 bzr
 aME
-edY
-aSf
+aYD
+aTo
 aTo
 bmS
+xvP
+bgB
 aSf
-aSf
-bLZ
+bMc
 aSd
-aaa
 aaa
 aaa
 aaa
@@ -113600,7 +113908,7 @@ bsq
 buf
 buS
 blV
-blV
+hCn
 uGE
 bDu
 bEm
@@ -113611,9 +113919,9 @@ jiy
 plc
 plc
 sTE
-bMc
-aSd
-aaa
+blg
+qaX
+aLd
 aaa
 aaa
 aaa
@@ -113868,9 +114176,9 @@ kNP
 vYh
 dsG
 cAm
-bwx
-blQ
-aaa
+aTp
+pEp
+aSd
 aaa
 aaa
 aaa
@@ -114127,7 +114435,7 @@ bnS
 ckp
 blQ
 nqv
-aaa
+blQ
 aaa
 aaa
 aaa
@@ -114362,10 +114670,10 @@ aZW
 bcX
 bgu
 bhO
-aSW
+pic
 bgj
 bjO
-bmo
+vcQ
 brk
 bgB
 bqr
@@ -114382,9 +114690,9 @@ jtt
 cTP
 bnS
 pfj
+bnK
 hEd
 mBl
-blQ
 nqv
 blQ
 iez
@@ -114640,7 +114948,7 @@ bqG
 bnS
 jFt
 bnK
-cEL
+bnK
 cjg
 bnw
 vwk

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -98861,7 +98861,7 @@
 /area/station/hallway/primary/central/se)
 "xvP" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Auxiliary Docking South";
+	c_tag = "Arrivals Auxiliary Docking South-East";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Чуточку улучшает прибытие Кибериады
 - Добавлен доп. порт стыковки "на будущее" и для симметричности
 - Переложил плитку, декали
 - Местами подвигал машинерию
 - Визуальные улучшения

## Почему это хорошо для игры
Улучшения Кибериады

## Изображения изменений
+Мапдифф
![arrival](https://github.com/ss220club/Paradise-SS220/assets/20109643/24402c22-77ae-4447-95e6-d27997bd724f)

## Тестирование
В игре

## Changelog

:cl:
add: Кибериада: Добавлен новый порт стыковки в прибытие "на будущее"
tweak: Кибериада: Улучшена визуальная составляющая, местами подвинута машинерия
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
