### PR TITLE
Revert: TTS whisper

### DIFF
--- a/modular_ss220/text_to_speech/code/hear.dm
+++ b/modular_ss220/text_to_speech/code/hear.dm
@@ -38,8 +38,6 @@
 	var/message_tts = combine_message_tts(message_pieces, speaker)
 	var/effect = isrobot(speaker) ? SOUND_EFFECT_ROBOT : SOUND_EFFECT_NONE
 	var/traits = TTS_TRAIT_RATE_FASTER
-	if(italics)
-		traits |= TTS_TRAIT_PITCH_WHISPER
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(tts_cast), speaker, src, message_tts, speaker.tts_seed, TRUE, effect, traits)
 
 /mob/hear_radio(list/message_pieces, verb = "says", part_a, part_b, mob/speaker = null, hard_to_hear = 0, vname = "", atom/follow_target, check_name_against)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Ревертит кринжовый голос при шёпоте.
в Силеро плохо реализован шёпот (а если точнее - это не реализация, а уничтожение интонации в речи)

## Почему это хорошо для игры
 Никому это не нравится, голос становится роботизирован
+уши

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
del: Реверт изменения голоса при шёпоте (плохая реализация в Силеро)
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
