### PR TITLE
fix: make gliding in Zero-G set correctly

### DIFF
--- a/code/controllers/subsystem/SSspacedrift.dm
+++ b/code/controllers/subsystem/SSspacedrift.dm
@@ -53,8 +53,7 @@ SUBSYSTEM_DEF(spacedrift)
 		var/old_dir = AM.dir
 		var/old_loc = AM.loc
 		AM.inertia_moving = TRUE
-		AM.set_glide_size(DELAY_TO_GLIDE_SIZE(AM.inertia_move_delay))
-		step(AM, AM.inertia_dir)
+		AM.Move(get_step(AM, AM.inertia_dir), AM.inertia_dir, DELAY_TO_GLIDE_SIZE(AM.inertia_move_delay))
 		AM.inertia_moving = FALSE
 		AM.inertia_next_move = world.time + AM.inertia_move_delay
 		if(AM.loc == old_loc)


### PR DESCRIPTION
## Что этот PR делает

Делает перемещение без гравитации плавным

## Почему это хорошо для игры

При отсутствии гравитации перемещение будет плавным

## Тестирование
Полетал в космосе. Да и step просто вызывает Move()

## Changelog

:cl:
fix: Глайдинг в космосе плавный
/:cl:

