### PR TITLE
Tweak: APC subtypes

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm
@@ -1445,9 +1445,7 @@
 /obj/effect/spawner/random_spawners/blood_often,
 /obj/effect/spawner/random_spawners/dirt_often,
 /obj/item/organ/external/hand,
-/obj/machinery/power/apc/off_station/empty_charge{
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/off_station/empty_charge/west,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/requires_power_space)
 "Ok" = (

--- a/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -218,9 +218,7 @@
 /area/ruin/space/spacehotelv1/engi2)
 "bC" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /obj/structure/dresser,
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/spacehotelv1/guestroom5)
@@ -283,10 +281,7 @@
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/spacehotelv1/forehallway)
 "cb" = (
-/obj/machinery/power/apc/off_station{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/off_station/west,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -379,10 +374,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /obj/structure/table/wood/fancy/blue,
 /obj/item/bee_briefcase,
 /turf/simulated/floor/carpet/royalblack,
@@ -664,10 +656,7 @@
 /obj/structure/railing/cap{
 	dir = 10
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -1391,9 +1380,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /obj/structure/chair/wood{
 	dir = 1
 	},
@@ -1573,9 +1560,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /obj/structure/table/reinforced/brass,
 /obj/item/paper_bin,
 /obj/item/pen/multi,
@@ -1692,9 +1677,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -2009,10 +1992,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
@@ -2503,10 +2483,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/off_station/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -2892,9 +2869,7 @@
 /area/ruin/space/spacehotelv1/engi1)
 "uI" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = 24
@@ -3113,10 +3088,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/off_station/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "cmo"
 	},
@@ -3498,10 +3470,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/power/apc/off_station/west,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
@@ -4258,10 +4227,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
@@ -4534,10 +4500,7 @@
 /area/ruin/space/spacehotelv1/entryhallway)
 "FP" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/off_station{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/off_station/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5130,9 +5093,7 @@
 /area/ruin/space/spacehotelv1/centralhallway)
 "Ki" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
@@ -5330,9 +5291,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/spacehotelv1/reception)
 "Lw" = (
@@ -5761,9 +5720,7 @@
 /area/ruin/space/spacehotelv1/guestroom6)
 "Oy" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/off_station{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/south,
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
@@ -5874,10 +5831,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -5933,10 +5887,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /obj/effect/spawner/random_spawners/dirt_often,
 /obj/machinery/atmospherics/portable/canister/nitrogen,
 /turf/simulated/floor/plating,
@@ -6028,10 +5979,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/off_station/east,
 /obj/vehicle/janicart,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/spacehotelv1/janitor)
@@ -6400,10 +6348,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi1)
 "TN" = (
@@ -6679,10 +6624,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 1;
-	pixel_y = 24
-	},
+/obj/machinery/power/apc/off_station/north,
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/spacehotelv1/guestroom2)
 "VH" = (
@@ -7068,10 +7010,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/off_station{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/off_station/east,
 /obj/effect/spawner/random_spawners/dirt_often,
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/engi2)

--- a/_maps/map_files220/RandomZLevels/caves.dmm
+++ b/_maps/map_files220/RandomZLevels/caves.dmm
@@ -4917,7 +4917,9 @@
 	},
 /area/awaymission/caves)
 "zk" = (
-/obj/machinery/power/apc/off_station/empty_charge/south,
+/obj/machinery/power/apc/off_station/empty_charge{
+	pixel_y = -24
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"

--- a/_maps/map_files220/RandomZLevels/caves.dmm
+++ b/_maps/map_files220/RandomZLevels/caves.dmm
@@ -4917,9 +4917,7 @@
 	},
 /area/awaymission/caves)
 "zk" = (
-/obj/machinery/power/apc/off_station/empty_charge{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/empty_charge/south,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"

--- a/_maps/map_files220/RandomZLevels/gate_lizard.dmm
+++ b/_maps/map_files220/RandomZLevels/gate_lizard.dmm
@@ -7494,9 +7494,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/random_spawners/dirt_frequent,
-/obj/machinery/power/apc/off_station/empty_charge{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/off_station/empty_charge/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -10059,9 +10057,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/off_station/empty_charge{
-	pixel_y = -24
-	},
+/obj/machinery/power/apc/off_station/empty_charge/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -5559,11 +5559,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4;
-	nightshift_allowed = 0;
-	nightshift_enabled = 1
-	},
+/obj/machinery/light/nightshifted/east,
 /turf/simulated/floor/beach/water{
 	icon_state = "seadeep"
 	},
@@ -10787,9 +10783,8 @@
 	name = "Engineering External Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
+/obj/machinery/access_button/north{
 	autolink_id = "apsolar_btn_ext";
-	pixel_y = 24;
 	req_one_access_txt = "13"
 	},
 /turf/simulated/floor/plating,
@@ -16973,7 +16968,7 @@
 /turf/simulated/floor/wood/oak,
 /area/station/service/library)
 "bmE" = (
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /mob/living/simple_animal/pet/dog/bullterrier/Genn,
 /obj/structure/bed/dogbed,
 /turf/simulated/floor/plasteel{
@@ -28741,9 +28736,8 @@
 	name = "Engineering External Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
+/obj/machinery/access_button/south{
 	autolink_id = "apsolar_btn_int";
-	pixel_y = -24;
 	req_one_access_txt = "13"
 	},
 /turf/simulated/floor/plating,

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -1435,11 +1435,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "amu" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/machinery/light,
+/obj/machinery/status_display/directional/north,
+/obj/machinery/light/directional/south,
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -26373,11 +26370,10 @@
 	locked = 1;
 	name = "Prison Wing"
 	},
-/obj/machinery/access_button{
+/obj/machinery/access_button/east{
 	autolink_id = "perma_btn_ext";
 	name = "Prison Wing Access Button";
-	req_one_access_txt = "2";
-	pixel_x = 24
+	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -58518,10 +58514,9 @@
 	locked = 1;
 	name = "Prison Wing"
 	},
-/obj/machinery/access_button{
+/obj/machinery/access_button/south{
 	autolink_id = "perma_btn_int";
 	name = "Prison Wing Access Button";
-	pixel_y = -24;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
@@ -64708,10 +64703,9 @@
 	locked = 1;
 	name = "Prison Wing"
 	},
-/obj/machinery/access_button{
+/obj/machinery/access_button/north{
 	autolink_id = "perma_btn_int";
 	name = "Prison Wing Access Button";
-	pixel_y = 24;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
@@ -101663,11 +101657,10 @@
 	locked = 1;
 	name = "Prison Wing"
 	},
-/obj/machinery/access_button{
+/obj/machinery/access_button/west{
 	autolink_id = "perma_btn_ext";
 	name = "Prison Wing Access Button";
-	req_one_access_txt = "2";
-	pixel_x = -24
+	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/autoname,

--- a/modular_ss220/maps220/code/directions.dm
+++ b/modular_ss220/maps220/code/directions.dm
@@ -498,6 +498,36 @@
 	pixel_x = 24
 	dir = 4
 
+/obj/machinery/power/apc/off_station/south
+	pixel_y = -24
+
+/obj/machinery/power/apc/off_station/north
+	pixel_y = 24
+	dir = 1
+
+/obj/machinery/power/apc/off_station/west
+	pixel_x = -24
+	dir = 8
+
+/obj/machinery/power/apc/off_station/east
+	pixel_x = 24
+	dir = 4
+
+/obj/machinery/power/apc/off_station/empty_charge/south
+	pixel_y = -24
+
+/obj/machinery/power/apc/off_station/empty_charge/north
+	pixel_y = 24
+	dir = 1
+
+/obj/machinery/power/apc/off_station/empty_charge/west
+	pixel_x = -24
+	dir = 8
+
+/obj/machinery/power/apc/off_station/empty_charge/east
+	pixel_x = 24
+	dir = 4
+
 /* Wall Tanks */
 /obj/structure/reagent_dispensers/fueltank/chem
 	name = "\improper fuel tank"

--- a/tools/UpdatePaths/Scripts/ss220/vars_to_subtypes.txt
+++ b/tools/UpdatePaths/Scripts/ss220/vars_to_subtypes.txt
@@ -560,3 +560,13 @@
 /obj/machinery/power/apc {pixel_y=24;name="Engineering Engine Super APC"} : /obj/machinery/power/apc/super/north
 /obj/machinery/power/apc {pixel_x=-24;name="Engineering Engine Super APC"} : /obj/machinery/power/apc/super/west
 /obj/machinery/power/apc {pixel_x=24;name="Engineering Engine Super APC"} : /obj/machinery/power/apc/super/east
+
+/obj/machinery/power/apc/off_station {pixel_y=-24} : /obj/machinery/power/apc/off_station/south
+/obj/machinery/power/apc/off_station {pixel_y=24} : /obj/machinery/power/apc/off_station/north
+/obj/machinery/power/apc/off_station {pixel_x=-24} : /obj/machinery/power/apc/off_station/west
+/obj/machinery/power/apc/off_station {pixel_x=24} : /obj/machinery/power/apc/off_station/east
+
+/obj/machinery/power/apc/off_station/empty_charge {pixel_y=-24} : /obj/machinery/power/apc/off_station/empty_charge/south
+/obj/machinery/power/apc/off_station/empty_charge {pixel_y=24} : /obj/machinery/power/apc/off_station/empty_charge/north
+/obj/machinery/power/apc/off_station/empty_charge {pixel_x=-24} : /obj/machinery/power/apc/off_station/empty_charge/west
+/obj/machinery/power/apc/off_station/empty_charge {pixel_x=24} : /obj/machinery/power/apc/off_station/empty_charge/east


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавляет подтипы направления для АПЦшек руин.
Плюс дополняет ими скрипт и применяет его же.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Closes #331 
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
Nope
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Nope
<!-- Как вы тестировали свой PR, если делали это вовсе? -->


<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
