### PR TITLE
[MAP] Добавляем пет-вендинг

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -7677,6 +7677,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/clothing/accessory/medal{
+	name = "медаль хорошему мальчику";
+	desc = "Тот кто её носит - определенно заслужил её!"
+	},
+/obj/item/petcollar{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/petcollar{
+	pixel_y = 3
+	},
+/obj/item/petcollar{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -11258,6 +11275,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/blue/partial{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -11297,13 +11317,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluered"
 	},
 /area/station/public/dorms)
 "aQA" = (
-/obj/machinery/economy/vending/snack,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11318,6 +11338,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/economy/vending/crittercare,
+/obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluered"
@@ -12936,7 +12958,8 @@
 /area/station/medical/reception)
 "aWJ" = (
 /mob/living/simple_animal/walrus{
-	name = "Джеди"
+	name = "Порфирий Корнеевич";
+	desc = "Обожает плескаться в холодной воде и всем рекомендует."
 	},
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
@@ -59602,6 +59625,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/warning_stripes/blue/partial{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluered"
@@ -74086,6 +74112,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"oqZ" = (
+/obj/effect/decal/warning_stripes/blue/partial,
+/turf/simulated/floor/plasteel,
+/area/station/public/dorms)
 "orf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -91126,6 +91156,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/toxins/mixing)
+"uAT" = (
+/obj/effect/decal/warning_stripes/blue/partial,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/public/dorms)
 "uAU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -94748,6 +94784,8 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/fish_eggs/salmon,
 /obj/item/fish_eggs/salmon,
+/obj/item/fish_eggs/shrimp,
+/obj/item/fish_eggs/shrimp,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -135705,7 +135743,7 @@ aKK
 aOb
 aFI
 aDv
-aSJ
+uAT
 aUI
 aWJ
 aWK
@@ -135962,7 +136000,7 @@ aGN
 aGN
 aPf
 aQA
-aSJ
+uAT
 aUK
 aWM
 aWM
@@ -136219,7 +136257,7 @@ qfL
 gLe
 aPf
 aQz
-aPm
+oqZ
 aUJ
 aWL
 aZz

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -37177,6 +37177,7 @@
 "cOs" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -37568,6 +37569,7 @@
 	srange = 7
 	},
 /obj/structure/closet/athletic_mixed,
+/obj/effect/decal/warning_stripes/blue/partial,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -53743,8 +53745,23 @@
 	},
 /area/station/hallway/secondary/exit)
 "fRm" = (
-/obj/machinery/economy/vending/cola,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/table,
+/obj/item/clothing/accessory/medal{
+	name = "медаль хорошему мальчику";
+	desc = "Тот кто её носит - определенно заслужил её!"
+	},
+/obj/item/petcollar{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/petcollar{
+	pixel_y = 3
+	},
+/obj/item/petcollar{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/effect/decal/warning_stripes/blue/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -54690,8 +54707,8 @@
 	},
 /area/station/science/explab)
 "gkj" = (
-/obj/machinery/economy/vending/snack,
-/obj/effect/decal/warning_stripes/yellow,
+/obj/machinery/economy/vending/crittercare,
+/obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -58264,6 +58281,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint/south)
+"hEU" = (
+/obj/machinery/economy/vending/cola,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/public/fitness)
 "hFh" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -62089,6 +62113,9 @@
 /area/station/service/barber)
 "jbW" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/decal/warning_stripes/blue/partial{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -67766,6 +67793,22 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/break_room)
+"lkf" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/warning_stripes/blue/partial{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/public/fitness)
 "lkh" = (
 /obj/structure/filingcabinet/chestdrawer/autopsy,
 /obj/machinery/status_display/directional/west,
@@ -72047,6 +72090,7 @@
 /area/station/maintenance/starboard2)
 "mYH" = (
 /obj/machinery/newscaster/directional/west,
+/obj/effect/decal/warning_stripes/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -155566,7 +155610,7 @@ iVg
 xql
 cAt
 cBZ
-ctx
+hEU
 mYH
 fLx
 cGX
@@ -155829,9 +155873,9 @@ olj
 cIs
 qfX
 olj
-olj
-olj
-olj
+lkf
+lkf
+lkf
 olj
 stG
 qfX


### PR DESCRIPTION
## Что этот PR делает

- Добавляем Пет-вендинг в дормитории на места дубликатов автоматов со снеками.
- Убираем непонятную отсылку на коробке и замещаем её на моржа, придавая ему солидный вид.
- Добавляем медаль хорошему мальчику

## Почему это хорошо для игры

Наконец-то можно готовить рыбу, не боясь потерять всё.

## Изображения изменений

![image](https://github.com/ss220club/Paradise-SS220/assets/41479614/5464f0d3-e1b5-4409-b471-dc3daea4242b)
![image](https://github.com/ss220club/Paradise-SS220/assets/41479614/bd4b9968-4c65-4266-9984-1ee283e67f87)

## Тестирование
Да?

## Changelog

:cl:
add: Добавлены пет-вендинги в дормитории
del: Непонятная отсылка у моржа
add: Медаль хорошему мальчику
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
