### PR TITLE
costil: adds `show_title_screen` to new_player/Login(), as well as to new_player/Initialize()

### DIFF
--- a/modular_ss220/title_screen/code/new_player.dm
+++ b/modular_ss220/title_screen/code/new_player.dm
@@ -11,3 +11,4 @@ GLOBAL_LIST_EMPTY(new_player_list)
 
 /mob/new_player/Login()
 	. = ..()
+	show_title_screen()


### PR DESCRIPTION

## Что этот PR делает

Quickfix для отображения лобби скрина

## Почему это хорошо для игры

Quickfix для отображения лобби скрина

## Changelog

:cl:
fix: Quickfix для отображения лобби скрина
/:cl:
