### PR TITLE
fix: show title properly, on `new_player` init

### DIFF
--- a/modular_ss220/title_screen/code/new_player.dm
+++ b/modular_ss220/title_screen/code/new_player.dm
@@ -2,6 +2,7 @@ GLOBAL_LIST_EMPTY(new_player_list)
 
 /mob/new_player/Initialize(mapload)
 	GLOB.new_player_list += src
+	show_title_screen()
 	. = ..()
 
 /mob/new_player/Destroy()
@@ -10,4 +11,3 @@ GLOBAL_LIST_EMPTY(new_player_list)
 
 /mob/new_player/Login()
 	. = ..()
-	show_title_screen()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Лобби скрин теперь подгружается вовремя(наверное)

## Почему это хорошо для игры

Не надо каждый раз жать FIX LOBBY SCREEN

## Тестирование
Запустил и сразу зашел - всё есть

## Changelog

:cl:
fix: Лобби скрин теперь подгружается вовремя(наверное)
/:cl:
