### PR TITLE
Fix: Cyberiad pack of fixes

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -17376,6 +17376,10 @@
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Computer"
 	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "yellow"
@@ -17679,6 +17683,11 @@
 	},
 /area/station/command/bridge)
 "bpq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -34590,6 +34599,16 @@
 /obj/effect/turf_decal/bot_red,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/classic/reversed{
+	dir = 1;
+	name = "Testing Chamber Delivery Chute"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/science/tox{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -60228,6 +60247,25 @@
 	icon_state = "darkred"
 	},
 /area/station/security/warden)
+"jfJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/command/bridge)
 "jfQ" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/camera{
@@ -129438,8 +129476,8 @@ bbr
 blU
 bnV
 bpq
-bqS
-hBF
+oTG
+jfJ
 bxw
 beE
 bxp

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -95650,8 +95650,9 @@
 /area/station/engineering/supermatter_room)
 "wnR" = (
 /obj/machinery/mineral/stacking_machine{
-	input_dir = 1;
-	stack_amt = 10
+	input_dir = 8;
+	stack_amt = 10;
+	output_dir = 2
 	},
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -22045,8 +22045,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/button/windowtint/west{
-	id = "rnd";
-	pixel_y = -9
+	id = "rnd"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -27843,10 +27843,6 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
 "ciI" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "garbage";
-	name = "disposal coveyor"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -52659,6 +52655,7 @@
 "gsg" = (
 /obj/effect/decal/warning_stripes/east,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "gsh" = (
@@ -55154,7 +55151,7 @@
 /obj/machinery/conveyor/east{
 	id = "garbage"
 	},
-/obj/machinery/alarm/directional/north,
+/obj/machinery/recycler,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "hjX" = (
@@ -63012,7 +63009,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "klN" = (
-/mob/living/simple_animal/hostile/feral_cat,
+/mob/living/simple_animal/hostile/feral_cat/forsaken,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/apmaint)
 "klS" = (
@@ -81139,7 +81136,6 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "qPt" = (
-/obj/machinery/recycler,
 /obj/machinery/conveyor/east{
 	dir = 6;
 	id = "QMLoad2"
@@ -82715,7 +82711,6 @@
 /turf/simulated/wall,
 /area/station/maintenance/apmaint)
 "rzr" = (
-/mob/living/simple_animal/mouse,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -83283,7 +83278,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
-/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "rMq" = (
@@ -89846,6 +89840,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "ueH" = (
@@ -90963,7 +90958,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/rat,
+/obj/machinery/conveyor_switch/oneway{
+	id = "garbage";
+	name = "disposal coveyor"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "uAb" = (
@@ -91954,6 +91952,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "uUf" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
- Исправляет подключение power monitor'а к сети на мостике
- Добавляет защитную стеклянную дверь к воронке в камеру испытания токсинов
- Исправляет неверные значения у stacking machine
- Правильная киса в техах
- Исправляет наложение кнопки на стойке РНД

## Почему это хорошо для игры
Меньше багов и недоработок

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/fbd04d49-23e9-40b5-b5b4-2f4b930753ac)
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/b6677aba-baa8-4d51-8184-652ec36f15b7)

## Тестирование
Trust me bro

## Changelog

:cl:
fix: Кибериада: Исправление подключения power monitor'а к сети на мостике
fix: Кибериада: Добавил защитную стеклянную дверь к воронке в камеру испытания токсинов
fix: Кибериада: Исправлена работа stacking machine
fix: Кибериада: Исправлен тип кисы в техах карго
fix: Кибериада: Исправлено наложение кнопки на стойке РНД
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
