### PR TITLE
Tweak: Return exile implant, fix archive icon

### DIFF
--- a/_maps/map_files220/RandomZLevels/caves.dmm
+++ b/_maps/map_files220/RandomZLevels/caves.dmm
@@ -205,7 +205,7 @@
 /turf/simulated/floor/plating/lavaland_air,
 /area/awaymission/caves)
 "aW" = (
-/obj/structure/cult/functional/archives,
+/obj/structure/cult/archives,
 /obj/item/spellbook/oneuse/fake_gib,
 /obj/effect/spawner/random_spawners/blood_often,
 /obj/effect/decal/cleanable/dust,

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -16976,7 +16976,7 @@
 	},
 /area/station/service/library)
 "bmF" = (
-/obj/structure/cult/functional/archives,
+/obj/structure/cult/archives,
 /obj/machinery/light_switch/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -75847,7 +75847,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "oWW" = (
-/obj/structure/cult/functional/archives,
+/obj/structure/cult/archives,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "oXo" = (

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -29514,7 +29514,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "cvo" = (
-/obj/structure/cult/functional/archives,
+/obj/structure/cult/archives,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/library)
 "cvp" = (

--- a/modular_ss220/gateway/code/exile.dm
+++ b/modular_ss220/gateway/code/exile.dm
@@ -14,6 +14,24 @@
 	notes = "The onboard station gateway system has been modified to reject entry by individuals containing this bio-chip."
 	function = "Prevents the user from reentering the station through the gateway.... alive."
 
+/datum/supply_packs/security/armory/exileimp
+	name = "Exile Bio-chips Crate"
+	contains = list(/obj/item/storage/box/exileimp)
+	cost = 600
+	containername = "exile bio-chip crate"
+
+/obj/item/storage/box/exileimp
+	name = "boxed exile bio-chip kit"
+	desc = "Box of exile bio-chips. It has a picture of a clown being booted through the Gateway."
+
+/obj/item/storage/box/exileimp/populate_contents()
+	new /obj/item/implanter/exile(src)
+	new /obj/item/implantcase/exile(src)
+	new /obj/item/implantcase/exile(src)
+	new /obj/item/implantcase/exile(src)
+	new /obj/item/implantcase/exile(src)
+	new /obj/item/implantcase/exile(src)
+
 /obj/item/implanter/exile
 	name = "bio-chip implanter (exile)"
 	implant_type = /obj/item/implant/exile

--- a/modular_ss220/objects/code/miscellaneous.dm
+++ b/modular_ss220/objects/code/miscellaneous.dm
@@ -112,3 +112,11 @@
 		/obj/item/encryptionkey,
 		/obj/item/clothing/gloves/ring)
 
+// These objects are deleted by Offs, i returned them
+// Archive structure
+/obj/structure/cult/archives
+	name = "Desk"
+	desc = "A desk covered in arcane manuscripts and tomes in unknown languages. Looking at the text makes your skin crawl."
+	icon_state = "archives"
+	light_range = 1.5
+	light_color = LIGHT_COLOR_FIRE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
- Возвращает Exile имплант
- Фиксит иконку архив и в его в целом, возвращая вырезанную структуру

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Возвращен Exile имплант после мержа с оффами
fix: Пофикшена иконка архивов
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
