### PR TITLE
Fix: BMPtraiders active turfs

### DIFF
--- a/_maps/map_files220/RandomZLevels/blackmarketpackers.dmm
+++ b/_maps/map_files220/RandomZLevels/blackmarketpackers.dmm
@@ -1570,7 +1570,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Engines)
 "eM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2667,7 +2667,7 @@
 /area/awaymission/BMPship/Fore)
 "hY" = (
 /obj/effect/gibspawner/robot,
-/turf/simulated,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Buffer)
 "hZ" = (
 /obj/structure/window/reinforced{
@@ -4242,7 +4242,7 @@
 	dir = 4;
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Gate)
 "tA" = (
 /turf/simulated/wall/mineral/titanium,
@@ -5578,7 +5578,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Gate)
 "FQ" = (
 /obj/effect/landmark/damageturf,
@@ -6168,7 +6168,7 @@
 	dir = 4;
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Bath)
 "Ms" = (
 /obj/structure/cable{
@@ -6601,7 +6601,7 @@
 /area/awaymission/BMPship/MedBay)
 "RB" = (
 /obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/TraderShuttle)
 "RF" = (
 /obj/structure/cable{
@@ -6683,7 +6683,7 @@
 	dir = 4;
 	tag = "icon-propulsion (WEST)"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Engines)
 "SJ" = (
 /obj/item/stack/ore/uranium,
@@ -7013,7 +7013,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless,
 /area/awaymission/BMPship/Bath)
 "WD" = (
 /obj/effect/gibspawner/generic,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Убрал активные турфы в гейте с кораблем контрабандистов.

## Почему это хорошо для игры

Меньше нагрузка

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Локалка

## Changelog

:cl:
fix: В гейте BMPtraiders убрал тайлы с воздухом из космоса.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
