### PR TITLE
Feat: Centcom level actualization

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -14051,7 +14051,7 @@
 	},
 /area/syndicate_mothership/jail)
 "lbv" = (
-/obj/structure/railing/cap{
+/obj/structure/railing/cap/reversed{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -23629,6 +23629,12 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/elite_squad)
+"sBI" = (
+/obj/structure/railing/cap/normal{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "sCq" = (
 /obj/structure/light_fake/spot,
 /obj/item/kirbyplants,
@@ -27104,9 +27110,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "vpg" = (
@@ -29124,6 +29128,12 @@
 	icon_state = "darkyellowcornersalt"
 	},
 /area/syndicate_mothership/cargo)
+"wRY" = (
+/obj/structure/railing/cap/reversed{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "wSr" = (
 /obj/effect/bump_teleporter{
 	id = "Synd25";
@@ -84757,7 +84767,7 @@ que
 hsR
 oqx
 cgV
-gEh
+wRY
 gEh
 gIe
 fyL
@@ -85271,7 +85281,7 @@ que
 hsR
 hiL
 bAr
-gEh
+sBI
 gEh
 gEh
 kZR

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -5,6 +5,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership)
+"aae" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "aaz" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -66,6 +72,12 @@
 	icon_state = "darkyellowfull"
 	},
 /area/syndicate_mothership/cargo)
+"acl" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "acq" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/indestructible
@@ -141,12 +153,6 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"afu" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "afG" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -195,11 +201,6 @@
 /obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin1)
-"aix" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "aiJ" = (
 /obj/structure/closet/syndicate/nuclear,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -327,6 +328,27 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin3)
+"anM" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "aoD" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate,
@@ -362,6 +384,10 @@
 "aph" = (
 /turf/simulated/floor/carpet/red,
 /area/wizard_station)
+"apS" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "aqj" = (
 /obj/structure/table/wood{
 	color = "#996633"
@@ -389,14 +415,6 @@
 /obj/machinery/plantgenes,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
-"aqx" = (
-/obj/structure/chair/stool/bar{
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/ghost_bar)
 "arh" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_sit)
@@ -421,6 +439,12 @@
 /obj/item/gun/energy/pulse/destroyer/annihilator,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"arE" = (
+/obj/machinery/economy/vending/autodrobe,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "arH" = (
 /obj/machinery/economy/vending/cola/free,
 /turf/simulated/floor/plasteel/dark,
@@ -442,6 +466,11 @@
 	icon_state = "neutral"
 	},
 /area/centcom/ss220/evac)
+"aso" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "ast" = (
 /obj/structure/toilet,
 /turf/simulated/floor/plasteel{
@@ -512,9 +541,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"atq" = (
-/turf/simulated/wall/indestructible/syndicate,
-/area/ghost_bar)
 "atu" = (
 /turf/simulated/wall/indestructible/wood,
 /area/ninja/holding)
@@ -846,6 +872,10 @@
 	icon_state = "bot"
 	},
 /area/shuttle/escape)
+"aEU" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "aFb" = (
 /obj/machinery/door/window/classic/reversed{
 	dir = 4;
@@ -954,11 +984,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/administration)
+"aKd" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "aKx" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/shuttle/syndicate)
+"aKD" = (
+/obj/machinery/economy/vending/cigarette,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "aKO" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/grass/jungle/no_creep,
@@ -1030,13 +1073,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"aMU" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "aNi" = (
 /obj/structure/curtain/black{
 	pixel_y = -32;
@@ -1198,6 +1234,10 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
+"aVs" = (
+/obj/machinery/economy/vending/boozeomat,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "aWR" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/wizrobe/marisa,
@@ -1206,6 +1246,16 @@
 /obj/item/staff/broom,
 /turf/simulated/floor/carpet/black,
 /area/wizard_station)
+"aXc" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "aXh" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/bottle/vodka{
@@ -1254,9 +1304,10 @@
 /obj/item/dice/d20,
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
-"aYV" = (
-/obj/structure/sign/poster/contraband/syndicate_recruitment,
-/turf/simulated/wall/indestructible/riveted,
+"aYQ" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/ashtray/plastic,
+/turf/simulated/floor/carpet/black,
 /area/ghost_bar)
 "aYX" = (
 /obj/structure/chair/sofa/pew{
@@ -1456,12 +1507,6 @@
 /obj/item/storage/box/alienhandcuffs,
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
-"bil" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "bit" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo3"
@@ -1543,12 +1588,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
-"blD" = (
-/obj/machinery/kitchen_machine/oven/upgraded,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "bmv" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -1597,10 +1636,6 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
-"boD" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "boO" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -1620,12 +1655,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
-"boY" = (
-/obj/machinery/economy/vending/hatdispenser,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "bpc" = (
 /obj/docking_port/stationary/transit{
 	dir = 2;
@@ -1870,10 +1899,18 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"bzF" = (
-/obj/item/clothing/head/cone,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+"bAr" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/stairs/left{
+	dir = 1
+	},
+/area/ghost_bar)
+"bCk" = (
+/obj/machinery/economy/vending/hatdispenser,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
 /area/ghost_bar)
 "bCs" = (
@@ -1908,6 +1945,14 @@
 	icon_state = "grimy"
 	},
 /area/syndicate_mothership)
+"bDn" = (
+/obj/structure/table/wood,
+/obj/structure/light_fake/small{
+	dir = 4
+	},
+/obj/item/deck/tarot,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "bDX" = (
 /obj/item/flag/syndi,
 /turf/simulated/floor/plasteel{
@@ -2003,10 +2048,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
-"bHi" = (
-/obj/structure/sign/bobross,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "bHy" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -2040,10 +2081,11 @@
 	water_overlay_image = null
 	},
 /area/centcom/ss220/evac)
-"bJA" = (
-/obj/structure/chair/comfy/black,
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
+"bIN" = (
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/space/nearstation)
 "bJO" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/marker_beacon/dock_marker/collision,
@@ -2060,10 +2102,11 @@
 /obj/machinery/photocopier/syndie,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
-"bKy" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+"bKq" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
 	},
 /area/ghost_bar)
 "bLl" = (
@@ -2108,10 +2151,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
-"bMH" = (
-/obj/machinery/economy/slot_machine,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "bNg" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "SyndFB_prison_stroll_blast";
@@ -2185,6 +2224,9 @@
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
+"bQD" = (
+/turf/simulated/wall/indestructible/necropolis,
+/area/ruin/space/bubblegum_arena)
 "bQR" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/miscellaneous/goldensiding{
@@ -2307,6 +2349,15 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/bar)
+"bSA" = (
+/obj/machinery/economy/vending/shoedispenser,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "bSN" = (
 /obj/structure/table/glass,
 /obj/item/mmi/syndie,
@@ -2511,6 +2562,10 @@
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/cargo)
+"bWh" = (
+/obj/structure/sign/poster/official/fruit_bowl,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "bWD" = (
 /obj/structure/closet/secure_closet/brig{
 	req_access_txt = "153"
@@ -2574,6 +2629,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
+"bYv" = (
+/obj/structure/closet/wardrobe/xenos,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "bZl" = (
 /obj/item/flag/syndi,
 /obj/machinery/computer/cryopod{
@@ -2587,6 +2646,14 @@
 	water_overlay_image = null
 	},
 /area/centcom/ss220/bar)
+"cas" = (
+/obj/structure/table/reinforced,
+/obj/machinery/kitchen_machine/microwave/upgraded,
+/obj/structure/light_fake/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "cat" = (
 /obj/structure/window/reinforced{
 	color = "red"
@@ -2597,6 +2664,12 @@
 /obj/structure/showcase,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
+"caI" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "caZ" = (
 /obj/machinery/sleeper,
 /turf/simulated/floor/plasteel{
@@ -2644,12 +2717,6 @@
 /obj/item/gun/energy/pulse/pistol/m1911,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
-"cdT" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "cdV" = (
 /obj/structure/table/reinforced,
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang,
@@ -2665,11 +2732,6 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
-"ceb" = (
-/obj/structure/railing/corner,
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "cex" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -2700,6 +2762,12 @@
 	icon_state = "darkbluealtstrip"
 	},
 /area/centcom/ss220/admin1)
+"cgy" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "cgE" = (
 /obj/structure/rack/gunrack,
 /obj/item/gun/energy/gun/nuclear{
@@ -2721,6 +2789,14 @@
 /obj/effect/landmark/spawner/commando_manual,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin3)
+"cgV" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/stairs/right{
+	dir = 1
+	},
+/area/ghost_bar)
 "cgX" = (
 /obj/structure/closet/secure_closet/clown{
 	req_access = null
@@ -2778,6 +2854,10 @@
 "ciP" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/admin2)
+"cjf" = (
+/obj/machinery/prize_counter,
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "cji" = (
 /obj/machinery/door/poddoor{
 	id_tag = "nukeop_ready";
@@ -2804,10 +2884,6 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
-"cjQ" = (
-/obj/effect/mob_spawn/human/corpse/clown/corpse,
-/turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/space/nearstation)
 "cjU" = (
 /obj/machinery/economy/vending/cigarette/free,
 /turf/simulated/floor/wood/fancy/oak,
@@ -2941,12 +3017,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin1)
-"coH" = (
-/obj/structure/chair/stool/bar{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "coJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2954,6 +3024,17 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/carpet/purple,
 /area/centcom/ss220/general)
+"cpn" = (
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
+"cpN" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "cqV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -3003,11 +3084,11 @@
 	icon_state = "darkbluealt"
 	},
 /area/shuttle/administration)
-"csk" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
+"csH" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Badmin's Bar"
 	},
+/turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
 "csQ" = (
 /obj/structure/bed,
@@ -3157,12 +3238,6 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
-"cAZ" = (
-/obj/structure/chair/stool/bar{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "cBB" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/marker_beacon/dock_marker/collision,
@@ -3222,9 +3297,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"cCG" = (
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "cDb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/adv,
@@ -3247,15 +3319,9 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
-"cDK" = (
-/obj/structure/sign/poster/official/fruit_bowl,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "cDO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/obj/structure/light_fake/small,
+/turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
 "cDV" = (
 /obj/structure/light_fake/spot{
@@ -3466,12 +3532,9 @@
 "cKO" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
-"cKR" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
+"cLd" = (
+/obj/structure/sign/bobross,
+/turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
 "cLj" = (
 /obj/machinery/door/airlock/external{
@@ -3491,11 +3554,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate)
-"cLl" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken3"
-	},
-/area/ghost_bar)
 "cLm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -3540,10 +3598,6 @@
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
-"cMe" = (
-/obj/structure/sign/barsign,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "cMK" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -3626,6 +3680,13 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"cOX" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/structure/light_fake/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "cPy" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced{
@@ -3726,19 +3787,10 @@
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"cTB" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "cTG" = (
 /obj/machinery/economy/vending/coffee/free,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/bar)
-"cUj" = (
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "cUk" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -3749,6 +3801,13 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
+"cUP" = (
+/obj/machinery/economy/slot_machine,
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "cUU" = (
 /obj/structure/closet/crate/secure/bin{
 	color = "36373a"
@@ -3863,6 +3922,11 @@
 	name = "sand"
 	},
 /area/syndicate_mothership/outside)
+"cZF" = (
+/obj/structure/railing/corner,
+/obj/structure/light_fake/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "cZG" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/stripes/line{
@@ -3902,13 +3966,6 @@
 	icon_state = "neutral"
 	},
 /area/centcom/ss220/evac)
-"daj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/beer{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "daq" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -4075,14 +4132,6 @@
 	},
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
-"dhV" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/stairs/right{
-	dir = 1
-	},
-/area/ghost_bar)
 "diL" = (
 /obj/structure/flora/junglebush/large{
 	layer = 4.8
@@ -4122,14 +4171,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/bar)
-"dkL" = (
-/obj/machinery/smartfridge/foodcart{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "dli" = (
 /obj/machinery/cryopod/offstation/right,
 /obj/machinery/computer/cryopod{
@@ -4171,6 +4212,14 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/elite_squad)
+"dna" = (
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "dnm" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -4181,11 +4230,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership)
-"dnu" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
-/turf/simulated/floor/plasteel/freezer,
+"dnr" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol,
+/turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
 "dnK" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -4289,6 +4336,12 @@
 	icon_state = "warndarkgreyred"
 	},
 /area/syndicate_mothership/infteam)
+"dqS" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "drf" = (
 /obj/machinery/computer/shuttle/sst,
 /obj/effect/decal/cleanable/dirt,
@@ -4400,6 +4453,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/cargo)
+"dul" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "duJ" = (
 /turf/simulated/floor/beach/away/coastline{
 	dir = 4;
@@ -4532,13 +4590,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
-"dyR" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "dyS" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/indestructible
@@ -4655,10 +4706,6 @@
 /obj/structure/rack/gunrack,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
-"dCl" = (
-/obj/structure/sign/goldenplaque,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "dCq" = (
 /obj/effect/turf_decal/siding/black{
 	dir = 1
@@ -4690,6 +4737,11 @@
 /obj/effect/landmark/spawner/syndie,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership)
+"dCP" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "dDW" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/plating/asteroid/ancient
@@ -4712,12 +4764,6 @@
 /obj/machinery/economy/vending/hydroseeds,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
-"dEt" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless,
-/area/ghost_bar)
 "dEN" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/light_fake/spot{
@@ -4750,11 +4796,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
-"dGy" = (
-/turf/simulated/floor/plasteel/stairs/right{
-	dir = 8
-	},
-/area/ghost_bar)
 "dGG" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Камера";
@@ -4984,6 +5025,12 @@
 	icon_state = "neutral"
 	},
 /area/centcom/ss220/evac)
+"dLq" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "dLK" = (
 /obj/machinery/computer/camera_advanced{
 	dir = 8
@@ -5035,6 +5082,15 @@
 /obj/item/flashlight/seclite,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin3)
+"dNH" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"dOg" = (
+/obj/structure/sign/vacuum/external,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "dOn" = (
 /obj/structure/light_fake/spot{
 	dir = 8
@@ -5151,12 +5207,6 @@
 	water_overlay_image = null
 	},
 /area/syndicate_mothership/outside)
-"dTs" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "dTw" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#6697cc";
@@ -5213,9 +5263,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
-"dYd" = (
-/turf/simulated/floor/plating,
-/area/ghost_bar)
 "dYf" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
@@ -5230,6 +5277,14 @@
 	},
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/jail)
+"dYF" = (
+/obj/structure/light_fake/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "dYJ" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -5343,6 +5398,12 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/beach/away/sand,
 /area/centcom/ss220/evac)
+"edz" = (
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "edF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -5365,22 +5426,18 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
+"eed" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "eeQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcornersalt"
 	},
 /area/syndicate_mothership/cargo)
-"efK" = (
-/obj/item/coin/antagtoken,
-/turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/space/nearstation)
-"efO" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 4
-	},
-/turf/simulated/wall/indestructible/syndicate,
-/area/ghost_bar)
 "efX" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -5390,12 +5447,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/supply)
-"egL" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "egO" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
@@ -5431,10 +5482,6 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
-"eik" = (
-/obj/structure/chair/office/dark,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "eim" = (
 /obj/structure/light_fake/small{
 	dir = 8
@@ -5522,11 +5569,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)
-"emX" = (
-/obj/machinery/door/airlock/multi_tile/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "eng" = (
 /obj/structure/chair/stool/bar/dark{
 	dir = 8
@@ -5715,6 +5757,14 @@
 	},
 /turf/space/transit/horizontal,
 /area/space/centcomm)
+"eta" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "etc" = (
 /obj/structure/mirror{
 	pixel_x = -30
@@ -5758,14 +5808,6 @@
 /obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
-"evk" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_y = -2
-	},
-/obj/structure/curtain/open/shower,
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "evo" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -5777,12 +5819,6 @@
 /obj/item/toy/plushie/marble_fox,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/bar)
-"evV" = (
-/obj/structure/closet/wardrobe/black,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "ewa" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/miscellaneous/goldensiding,
@@ -5801,9 +5837,15 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/carpet/orange,
 /area/centcom/ss220/general)
-"ewU" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/carpet/green,
+"exn" = (
+/obj/structure/sink/directional/west,
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
 /area/ghost_bar)
 "exx" = (
 /obj/structure/table/wood,
@@ -5829,6 +5871,30 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_elite)
+"eyi" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "eyy" = (
 /obj/structure/closet/boxinggloves,
 /obj/structure/light_fake/spot,
@@ -6088,9 +6154,6 @@
 	icon_state = "neutral"
 	},
 /area/centcom/ss220/evac)
-"eFq" = (
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "eFF" = (
 /obj/effect/turf_decal/miscellaneous/goldensiding{
 	dir = 5
@@ -6136,6 +6199,12 @@
 /obj/structure/grille,
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"eHd" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "eHi" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "CC_Armory_Blue";
@@ -6386,14 +6455,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
-"ePh" = (
-/obj/structure/sink{
-	pixel_y = 24
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "ePp" = (
 /obj/structure/table/reinforced{
 	color = "#996633"
@@ -6529,10 +6590,6 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
-"eTT" = (
-/obj/effect/landmark/spawner/bubblegum_arena,
-/turf/simulated/floor/indestructible/necropolis,
-/area/ruin/space/bubblegum_arena)
 "eUn" = (
 /obj/structure/rack/holorack,
 /obj/item/organ/internal/cyberimp/brain/anti_drop,
@@ -6570,12 +6627,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
-"eUO" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "eVk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine/longrange/syndie{
@@ -6610,6 +6661,11 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
+"eWD" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "eWM" = (
 /obj/structure/light_fake/spot,
 /turf/simulated/floor/plasteel{
@@ -6671,9 +6727,6 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/ss220/bar)
-"eYM" = (
-/turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/space/nearstation)
 "eYN" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
@@ -6760,14 +6813,6 @@
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"fbm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/kitchen_machine/microwave/upgraded,
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "fbq" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/beer/upgraded{
@@ -6800,11 +6845,6 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
-"fca" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/centcom,
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "fcL" = (
 /obj/structure/fence/corner{
 	color = "#b0b7c6";
@@ -6910,9 +6950,6 @@
 	icon_state = "darkbluefull"
 	},
 /area/centcom/ss220/admin3)
-"fgL" = (
-/turf/simulated/floor/plasteel/stairs/right,
-/area/ghost_bar)
 "fgP" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/reedbush,
@@ -7062,6 +7099,33 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/elite_squad)
+"fmr" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/carrot,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "fms" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -7143,11 +7207,6 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
-"foh" = (
-/obj/structure/table/reinforced,
-/obj/item/lighter/zippo/contractor,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "foF" = (
 /obj/effect/decal/nanotrasen_logo/n4,
 /turf/simulated/floor/plasteel,
@@ -7198,13 +7257,41 @@
 	icon_state = "blue"
 	},
 /area/shuttle/escape)
+"fqY" = (
+/obj/structure/statue/sandstone/assistant,
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/space/nearstation)
+"fqZ" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "frK" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/administration)
-"frZ" = (
-/obj/machinery/economy/arcade/claw,
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "fsg" = (
 /obj/item/flag/syndi,
 /obj/effect/turf_decal/miscellaneous/goldensiding/corner{
@@ -7334,6 +7421,9 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership/jail)
+"fyL" = (
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "fyY" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/snacks/applepie,
@@ -7526,6 +7616,14 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"fFZ" = (
+/obj/machinery/smartfridge/foodcart{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "fGk" = (
 /obj/effect/decal/nanotrasen_logo/n5,
 /turf/simulated/floor/plasteel,
@@ -7551,6 +7649,10 @@
 	icon_state = "darkyellowalt"
 	},
 /area/syndicate_mothership/cargo)
+"fJv" = (
+/obj/effect/mob_spawn/human/alive/ghost_bar,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "fJB" = (
 /obj/effect/turf_decal/grass{
 	icon_state = "grass_edge_medium_corner";
@@ -7585,10 +7687,6 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/control)
-"fKf" = (
-/obj/structure/closet/wardrobe/grey,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "fLa" = (
 /obj/structure/railing{
 	dir = 8
@@ -7814,6 +7912,10 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
+"fVA" = (
+/obj/effect/mob_spawn/human/corpse/clown/corpse,
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "fVW" = (
 /turf/simulated/floor/beach/away/coastline{
 	water_overlay_image = null
@@ -7868,6 +7970,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
+"fYV" = (
+/turf/simulated/mineral/ancient/outer,
+/area/space/nearstation)
 "fZS" = (
 /obj/effect/decal/warning_stripes/white,
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -7941,6 +8046,10 @@
 "gcV" = (
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/general)
+"gdw" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "geo" = (
 /obj/structure/fence/door{
 	color = "#b0b7c6";
@@ -7959,15 +8068,19 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"gfb" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "gfg" = (
 /obj/structure/displaycase{
 	start_showpiece_type = /obj/item/toy/spinningtoy
 	},
 /turf/simulated/floor/carpet/purple,
 /area/wizard_station)
-"gfm" = (
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "gfN" = (
 /obj/effect/bump_teleporter{
 	id = "Synd13";
@@ -7979,11 +8092,6 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
-"gfZ" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "ggq" = (
 /obj/effect/turf_decal/miscellaneous/goldensiding{
 	dir = 6
@@ -8183,10 +8291,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
-"goi" = (
-/obj/effect/mob_spawn/human/alive/ghost_bar,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "goZ" = (
 /obj/machinery/flasher{
 	id = "syndie_FB_cells";
@@ -8225,6 +8329,11 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/admin1)
+"gpw" = (
+/turf/simulated/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ghost_bar)
 "gqe" = (
 /obj/structure/chair/sofa{
 	color = "#63009c"
@@ -8350,6 +8459,9 @@
 	icon_state = "whitebluefull"
 	},
 /area/centcom/ss220/general)
+"gvF" = (
+/turf/simulated/wall/indestructible/syndicate,
+/area/ghost_bar)
 "gvI" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -8422,13 +8534,6 @@
 	},
 /turf/simulated/floor/carpet/cyan,
 /area/centcom/ss220/general)
-"gxG" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "gxS" = (
 /obj/structure/fence/corner{
 	color = "#b0b7c6";
@@ -8462,6 +8567,12 @@
 /obj/effect/turf_decal/miscellaneous/goldensiding,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
+"gyu" = (
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "gyx" = (
 /obj/item/reagent_containers/food/snacks/grown/cannabis/rainbow,
 /obj/item/reagent_containers/food/snacks/grown/cannabis/rainbow,
@@ -8628,6 +8739,28 @@
 /obj/structure/light_fake/small,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/infteam)
+"gDl" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/obj/item/reagent_containers/food/snacks/grown/cherries,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "gDq" = (
 /obj/machinery/light/spot,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -8640,11 +8773,8 @@
 "gDW" = (
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
-"gDY" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 32
-	},
-/turf/simulated/wall/indestructible/riveted,
+"gEh" = (
+/turf/simulated/floor/plasteel/dark,
 /area/ghost_bar)
 "gEl" = (
 /obj/machinery/light/small/directional/east,
@@ -8732,6 +8862,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
+"gIe" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "gIY" = (
 /obj/structure/light_fake/small{
 	dir = 4
@@ -8758,12 +8892,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
-"gJw" = (
-/obj/machinery/economy/vending/autodrobe,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "gJB" = (
 /obj/machinery/economy/vending/cola/free,
 /turf/simulated/floor/plasteel{
@@ -8836,12 +8964,6 @@
 "gKF" = (
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership/elite_squad)
-"gMc" = (
-/obj/machinery/economy/vending/tool/free,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "gMt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -9006,12 +9128,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
-"gVg" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "gVh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/ore_box,
@@ -9210,12 +9326,6 @@
 	dir = 6
 	},
 /area/shuttle/syndicate)
-"hdj" = (
-/obj/structure/stone_tile/surrounding/burnt,
-/obj/structure/stone_tile/center/burnt,
-/obj/effect/landmark/spawner/bubblegum,
-/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/space/bubblegum_arena)
 "hdo" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo17"
@@ -9269,13 +9379,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/transport)
-"heL" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "heV" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'FOURTH WALL'.";
@@ -9320,13 +9423,6 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
-"hha" = (
-/obj/machinery/door/window{
-	dir = 8;
-	opacity = 1
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "hhA" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -9339,13 +9435,6 @@
 "hhK" = (
 /turf/simulated/wall/indestructible/fakedoor,
 /area/ninja/holding)
-"hhQ" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "hii" = (
 /obj/structure/window/reinforced{
 	color = "red";
@@ -9356,6 +9445,10 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"hiL" = (
+/obj/structure/railing/corner,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "hiV" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/simulated/floor/plasteel{
@@ -9462,12 +9555,6 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
-"hnb" = (
-/obj/machinery/computer/arcade/recruiter{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "hns" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
@@ -9488,6 +9575,10 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
+"hnL" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "hnM" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/specops)
@@ -9661,6 +9752,9 @@
 	},
 /turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
+"hsR" = (
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "htr" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
@@ -9695,21 +9789,6 @@
 /obj/effect/mapping_helpers/light,
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
-"hva" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Toilet";
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "hvm" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/portable/canister/oxygen,
@@ -9728,12 +9807,6 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass/no_creep,
 /area/trader_station/sol)
-"hwh" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "hwj" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -9795,6 +9868,10 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/trader_station/sol)
+"hym" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "hzk" = (
 /obj/structure/window/reinforced,
 /obj/item/kirbyplants,
@@ -9862,11 +9939,6 @@
 	icon_state = "warndarkgreyred"
 	},
 /area/syndicate_mothership)
-"hDQ" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/ghost_bar)
 "hDW" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/effect/mapping_helpers/light,
@@ -9967,6 +10039,11 @@
 	name = "Comemmorative Plaque"
 	},
 /area/centcom/ss220/park)
+"hFT" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "hFV" = (
 /obj/structure/rack/holorack,
 /obj/effect/turf_decal/box/white,
@@ -10044,10 +10121,6 @@
 	icon_state = "darkredalt"
 	},
 /area/syndicate_mothership/control)
-"hIJ" = (
-/obj/structure/railing,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "hIM" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -10135,6 +10208,11 @@
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/infteam)
+"hKm" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "hLd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fans/tiny/invisible,
@@ -10165,30 +10243,6 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
-"hMl" = (
-/obj/structure/closet/secure_closet/freezer/meat/open,
-/obj/item/reagent_containers/food/snacks/raw_bacon,
-/obj/item/reagent_containers/food/snacks/raw_bacon,
-/obj/item/reagent_containers/food/snacks/raw_bacon,
-/obj/item/reagent_containers/food/snacks/raw_bacon,
-/obj/item/reagent_containers/food/snacks/sausage,
-/obj/item/reagent_containers/food/snacks/sausage,
-/obj/item/reagent_containers/food/snacks/rawcutlet,
-/obj/item/reagent_containers/food/snacks/rawcutlet,
-/obj/item/reagent_containers/food/snacks/rawcutlet,
-/obj/item/reagent_containers/food/snacks/catfishmeat,
-/obj/item/reagent_containers/food/snacks/catfishmeat,
-/obj/item/reagent_containers/food/snacks/catfishmeat,
-/obj/item/reagent_containers/food/snacks/catfishmeat,
-/obj/item/reagent_containers/food/snacks/rawcutlet,
-/obj/item/reagent_containers/food/snacks/rawcutlet,
-/obj/item/reagent_containers/food/snacks/rawcutlet,
-/obj/item/reagent_containers/food/snacks/spaghetti,
-/obj/item/reagent_containers/food/snacks/spaghetti,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "hMm" = (
 /obj/structure/barricade{
 	icon = 'icons/turf/shuttle.dmi';
@@ -10202,6 +10256,12 @@
 	},
 /turf/simulated/floor/indestructible/transparent_floor,
 /area/shuttle/syndicate_sit)
+"hMr" = (
+/obj/item/clothing/head/cone,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "hMQ" = (
 /obj/structure/light_fake/small,
 /obj/structure/curtain/black{
@@ -10333,14 +10393,6 @@
 /obj/item/kitchen/knife/combat,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
-"hPV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "hQe" = (
 /obj/structure/chair/sofa/bench/right{
 	cover_color = "#404144";
@@ -10399,12 +10451,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
-"hVa" = (
-/obj/machinery/computer/arcade/battle{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "hVc" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo18"
@@ -10467,19 +10513,6 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
-"hWK" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "hXd" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "nukeop_outside";
@@ -10662,10 +10695,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
-"igP" = (
-/obj/structure/lattice,
-/turf/space,
-/area/space/nearstation)
 "iht" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/wood/oak,
@@ -10684,12 +10713,6 @@
 	icon_state = "darkyellowcornersalt"
 	},
 /area/syndicate_mothership/cargo)
-"iip" = (
-/obj/structure/chair/stool{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "iiw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/oak,
@@ -10763,6 +10786,11 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
+"ikq" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "ikt" = (
 /turf/simulated/wall/indestructible/syndicate{
 	smoothing_flags = 2
@@ -10811,6 +10839,11 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
+"imT" = (
+/turf/simulated/floor/plasteel/stairs/medium{
+	dir = 1
+	},
+/area/ghost_bar)
 "ink" = (
 /obj/effect/decal/warning_stripes/white,
 /obj/machinery/door/poddoor/impassable{
@@ -11017,11 +11050,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"isq" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/external_no_weld,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "isB" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/medal/gold{
@@ -11284,10 +11312,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/syndicate_mothership/infteam)
-"iAD" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "iAT" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -11486,6 +11510,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
+"iLq" = (
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "iLT" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
@@ -11590,6 +11620,21 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/syndicate)
+"iSJ" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Toilet";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "iSW" = (
 /obj/structure/table{
 	color = "#996633"
@@ -11924,10 +11969,6 @@
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
-"jgL" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "jhd" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -11956,16 +11997,13 @@
 "jiu" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/admin3)
-"jjL" = (
-/obj/structure/chair/sofa/corp/left,
+"jjt" = (
+/obj/effect/landmark/damageturf,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
-"jjW" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor/wood,
+"jjU" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/mineral/plastitanium/red,
 /area/ghost_bar)
 "jjX" = (
 /obj/machinery/recharge_station/upgraded,
@@ -12002,6 +12040,11 @@
 	icon_state = "grimy"
 	},
 /area/syndicate_mothership)
+"jmo" = (
+/obj/structure/bookcase/random,
+/obj/structure/light_fake/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "jms" = (
 /obj/structure/light_fake/spot,
 /turf/simulated/floor/plasteel/dark{
@@ -12015,6 +12058,12 @@
 	},
 /turf/simulated/floor/beach/away/sand,
 /area/syndicate_mothership/outside)
+"jnj" = (
+/obj/machinery/kitchen_machine/oven/upgraded,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "jnv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -12050,6 +12099,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_elite)
+"jon" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ghost_bar)
 "joz" = (
 /obj/structure/bookcase/manuals,
 /obj/item/book/manual/random,
@@ -12075,15 +12128,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
-"jpA" = (
-/obj/structure/mopbucket,
-/obj/item/soap/syndie,
-/obj/item/mop,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "jpY" = (
 /obj/structure/light_fake/small{
 	dir = 1
@@ -12555,6 +12599,11 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass/no_creep,
 /area/trader_station/sol)
+"jKx" = (
+/obj/structure/lattice,
+/obj/structure/light_fake/small,
+/turf/space,
+/area/space/nearstation)
 "jKB" = (
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
@@ -12602,6 +12651,11 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
+"jLh" = (
+/obj/structure/table/reinforced,
+/obj/item/ashtray/glass,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "jLy" = (
 /obj/item/flag/nt,
 /turf/simulated/floor/plasteel{
@@ -12659,6 +12713,9 @@
 "jMU" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate_elite)
+"jMW" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "jNh" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -12752,24 +12809,14 @@
 	icon_state = "hydrofloor"
 	},
 /area/centcom/ss220/evac)
-"jTa" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "jTq" = (
 /obj/machinery/mech_bay_recharge_port/upgraded{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/admin2)
-"jTG" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
+"jUj" = (
+/obj/structure/chair/office/dark,
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "jUW" = (
@@ -12929,6 +12976,11 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
+"kcR" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter/zippo/contractor,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "kdg" = (
 /obj/structure/table/abductor,
 /obj/effect/spawner/lootdrop/CCfood/desert,
@@ -12997,6 +13049,11 @@
 /obj/structure/chair/comfy/shuttle/dark,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
+"kfL" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/deck/cards/black,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "khe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13015,6 +13072,12 @@
 	icon_state = "cmo"
 	},
 /area/shuttle/escape)
+"khC" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "kin" = (
 /obj/structure/rack,
 /obj/item/camera,
@@ -13218,10 +13281,6 @@
 	name = "floor"
 	},
 /area/syndicate_mothership)
-"koB" = (
-/obj/machinery/recharge_station,
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "kpq" = (
 /obj/structure/dresser,
 /turf/simulated/floor/carpet/green,
@@ -13287,6 +13346,10 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
+"ksx" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "kth" = (
 /obj/machinery/bodyscanner{
 	dir = 2
@@ -13430,10 +13493,6 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/general)
-"kzD" = (
-/obj/structure/sign/nosmoking_2,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "kAL" = (
 /obj/item/flashlight/lantern{
 	anchored = 1;
@@ -13457,17 +13516,6 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
-"kBT" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
-"kBV" = (
-/obj/machinery/computer/camera_advanced{
-	dir = 4
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "kBX" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
@@ -13560,6 +13608,12 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
+"kEI" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "kEZ" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -13611,9 +13665,8 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
-"kFL" = (
-/obj/structure/sign/poster/official/space_cops,
-/turf/simulated/wall/indestructible/riveted,
+"kGm" = (
+/turf/simulated/wall/indestructible/fakeglass,
 /area/ghost_bar)
 "kGA" = (
 /obj/machinery/cryopod/offstation/right,
@@ -13719,45 +13772,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
-"kJd" = (
-/obj/machinery/economy/vending/shoedispenser,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "kJs" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"kJv" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/kitchen/knife,
-/obj/item/reagent_containers/food/condiment/enzyme{
-	pixel_y = 5
-	},
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "kJF" = (
 /obj/machinery/optable,
 /obj/machinery/light/directional/west,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/syndicate)
+"kKi" = (
+/turf/simulated/floor/indestructible/necropolis,
+/area/ruin/space/bubblegum_arena)
 "kKp" = (
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
@@ -13888,6 +13914,10 @@
 	icon_state = "darkbluecorners"
 	},
 /area/centcom/ss220/bar)
+"kSy" = (
+/obj/effect/landmark/spawner/bubblegum_arena,
+/turf/simulated/floor/indestructible/necropolis,
+/area/ruin/space/bubblegum_arena)
 "kSJ" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "SyndFB_prison_stroll_blast";
@@ -13905,6 +13935,12 @@
 /obj/structure/light_fake,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/trader_station/sol)
+"kTj" = (
+/obj/structure/railing,
+/turf/simulated/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ghost_bar)
 "kTp" = (
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
@@ -13976,12 +14012,21 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
+"kYo" = (
+/turf/simulated/wall/indestructible,
+/area/ghost_bar)
 "kZg" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
 /area/centcom/ss220/bar)
+"kZR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "lae" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo16"
@@ -14005,6 +14050,16 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
+"lbv" = (
+/obj/structure/railing/cap{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"lbE" = (
+/obj/structure/musician/piano,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "lbU" = (
 /obj/structure/punching_bag,
 /turf/simulated/floor/wood/oak,
@@ -14078,10 +14133,6 @@
 /obj/structure/chair/comfy/purp,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
-"leU" = (
-/obj/structure/marker_beacon/dock_marker,
-/turf/space,
-/area/space/centcomm)
 "leW" = (
 /obj/machinery/economy/vending/magivend,
 /turf/simulated/floor/carpet/black,
@@ -14117,6 +14168,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
+"lgW" = (
+/obj/machinery/economy/vending/suitdispenser,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "lhx" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -14160,9 +14217,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/syndicate_mothership/control)
-"lji" = (
-/turf/simulated/wall/indestructible,
-/area/ghost_bar)
 "ljl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -14190,6 +14244,12 @@
 /obj/effect/landmark/spawner/nuclear_bomb/death_squad,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin3)
+"lka" = (
+/obj/structure/signpost,
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/space/nearstation)
 "lkx" = (
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
@@ -14198,6 +14258,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
+"lkI" = (
+/obj/structure/mopbucket,
+/obj/item/soap/syndie,
+/obj/item/mop,
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "lkU" = (
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/control)
@@ -14209,9 +14278,6 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
-"lmq" = (
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "lmy" = (
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/green,
@@ -14290,6 +14356,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
+"lqM" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "lra" = (
 /obj/structure/rack/gunrack,
 /obj/item/gun/projectile/automatic/sniper_rifle{
@@ -14319,6 +14391,10 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/elite_squad)
+"lrj" = (
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "lry" = (
 /obj/machinery/door/airlock/hatch/syndicate/command{
 	name = "Тюрьма"
@@ -14333,12 +14409,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/administration)
-"lrQ" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "lrX" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -14496,13 +14566,6 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership)
-"luQ" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "luW" = (
 /obj/structure/chair/comfy/purp{
 	dir = 1;
@@ -14677,6 +14740,15 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
+"lze" = (
+/obj/machinery/washing_machine,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "lzj" = (
 /obj/machinery/computer/shuttle/sit{
 	dir = 1
@@ -14835,13 +14907,6 @@
 /obj/structure/table/wood/fancy/orange,
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
-"lGh" = (
-/obj/machinery/economy/vending/cigarette,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "lGl" = (
 /obj/structure/bookcase/manuals,
 /obj/item/book/manual/wiki/sop_service,
@@ -15017,16 +15082,6 @@
 "lJY" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"lKi" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "lKj" = (
 /obj/structure/table,
 /obj/item/storage/firstaid,
@@ -15129,13 +15184,6 @@
 	icon_state = "darkyellowalt"
 	},
 /area/centcom/ss220/supply)
-"lMI" = (
-/obj/effect/decal/warning_stripes/northeastcorner,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "lMN" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo19"
@@ -15181,10 +15229,6 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
-"lNp" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "lNA" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15206,13 +15250,6 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
-"lNS" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "lOi" = (
 /obj/structure/rack/holorack,
 /obj/effect/turf_decal/box/white,
@@ -15239,6 +15276,9 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"lOn" = (
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "lOq" = (
 /obj/structure/curtain/black{
 	pixel_y = 32;
@@ -15316,12 +15356,6 @@
 	icon_state = "cafeteria"
 	},
 /area/ninja/holding)
-"lRa" = (
-/obj/structure/signpost,
-/turf/simulated/floor/plating/airless{
-	icon_state = "asteroidplating"
-	},
-/area/space/nearstation)
 "lRi" = (
 /obj/structure/light_fake,
 /obj/machinery/optable,
@@ -15348,6 +15382,11 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
+"lRI" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/external_no_weld,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "lRO" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 10;
@@ -15588,6 +15627,10 @@
 /obj/structure/bedsheetbin,
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
+"maG" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "maY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/light_fake/small,
@@ -15751,11 +15794,6 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"mjk" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/storage/box/matches,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "mjx" = (
 /obj/structure/table/glass,
 /obj/item/pizzabox/pizza_bomb/autoarm{
@@ -15908,6 +15946,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/centcom/ss220/bar)
+"mnG" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/turf/simulated/wall/indestructible/syndicate,
+/area/ghost_bar)
 "mnU" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo3"
@@ -16003,10 +16047,6 @@
 /obj/effect/decal/syndie_logo,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
-"mrG" = (
-/obj/structure/coatrack,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "mrL" = (
 /obj/structure/statue/sandstone/assistant{
 	anchored = 1;
@@ -16055,6 +16095,14 @@
 	icon_state = "darkredalt"
 	},
 /area/syndicate_mothership/control)
+"mtU" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "muB" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood/oak,
@@ -16207,6 +16255,11 @@
 	icon_state = "grimy"
 	},
 /area/centcom/ss220/admin1)
+"mBu" = (
+/obj/structure/marker_beacon/dock_marker,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "mBD" = (
 /obj/machinery/door/airlock/hatch/syndicate/command{
 	name = "Тюрьма";
@@ -16290,6 +16343,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"mHj" = (
+/obj/structure/sign/goldenplaque,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "mHs" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -16420,11 +16477,9 @@
 /obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"mNm" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
+"mNv" = (
+/obj/structure/sign/nosmoking_2,
+/turf/simulated/wall/indestructible/riveted,
 /area/ghost_bar)
 "mND" = (
 /obj/machinery/mech_bay_recharge_port,
@@ -16470,12 +16525,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin1)
-"mPY" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	name = "Badmin's Bar"
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "mQn" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -16506,9 +16555,6 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/centcom/ss220/supply)
-"mRh" = (
-/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/space/bubblegum_arena)
 "mRk" = (
 /obj/machinery/door/poddoor/multi_tile/four_tile_hor{
 	id_tag = "nukeop_ready"
@@ -16554,28 +16600,6 @@
 	icon_state = "grimy"
 	},
 /area/trader_station/sol)
-"mTy" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/potato,
-/obj/item/reagent_containers/food/snacks/grown/whitebeet,
-/obj/item/reagent_containers/food/snacks/grown/whitebeet,
-/obj/item/reagent_containers/food/snacks/grown/tomato,
-/obj/item/reagent_containers/food/snacks/grown/tomato,
-/obj/item/reagent_containers/food/snacks/grown/rice,
-/obj/item/reagent_containers/food/snacks/grown/rice,
-/obj/item/reagent_containers/food/snacks/grown/icepepper,
-/obj/item/reagent_containers/food/snacks/grown/icepepper,
-/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
-/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/obj/item/reagent_containers/food/snacks/grown/cherries,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "mTB" = (
 /turf/simulated/floor/beach/away/water{
 	water_overlay_image = null
@@ -16587,6 +16611,10 @@
 	icon_state = "darkbluecornersalt"
 	},
 /area/centcom/ss220/admin3)
+"mTY" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "mTZ" = (
 /obj/structure/window/full/basic,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -16614,6 +16642,9 @@
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
+"mWE" = (
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ghost_bar)
 "mXk" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
@@ -16691,24 +16722,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin1)
-"mZU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/ghost_bar)
 "nar" = (
 /obj/machinery/cryopod/offstation{
 	dir = 2
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"nau" = (
-/obj/machinery/prize_counter,
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "naF" = (
 /obj/structure/table/wood,
 /obj/item/candle,
@@ -16906,6 +16925,12 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership/jail)
+"nhC" = (
+/obj/machinery/computer/arcade/battle{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "niG" = (
 /obj/structure/table,
 /obj/item/ashtray/glass,
@@ -16917,15 +16942,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/syndicate_mothership/infteam)
-"niL" = (
-/obj/machinery/washing_machine,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "niY" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/stripes/line,
@@ -16934,6 +16950,10 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
+"njf" = (
+/obj/structure/stone_tile/slab/burnt,
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "njR" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/marker_beacon/dock_marker/collision,
@@ -17009,6 +17029,18 @@
 	icon_state = "darkbluecorners"
 	},
 /area/centcom/ss220/bar)
+"nmd" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Toilet";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "nmC" = (
 /obj/machinery/economy/vending/nta,
 /turf/simulated/floor/plasteel/dark{
@@ -17084,11 +17116,6 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
-"npr" = (
-/obj/structure/lattice,
-/obj/machinery/light/small,
-/turf/space,
-/area/space/nearstation)
 "npy" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo15"
@@ -17126,6 +17153,10 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
+"nqk" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "nrf" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo12"
@@ -17237,14 +17268,6 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
-"nuU" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "nuW" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -17267,6 +17290,14 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
+"nvT" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/structure/light_fake{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "nwi" = (
 /turf/simulated/floor/plating{
 	icon = 'icons/turf/floors.dmi';
@@ -17275,6 +17306,19 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership)
+"nwu" = (
+/obj/structure/table/wood,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "nwV" = (
 /obj/structure/light_fake/small{
 	dir = 4
@@ -17365,12 +17409,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
-"nBr" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "nBx" = (
 /obj/structure/table/reinforced,
 /obj/item/borg/upgrade/selfrepair,
@@ -17404,12 +17442,6 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
-"nCJ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/stairs/left,
-/area/ghost_bar)
 "nCM" = (
 /obj/structure/light_fake{
 	dir = 1
@@ -17614,12 +17646,6 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
-"nJx" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "nKl" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/admin1)
@@ -17647,10 +17673,6 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
-"nLP" = (
-/obj/structure/sign/poster/official/random,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "nMa" = (
 /turf/simulated/floor/beach/away/coastline{
 	water_overlay_image = null
@@ -17687,6 +17709,9 @@
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
+"nNr" = (
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "nNB" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -17698,6 +17723,12 @@
 	icon_state = "darkredfull"
 	},
 /area/centcom/ss220/admin2)
+"nNP" = (
+/obj/structure/light_fake/small,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "nNU" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/syndicate{
@@ -17710,6 +17741,12 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/evac)
+"nOu" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "nOJ" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -17763,6 +17800,12 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
+"nRD" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "nRE" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -17861,9 +17904,6 @@
 "nUM" = (
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)
-"nVt" = (
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/ghost_bar)
 "nVW" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
@@ -17911,12 +17951,6 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
-"nXK" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "nZe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/beer/upgraded{
@@ -17967,6 +18001,12 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
+"oaf" = (
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ghost_bar)
 "oah" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17982,43 +18022,6 @@
 	water_overlay_image = null
 	},
 /area/syndicate_mothership/outside)
-"oaE" = (
-/obj/structure/rack,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/tank/internals/plasmaman/belt/full,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "obm" = (
 /obj/structure/chair/comfy/red{
 	dir = 8
@@ -18030,15 +18033,6 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
-"obL" = (
-/turf/simulated/wall/indestructible/fakeglass,
-/area/ghost_bar)
-"occ" = (
-/obj/machinery/economy/merch{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "ocR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18108,13 +18102,9 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
-"ohx" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
+"ohd" = (
+/obj/structure/bookcase/random,
+/turf/simulated/floor/carpet/green,
 /area/ghost_bar)
 "ohV" = (
 /obj/machinery/computer/shuttle/sst,
@@ -18172,6 +18162,12 @@
 	name = "Comemmorative Plaque"
 	},
 /area/centcom/ss220/park)
+"okL" = (
+/obj/machinery/economy/vending/clothing,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "okW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -18299,18 +18295,18 @@
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
-"opP" = (
-/obj/machinery/economy/vending/clothing,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "oqn" = (
 /obj/machinery/door/airlock{
 	name = "Кошерная спальна"
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/general)
+"oqx" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "oqA" = (
 /obj/machinery/computer/cryopod{
 	pixel_x = 32;
@@ -18324,11 +18320,6 @@
 "orn" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
-"orw" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "orK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -18378,12 +18369,6 @@
 	icon_state = "darkbluealt"
 	},
 /area/centcom/ss220/admin1)
-"otz" = (
-/obj/structure/table,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "otG" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/blood,
@@ -18408,11 +18393,6 @@
 "ouy" = (
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/wizard_station)
-"ouK" = (
-/obj/item/flashlight/lamp,
-/obj/structure/table/wood,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "ouY" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -18678,12 +18658,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
-"oEA" = (
-/obj/machinery/computer/arcade/orion_trail{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "oEC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery/red,
@@ -18779,6 +18753,12 @@
 	icon_state = "darkredalt"
 	},
 /area/syndicate_mothership/cargo)
+"oGP" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "oGQ" = (
 /obj/structure/table,
 /obj/structure/closet/walllocker/medlocker/south,
@@ -18794,6 +18774,11 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
+"oHR" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "oHW" = (
 /obj/effect/turf_decal/box/red,
 /obj/machinery/door/window/brigdoor{
@@ -18828,6 +18813,11 @@
 	icon_state = "darkyellowalt"
 	},
 /area/centcom/ss220/supply)
+"oJA" = (
+/obj/structure/table/wood,
+/obj/item/deck/unum,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "oJG" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Библиотекарь"
@@ -18869,6 +18859,10 @@
 	icon_state = "barber"
 	},
 /area/shuttle/administration)
+"oKn" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "oKw" = (
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 4
@@ -18998,33 +18992,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/evac)
-"oSa" = (
-/obj/structure/closet/secure_closet/freezer/kitchen{
-	req_access = null
-	},
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/vanillapod,
-/obj/item/reagent_containers/food/snacks/grown/vanillapod,
-/obj/item/reagent_containers/food/snacks/grown/sugarcane,
-/obj/item/reagent_containers/food/snacks/grown/sugarcane,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/oat,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
-/obj/item/reagent_containers/food/snacks/grown/corn,
-/obj/item/reagent_containers/food/snacks/grown/corn,
-/obj/item/reagent_containers/food/snacks/grown/chili,
-/obj/item/reagent_containers/food/snacks/grown/chili,
-/obj/item/reagent_containers/food/snacks/grown/carrot,
-/obj/item/reagent_containers/food/snacks/grown/apple,
-/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "oSk" = (
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
@@ -19234,12 +19201,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/elite_squad)
-"oZv" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/ghost_bar)
 "oZO" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
@@ -19402,15 +19363,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
-"peN" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "pfz" = (
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/evac)
@@ -19461,6 +19413,12 @@
 	icon_state = "darkbluealt"
 	},
 /area/centcom/ss220/admin2)
+"phD" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "phM" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/wood/fancy/oak,
@@ -19486,21 +19444,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
-"pkG" = (
-/obj/structure/window/reinforced/tinted,
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Toilet";
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "plv" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/spawner/syndie,
@@ -19637,13 +19580,6 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
-"psK" = (
-/obj/machinery/economy/slot_machine,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "psX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -19735,10 +19671,6 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
-"pvO" = (
-/obj/structure/ghost_bar_cryopod,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "pwb" = (
 /obj/structure/bed{
 	dir = 4
@@ -19792,6 +19724,10 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
+"pxm" = (
+/obj/item/coin/antagtoken,
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "pxu" = (
 /obj/effect/turf_decal/siding/black{
 	dir = 8
@@ -19826,15 +19762,6 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"pyb" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/obj/item/deck/tarot,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "pyl" = (
 /obj/structure/closet/crate/secure/bin{
 	color = "36373a"
@@ -19942,6 +19869,10 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
+"pED" = (
+/obj/machinery/economy/arcade/claw,
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "pEW" = (
 /obj/machinery/suit_storage_unit/syndicate,
 /turf/simulated/floor/plasteel{
@@ -19999,12 +19930,6 @@
 /obj/machinery/economy/vending/cigarette/free,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
-"pHW" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "pIL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Брифинг";
@@ -20085,11 +20010,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
-"pKj" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/clothing/mask/cigarette/cigar,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "pKm" = (
 /obj/item/kirbyplants,
 /obj/structure/curtain/black{
@@ -20102,12 +20022,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/elite_squad)
-"pLl" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "pLm" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -20128,6 +20042,10 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership/jail)
+"pLx" = (
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "pMa" = (
 /obj/machinery/computer/shuttle/syndicate/drop_pod,
 /turf/simulated/wall/mineral/plastitanium,
@@ -20290,10 +20208,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/evac)
-"pPq" = (
-/obj/structure/musician/piano,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "pPs" = (
 /obj/machinery/computer/camera_advanced{
 	dir = 1
@@ -20404,6 +20318,9 @@
 "pUk" = (
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership)
+"pUt" = (
+/turf/simulated/floor/plasteel/stairs/right,
+/area/ghost_bar)
 "pUQ" = (
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership)
@@ -20420,6 +20337,13 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
+"pWy" = (
+/obj/structure/table,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "pWD" = (
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
@@ -20434,13 +20358,6 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership/infteam)
-"pWQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/soda{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "pXL" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/medbeam,
@@ -20742,10 +20659,6 @@
 	icon_state = "darkyellowalt"
 	},
 /area/syndicate_mothership/cargo)
-"qgH" = (
-/obj/structure/railing/corner,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "qgL" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -20765,16 +20678,6 @@
 	icon_state = "warndarkgreycornerred"
 	},
 /area/syndicate_mothership)
-"qkF" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
-"qkG" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "qla" = (
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
@@ -20812,9 +20715,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
-"qlB" = (
-/turf/simulated/wall/indestructible/necropolis,
-/area/ruin/space/bubblegum_arena)
+"qlA" = (
+/obj/effect/decal/warning_stripes/white/partial,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "qmm" = (
 /obj/machinery/economy/vending/snack/free{
 	name = "\improper Wizmore Chocolate Corp"
@@ -20831,10 +20737,6 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership/jail)
-"qni" = (
-/obj/structure/stone_tile/slab/cracked,
-/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/space/bubblegum_arena)
 "qnl" = (
 /obj/structure/mirror{
 	pixel_x = 30
@@ -20964,11 +20866,6 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
-"qsr" = (
-/obj/structure/table/wood,
-/obj/item/deck/unum,
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "qsF" = (
 /obj/structure/curtain/black{
 	pixel_y = 32;
@@ -20986,11 +20883,7 @@
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
 "que" = (
-/obj/structure/table,
-/obj/item/storage/fancy/crayons,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/wood,
 /area/ghost_bar)
 "quh" = (
 /obj/machinery/door/poddoor/impassable{
@@ -21008,12 +20901,6 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
-"quV" = (
-/obj/structure/chair/stool{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "qvc" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
@@ -21222,6 +21109,13 @@
 	dir = 4
 	},
 /area/shuttle/syndicate)
+"qDf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "qDx" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/miscellaneous/goldensiding{
@@ -21431,11 +21325,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/admin1)
-"qLv" = (
-/obj/structure/table/wood,
-/obj/item/ashtray/bronze,
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "qLF" = (
 /obj/machinery/economy/vending/coffee/free,
 /turf/simulated/floor/plasteel/dark,
@@ -21443,11 +21332,6 @@
 "qLO" = (
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
-"qLY" = (
-/turf/simulated/floor/plasteel/stairs/left{
-	dir = 8
-	},
-/area/ghost_bar)
 "qNg" = (
 /obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/cobweb,
@@ -21511,10 +21395,6 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
-"qOS" = (
-/obj/structure/bookcase/random,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "qPk" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership;
@@ -21565,6 +21445,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
+"qQx" = (
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "qQI" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/grass/no_creep,
@@ -21587,12 +21472,6 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
-"qRW" = (
-/obj/structure/statue/sandstone/assistant,
-/turf/simulated/floor/plating/airless{
-	icon_state = "asteroidplating"
-	},
-/area/space/nearstation)
 "qSC" = (
 /obj/structure/table/glass,
 /obj/item/clipboard{
@@ -21743,12 +21622,6 @@
 	},
 /turf/simulated/floor/mineral/abductor,
 /area/centcom/ss220/bar)
-"qXL" = (
-/obj/effect/decal/warning_stripes/white/partial,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "qYl" = (
 /obj/machinery/conveyor/east{
 	id = "QMLoad"
@@ -21859,6 +21732,10 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
+"rdl" = (
+/obj/structure/bookcase/random,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "rdx" = (
 /obj/structure/ninjatele{
 	pixel_y = 25
@@ -21920,11 +21797,6 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
-"rfR" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "rgd" = (
 /obj/structure/table/abductor,
 /obj/effect/spawner/lootdrop/CCfood/desert,
@@ -21974,11 +21846,6 @@
 /obj/mecha/working/ripley/firefighter,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"rhf" = (
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/ghost_bar)
 "rhB" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "ferry_away";
@@ -22003,6 +21870,11 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"riZ" = (
+/turf/simulated/floor/plasteel/stairs/right{
+	dir = 8
+	},
+/area/ghost_bar)
 "rjq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/watermelonslice,
@@ -22108,6 +21980,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"roI" = (
+/obj/machinery/computer/arcade/recruiter{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "rpv" = (
 /obj/docking_port/stationary/transit{
 	dir = 8;
@@ -22127,6 +22005,10 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
+"rqm" = (
+/obj/structure/sign/poster/official/random,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "rqt" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -22397,12 +22279,6 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
-"rtU" = (
-/turf/simulated/floor/wood{
-	broken = 1;
-	icon_state = "wood-broken"
-	},
-/area/ghost_bar)
 "rus" = (
 /obj/structure/light_fake/spot{
 	dir = 4
@@ -22599,10 +22475,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
-"rDd" = (
-/obj/machinery/door/airlock/external_no_weld,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "rDf" = (
 /obj/machinery/economy/vending/chinese/free,
 /turf/simulated/floor/plasteel/dark,
@@ -22617,6 +22489,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
+"rDJ" = (
+/obj/structure/ghost_bar_cryopod,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
+"rDM" = (
+/turf/simulated/floor/plating,
+/area/ghost_bar)
 "rDS" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/light_fake/spot{
@@ -22624,9 +22503,6 @@
 	},
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
-"rDY" = (
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "rEF" = (
 /obj/machinery/economy/vending/security,
 /turf/simulated/floor/plasteel{
@@ -22679,6 +22555,18 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"rHL" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
+"rHU" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "rIi" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -22687,11 +22575,6 @@
 /obj/item/flag/nt,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/evac)
-"rIB" = (
-/turf/simulated/floor/plating/airless{
-	icon_state = "asteroidplating"
-	},
-/area/space/nearstation)
 "rIO" = (
 /obj/structure/chair/sofa/bench/right{
 	cover_color = "#68452a";
@@ -22770,10 +22653,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/trader_station/sol)
-"rLG" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/carpet/arcade,
-/area/ghost_bar)
 "rLQ" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -22912,6 +22791,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/bar)
+"rRR" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "rRY" = (
 /obj/structure/light_fake{
 	dir = 8
@@ -23029,12 +22914,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/evac)
-"rUm" = (
-/obj/machinery/economy/vending/suitdispenser,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "rUo" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -23070,6 +22949,12 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
+"rVf" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "rVg" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/shaker{
@@ -23208,6 +23093,13 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
+"sag" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/light_fake{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "saI" = (
 /obj/effect/turf_decal/siding/black{
 	dir = 1
@@ -23357,10 +23249,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
-"seS" = (
-/obj/machinery/economy/vending/boozeomat,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "sfM" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -23582,6 +23470,12 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
+"sps" = (
+/obj/structure/stone_tile/surrounding/burnt,
+/obj/structure/stone_tile/center/burnt,
+/obj/effect/landmark/spawner/bubblegum,
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "spM" = (
 /obj/structure/rack,
 /obj/item/grenade/clusterbuster/holy,
@@ -23698,6 +23592,12 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
+"syc" = (
+/obj/structure/light_fake/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "syd" = (
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/admin3)
@@ -23745,37 +23645,6 @@
 	icon_state = "darkfull"
 	},
 /area/syndicate_mothership/cargo)
-"sCy" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/tank/internals/emergency_oxygen/double/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/obj/item/clothing/mask/breath/vox,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
-"sCH" = (
-/turf/simulated/floor/plating{
-	icon_state = "asteroidplating"
-	},
-/area/ghost_bar)
 "sCI" = (
 /obj/machinery/computer/security{
 	dir = 4;
@@ -23854,6 +23723,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/admin3)
+"sES" = (
+/obj/machinery/economy/vending/tool/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "sEX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23900,11 +23775,6 @@
 	icon_state = "grimy"
 	},
 /area/centcom/ss220/general)
-"sFG" = (
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "sFV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -23996,6 +23866,10 @@
 /obj/structure/light_fake/small,
 /turf/simulated/floor/carpet/arcade,
 /area/centcom/ss220/general)
+"sJJ" = (
+/obj/structure/light_fake/small,
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "sJP" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced{
@@ -24112,10 +23986,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"sNv" = (
-/obj/structure/closet/wardrobe/xenos,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/ghost_bar)
 "sNA" = (
 /obj/structure/fence{
 	invulnerable = 1
@@ -24177,6 +24047,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
+"sQi" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space/nearstation)
 "sQk" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
@@ -24225,6 +24099,13 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership/elite_squad)
+"sTn" = (
+/obj/machinery/door/window{
+	dir = 8;
+	opacity = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "sTr" = (
 /obj/effect/turf_decal/grass{
 	icon_state = "grass_edge_medium_corner";
@@ -24234,6 +24115,13 @@
 	name = "sand"
 	},
 /area/syndicate_mothership/outside)
+"sTw" = (
+/obj/structure/bookcase/random,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "sUd" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -24331,6 +24219,12 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
+"sXQ" = (
+/obj/structure/light_fake/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/stairs/left,
+/area/ghost_bar)
 "sXX" = (
 /obj/structure/light_fake/small{
 	dir = 1
@@ -24413,6 +24307,12 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
+"tbo" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "tbJ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -24591,12 +24491,6 @@
 /obj/effect/landmark/spawner/syndicate_infiltrator_leader,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/infteam)
-"tin" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "tiB" = (
 /obj/structure/light_fake/small{
 	dir = 1
@@ -24665,6 +24559,12 @@
 /obj/item/camera,
 /turf/simulated/floor/beach/away/sand,
 /area/ninja/holding)
+"tng" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "tni" = (
 /obj/structure/light_fake/small{
 	dir = 4
@@ -24730,6 +24630,9 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
+"tpP" = (
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "tpQ" = (
 /obj/effect/turf_decal/box/corners,
 /turf/simulated/floor/mineral/abductor,
@@ -24740,17 +24643,18 @@
 	icon_state = "darkredcornersalt"
 	},
 /area/syndicate_mothership/jail)
-"tqJ" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/deck/cards/black,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "tqQ" = (
 /obj/structure/sink/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership/infteam)
+"trm" = (
+/obj/structure/sink/directional/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "try" = (
 /obj/structure/table,
 /obj/item/bonegel,
@@ -24826,6 +24730,13 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/evac)
+"ttJ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "tut" = (
 /obj/structure/bed,
 /obj/effect/decal/cleanable/blood,
@@ -25096,10 +25007,6 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
-"tEY" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/plating/asteroid/ancient/airless,
-/area/space/nearstation)
 "tEZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -25113,12 +25020,6 @@
 	icon_state = "darkred"
 	},
 /area/syndicate_mothership/infteam)
-"tGT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Port Asteroid Maintenance"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "tHa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -25132,15 +25033,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
-"tHr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "tHw" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -25333,12 +25225,6 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
-"tNd" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "tNi" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -25367,7 +25253,10 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
-"tPb" = (
+"tOT" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "tPc" = (
@@ -25512,12 +25401,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
-"tVb" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "tVr" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -25639,19 +25522,6 @@
 /obj/effect/landmark/abductor/scientist,
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
-"tZr" = (
-/obj/structure/table/wood,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/obj/item/pen/multi,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "tZB" = (
 /obj/machinery/computer/shuttle/ert{
 	dir = 8
@@ -25667,6 +25537,10 @@
 	},
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/transport)
+"uaw" = (
+/obj/structure/railing,
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "uaS" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_white,
@@ -25804,6 +25678,14 @@
 	icon_state = "neutral"
 	},
 /area/shuttle/escape)
+"ufM" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = -2
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "ugE" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "SyndFB_prison_stroll_blast";
@@ -25818,6 +25700,10 @@
 	icon_state = "darkredcornersalt"
 	},
 /area/syndicate_mothership/jail)
+"ugH" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "uhH" = (
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 1
@@ -25988,10 +25874,6 @@
 /obj/docking_port/mobile/assault_pod,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
-"uou" = (
-/obj/effect/decal/warning_stripes/north,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "uow" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -26003,10 +25885,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
-"uoP" = (
-/obj/structure/railing,
-/turf/simulated/floor/plasteel/dark,
-/area/ghost_bar)
 "uoU" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo4"
@@ -26092,17 +25970,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
-"uss" = (
-/obj/structure/table/wood,
-/turf/simulated/floor/plating/asteroid/ancient,
-/area/ghost_bar)
-"usH" = (
-/obj/structure/dresser,
-/obj/machinery/light/small,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ghost_bar)
 "utc" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -26219,6 +26086,12 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
+"uzE" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "uzJ" = (
 /obj/docking_port/mobile/emergency{
 	dwidth = 11;
@@ -26325,6 +26198,12 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
+"uCL" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "uCR" = (
 /obj/structure/light_fake/small{
 	dir = 8
@@ -26412,11 +26291,6 @@
 	},
 /turf/simulated/floor/fakespace,
 /area/centcom/ss220/bar)
-"uGl" = (
-/turf/simulated/floor/plasteel/stairs/medium{
-	dir = 1
-	},
-/area/ghost_bar)
 "uGR" = (
 /obj/structure/chair/comfy/red,
 /turf/simulated/floor/carpet/arcade,
@@ -26680,6 +26554,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/elite_squad)
+"uPy" = (
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "uQl" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/clothing/suit/browntrenchcoat,
@@ -26695,12 +26575,6 @@
 /obj/structure/sink/directional/west,
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/evac)
-"uRl" = (
-/obj/structure/chair/stool/bar{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "uRt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -26891,14 +26765,6 @@
 	icon_state = "warndarkgreycornerred"
 	},
 /area/syndicate_mothership/infteam)
-"uYB" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/stairs/left{
-	dir = 1
-	},
-/area/ghost_bar)
 "uYN" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -27034,18 +26900,6 @@
 /obj/machinery/photocopier/syndie,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/infteam)
-"vgK" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Toilet";
-	opacity = 1
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "vgR" = (
 /obj/machinery/computer/card/centcom{
 	dir = 1
@@ -27246,6 +27100,19 @@
 	},
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
+"vpc" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"vpg" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "vpo" = (
 /turf/space/transit/horizontal{
 	dir = 4
@@ -27456,6 +27323,10 @@
 	icon_state = "darkred"
 	},
 /area/syndicate_mothership/elite_squad)
+"vvI" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "vwn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -27525,6 +27396,10 @@
 "vxy" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate_sit)
+"vxC" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "vxK" = (
 /obj/structure/railing{
 	dir = 1
@@ -27878,16 +27753,6 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
-"vOw" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/turf/simulated/floor/plasteel/freezer,
-/area/ghost_bar)
 "vOJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -27919,10 +27784,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
-"vPn" = (
-/obj/structure/chair/stool,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "vPu" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/wood,
@@ -28021,9 +27882,6 @@
 	icon_state = "darkbluealt"
 	},
 /area/shuttle/administration)
-"vSJ" = (
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "vTX" = (
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/plasteel/freezer,
@@ -28368,6 +28226,11 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
+"whJ" = (
+/obj/structure/light_fake/small,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "wjg" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/admin1)
@@ -28437,10 +28300,6 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
-"wkT" = (
-/obj/structure/sign/vacuum/external,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "wlp" = (
 /obj/machinery/economy/vending/chinese/free,
 /turf/simulated/floor/carpet/black,
@@ -28461,11 +28320,6 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
-"wmw" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/ashtray/plastic,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "wmC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -28473,6 +28327,12 @@
 /obj/machinery/light/spot,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/specops)
+"wnL" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ghost_bar)
 "wnU" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/carpet/black,
@@ -28517,9 +28377,6 @@
 	icon_state = "grimy"
 	},
 /area/syndicate_mothership/elite_squad)
-"wqB" = (
-/turf/simulated/mineral/ancient/outer,
-/area/space/nearstation)
 "wqZ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -28594,6 +28451,13 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
+"wti" = (
+/obj/machinery/economy/slot_machine,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"wtj" = (
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "wtn" = (
 /obj/structure/table/wood,
 /obj/machinery/kitchen_machine/microwave/upgraded{
@@ -28943,6 +28807,47 @@
 	icon_state = "warndarkgreyred"
 	},
 /area/syndicate_mothership/infteam)
+"wIt" = (
+/obj/structure/sign/barsign,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
+"wIu" = (
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "wIB" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -28999,6 +28904,12 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"wLy" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "wLN" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random_spawners/syndicate/loot{
@@ -29060,6 +28971,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
+"wOd" = (
+/obj/machinery/economy/merch{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "wOh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29125,6 +29042,13 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"wPr" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "wPL" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/syndicate,
@@ -29147,12 +29071,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
-"wQi" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "wQK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -29175,10 +29093,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/administration)
-"wRr" = (
-/obj/structure/sign/poster/contraband/syndicate_pistol,
-/turf/simulated/wall/indestructible/riveted,
-/area/ghost_bar)
 "wRu" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/tree/jungle,
@@ -29267,6 +29181,13 @@
 	},
 /turf/simulated/floor/fakespace,
 /area/centcom/ss220/bar)
+"wVB" = (
+/obj/structure/sink/directional/west,
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "wWg" = (
 /obj/machinery/door/poddoor{
 	id_tag = "SIT_ready";
@@ -29310,16 +29231,15 @@
 	icon_state = "grimy"
 	},
 /area/trader_station/sol)
-"wYf" = (
-/obj/structure/railing,
-/turf/simulated/floor/plasteel/stairs/left{
-	dir = 8
-	},
-/area/ghost_bar)
 "wYt" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"wYx" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/storage/box/matches,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "wYC" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility/chief/full{
@@ -29363,6 +29283,10 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
+"wZS" = (
+/obj/structure/sign/poster/official/space_cops,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "xau" = (
 /obj/docking_port/stationary/transit{
 	dir = 8;
@@ -29707,6 +29631,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"xhE" = (
+/obj/structure/light_fake/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "xhK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30009,6 +29939,13 @@
 /obj/item/flag/species/nian,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/evac)
+"xrf" = (
+/obj/structure/dresser,
+/obj/structure/light_fake/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "xrm" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/spawner/random_spawners/syndicate/loot{
@@ -30277,10 +30214,6 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/elite_squad)
-"xBr" = (
-/obj/structure/bookcase/random,
-/turf/simulated/floor/carpet/green,
-/area/ghost_bar)
 "xBZ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull"
@@ -30315,6 +30248,11 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
+"xCY" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "xDl" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood/fancy/oak,
@@ -30405,6 +30343,10 @@
 	name = "sand"
 	},
 /area/syndicate_mothership/outside)
+"xHm" = (
+/obj/machinery/door/airlock/external_no_weld,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "xIB" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -30495,6 +30437,12 @@
 "xMj" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/jail)
+"xMm" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "xMF" = (
 /obj/item/decorations/sticky_decorations/flammable/snowman{
 	pixel_x = -7;
@@ -30506,6 +30454,13 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
+"xNB" = (
+/obj/structure/bookcase/random,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "xOd" = (
 /obj/machinery/computer/station_alert,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -30516,11 +30471,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/centcom/ss220/general)
-"xOl" = (
-/obj/structure/table/wood,
-/obj/item/storage/pill_bottle/dice,
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "xOp" = (
 /obj/structure/table/wood{
 	color = "#996633"
@@ -30547,6 +30497,13 @@
 "xOF" = (
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
+"xOG" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "xPy" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/grass/jungle/no_creep,
@@ -30578,20 +30535,10 @@
 /obj/structure/flora/bush,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/control)
-"xRZ" = (
-/obj/structure/stone_tile/slab/burnt,
-/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
-/area/ruin/space/bubblegum_arena)
 "xSq" = (
 /obj/machinery/economy/vending/dinnerware,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
-"xSt" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "xSv" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -30634,6 +30581,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/administration)
+"xTX" = (
+/obj/structure/table/reinforced,
+/obj/structure/light_fake/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
+"xUj" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "xUI" = (
 /obj/structure/closet/secure_closet/clown{
 	req_access = null
@@ -30647,11 +30607,6 @@
 	icon_state = "darkred"
 	},
 /area/syndicate_mothership/infteam)
-"xVC" = (
-/obj/structure/table/reinforced,
-/obj/item/ashtray/glass,
-/turf/simulated/floor/carpet/black,
-/area/ghost_bar)
 "xVK" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -30678,6 +30633,11 @@
 	icon_state = "darkredcornersalt"
 	},
 /area/syndicate_mothership/control)
+"xWr" = (
+/obj/item/flashlight/lamp,
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "xWv" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate{
@@ -30723,9 +30683,6 @@
 "xYo" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
-"xYG" = (
-/turf/simulated/floor/indestructible/necropolis,
-/area/ruin/space/bubblegum_arena)
 "xZd" = (
 /obj/machinery/economy/vending/nta/green,
 /turf/simulated/floor/plasteel/dark{
@@ -30775,6 +30732,21 @@
 "xZL" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/jail)
+"yap" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Toilet";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "yaB" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo14"
@@ -30802,6 +30774,10 @@
 	},
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/admin2)
+"ybB" = (
+/obj/structure/railing,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "ybG" = (
 /obj/structure/light_fake/small{
 	dir = 8
@@ -30851,15 +30827,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
-"ydG" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/turf/simulated/floor/wood,
-/area/ghost_bar)
 "yex" = (
 /obj/item/syndicatedetonator{
 	desc = "Радиус взрыва: 255x255x255";
@@ -30923,12 +30890,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/elite_squad)
-"yft" = (
-/obj/machinery/processor,
-/turf/simulated/floor/plasteel{
-	icon_state = "cafeteria"
-	},
-/area/ghost_bar)
 "yfK" = (
 /obj/machinery/economy/vending/cola/free,
 /turf/simulated/floor/carpet/black,
@@ -31065,6 +31026,12 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/centcom/ss220/supply)
+"ykx" = (
+/obj/machinery/processor,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "ykz" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plasteel{
@@ -79328,39 +79295,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
 adJ
 adJ
 adJ
@@ -79369,9 +79336,9 @@ adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
+nNr
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -79379,14 +79346,14 @@ adJ
 adJ
 adJ
 adJ
-eYM
-wqB
-eYM
-wqB
+nNr
+fYV
+nNr
+fYV
 adJ
 adJ
-eYM
-eYM
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -79585,66 +79552,51 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-wqB
-wqB
-wqB
-eYM
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-eYM
-eYM
-wqB
-wqB
-eYM
-eYM
-wqB
-eYM
+nNr
+nNr
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -79652,12 +79604,27 @@ adJ
 adJ
 adJ
 adJ
+nNr
+nNr
+fYV
+fYV
+nNr
+nNr
+fYV
+nNr
 adJ
 adJ
 adJ
 adJ
-wqB
-wqB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -79842,79 +79809,79 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-mRh
-mRh
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-mRh
-mRh
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+lOn
+lOn
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+lOn
+lOn
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-eYM
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
 adJ
-tEY
-eYM
-eYM
-eYM
-eYM
-eYM
-eYM
-eYM
-eYM
-wqB
-eYM
-adJ
-adJ
-adJ
-adJ
-adJ
+pLx
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+fYV
+nNr
 adJ
 adJ
 adJ
 adJ
 adJ
-cjQ
-wqB
+adJ
+adJ
+adJ
+adJ
+adJ
+fVA
+fYV
 adJ
 adJ
 adJ
@@ -80099,68 +80066,68 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-eYM
-eYM
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+nNr
+nNr
 adJ
 adJ
 adJ
-eYM
-eYM
-wqB
-wqB
-wqB
-eYM
-eYM
-wqB
-eYM
-wqB
-wqB
-eYM
+nNr
+nNr
+fYV
+fYV
+fYV
+nNr
+nNr
+fYV
+nNr
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -80356,68 +80323,68 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-eYM
-eYM
-eYM
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-eYM
+nNr
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+nNr
+nNr
+nNr
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -80613,80 +80580,80 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
-eYM
+nNr
 adJ
 adJ
-igP
-wqB
-wqB
-wqB
-vSJ
-vSJ
-obL
-obL
-obL
-obL
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-wqB
-wqB
-wqB
-wqB
-wqB
-eYM
-eYM
-eYM
-eYM
-eYM
-eYM
+sQi
+fYV
+fYV
+fYV
+fyL
+fyL
+kGm
+kGm
+kGm
+kGm
+fyL
+fyL
+fyL
+fyL
+fyL
+fYV
+fYV
+fYV
+fYV
+fYV
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
 adJ
 adJ
-efK
-eYM
-eYM
-eYM
-eYM
+pxm
+nNr
+nNr
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -80870,39 +80837,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -80912,39 +80879,39 @@ adJ
 adJ
 adJ
 adJ
-igP
-wqB
-wqB
-vSJ
-niL
-sFG
-sFG
-sFG
-sFG
-hPV
-fca
-cUj
-iAD
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-wqB
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-eYM
-eYM
+sQi
+fYV
+fYV
+fyL
+lze
+aso
+aso
+aso
+aso
+dna
+dCP
+cpn
+cDO
+fyL
+fyL
+fyL
+fyL
+fyL
+fYV
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -81127,39 +81094,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -81171,37 +81138,37 @@ adJ
 adJ
 adJ
 adJ
-igP
-vSJ
-gMc
-sFG
-gxG
-evV
-sFG
-lKi
-vSJ
-cUj
-cdT
-vSJ
-jpA
-evk
-evk
-vSJ
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-vSJ
-obL
-obL
-vSJ
-vSJ
-wqB
-wqB
-wqB
-eYM
+sQi
+fyL
+sES
+aso
+wPr
+xMm
+aso
+aXc
+fyL
+cpn
+mTY
+fyL
+lkI
+ufM
+ufM
+fyL
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fyL
+kGm
+kGm
+fyL
+fyL
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -81384,81 +81351,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
-adJ
-leU
-adJ
-adJ
-adJ
-leU
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
-igP
-vSJ
-boY
-sFG
-que
-sCy
-sFG
-gJw
-vSJ
-dnu
-cUj
-vSJ
-cUj
-cUj
-cUj
-vSJ
-wqB
-wqB
-wqB
-wqB
-wqB
-vSJ
-vSJ
-csk
-uss
-bzF
-vSJ
-wqB
-wqB
-wqB
-eYM
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+sQi
+fyL
+bCk
+aso
+pWy
+fqZ
+aso
+arE
+fyL
+acl
+cpn
+fyL
+cpn
+cpn
+cpn
+fyL
+fYV
+fYV
+fYV
+fYV
+fYV
+fyL
+fyL
+kEI
+jon
+hMr
+fyL
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -81641,81 +81608,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
-atq
-atq
-atq
-adJ
-adJ
-adJ
+gvF
+gvF
+gvF
 adJ
 adJ
 adJ
-igP
-vSJ
-rUm
-sFG
-otz
-oaE
-sFG
-opP
-vSJ
-dnu
-cUj
-cUj
-cUj
-cUj
-cUj
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-wRr
-oZv
-aqx
-aqx
-nVt
-vSJ
-wqB
-wqB
-wqB
-eYM
+adJ
+adJ
+adJ
+sQi
+fyL
+lgW
+aso
+uPy
+wIu
+aso
+okL
+fyL
+acl
+cpn
+cpn
+cpn
+cpn
+cpn
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+dnr
+oaf
+eta
+eta
+mWE
+fyL
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -81898,80 +81865,80 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-atq
-kBV
-atq
-atq
-igP
-leU
+gvF
+gvF
+rVf
+gvF
+gvF
+sQi
 adJ
-igP
 adJ
-igP
-vSJ
-kJd
-sFG
-sFG
-sFG
-sFG
-usH
-vSJ
-hWK
-vOw
-hva
-pkG
-vgK
-koB
-aYV
-nVt
-sCH
-sCH
-sCH
-sCH
-sCH
-sCH
-sCH
-sCH
-sCH
-vSJ
-wqB
-wqB
-eYM
+sQi
+adJ
+sQi
+fyL
+bSA
+aso
+aso
+aso
+aso
+xrf
+fyL
+exn
+wVB
+iSJ
+yap
+nmd
+aEU
+vpg
+mWE
+qQx
+qQx
+qQx
+qQx
+qQx
+qQx
+qQx
+qQx
+qQx
+fyL
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -82155,79 +82122,79 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-rDY
-rDY
-nJx
-atq
-igP
-igP
-igP
-igP
-igP
-npr
-vSJ
-obL
-obL
-dGy
-qLY
-obL
-obL
-vSJ
-vSJ
-vSJ
-kzD
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-mZU
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-nVt
-vSJ
-wqB
-eYM
+gvF
+jMW
+jMW
+tng
+gvF
+mBu
+sQi
+sQi
+sQi
+sQi
+jKx
+fyL
+kGm
+kGm
+riZ
+gpw
+kGm
+kGm
+fyL
+fyL
+fyL
+mNv
+fyL
+fyL
+fyL
+fyL
+fyL
+cpN
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+mWE
+fyL
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -82412,79 +82379,79 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-goi
-rDY
-nJx
-atq
-vSJ
-obL
-obL
-obL
-obL
-vSJ
-wkT
-lMI
-tPb
-tPb
-tPb
-tPb
-tPb
-emX
-nCJ
-eFq
-uoP
-cDO
-xSt
-ydG
-hwh
-jTG
-tPb
-bMH
-psK
-obL
-oEA
-hnb
-hVa
-vSJ
-nVt
-vSJ
-wqB
-eYM
+gvF
+fJv
+jMW
+tng
+gvF
+fyL
+kGm
+kGm
+kGm
+kGm
+fyL
+dOg
+gfb
+que
+que
+que
+que
+que
+eWD
+sXQ
+gEh
+uaw
+edz
+wLy
+vpc
+phD
+oGP
+que
+wti
+cUP
+kGm
+rHL
+roI
+nhC
+fyL
+mWE
+fyL
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -82669,79 +82636,79 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-hhQ
-rDY
-rDY
-rDd
-qXL
-sFG
-dYd
-dYd
-sFG
-dYd
-isq
-uou
-tPb
-tPb
-tPb
-tPb
-tPb
-tPb
-fgL
-eFq
-uoP
-tPb
-jjL
-tqJ
-wmw
-tin
-tPb
-uRl
-uRl
-obL
-egL
-egL
-egL
-vSJ
-sCH
-vSJ
-wqB
-wqB
+gvF
+sag
+jMW
+jMW
+xHm
+qlA
+aso
+rDM
+rDM
+aso
+rDM
+lRI
+maG
+que
+que
+que
+que
+que
+que
+pUt
+gEh
+uaw
+que
+oKn
+kfL
+aYQ
+khC
+que
+eed
+eed
+kGm
+rHU
+rHU
+rHU
+fyL
+qQx
+fyL
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -82926,79 +82893,79 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xRZ
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-pvO
-rDY
-rDY
-rDd
-qXL
-dYd
-dYd
-sFG
-dYd
-sFG
-isq
-uou
-tPb
-wQi
-wQi
-wQi
-tPb
-vSJ
-dCl
-dGy
-wYf
-tPb
-cLl
-lmq
-lmq
-tPb
-tPb
-tPb
-tPb
-mPY
-gfm
-gfm
-gfm
-vSJ
-sCH
-vSJ
-vSJ
-wqB
+gvF
+rDJ
+jMW
+jMW
+xHm
+qlA
+rDM
+rDM
+aso
+rDM
+aso
+lRI
+maG
+que
+eHd
+eHd
+eHd
+que
+fyL
+mHj
+riZ
+kTj
+que
+jjt
+hsR
+hsR
+que
+que
+que
+que
+csH
+wtj
+wtj
+wtj
+fyL
+qQx
+fyL
+fyL
+fYV
 adJ
 adJ
 adJ
@@ -83183,80 +83150,80 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xRZ
-xRZ
-xRZ
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+njf
+njf
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-rDY
-rDY
-rDY
-atq
-gDY
-obL
-obL
-obL
-obL
-vSJ
-vSJ
-heL
-tPb
-qsr
-qLv
-ewU
-aMU
-vSJ
-pPq
-tPb
-pHW
-tPb
-tPb
-tPb
-tPb
-tPb
-tPb
-tPb
-tPb
-gfm
-gfm
-gfm
-rLG
-vSJ
-nVt
-vSJ
-vSJ
-wqB
-eYM
+gvF
+jMW
+jMW
+jMW
+gvF
+tbo
+kGm
+kGm
+kGm
+kGm
+fyL
+fyL
+xNB
+que
+oJA
+dul
+ugH
+whJ
+fyL
+lbE
+que
+lbv
+que
+que
+que
+que
+que
+que
+que
+que
+wtj
+wtj
+wtj
+sJJ
+fyL
+mWE
+fyL
+fyL
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -83440,81 +83407,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qni
-qni
-xRZ
-xRZ
-xRZ
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+hym
+hym
+njf
+njf
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-fKf
-sNv
-lNp
-atq
-igP
-igP
-igP
-igP
-igP
-npr
-bHi
-qOS
-tPb
-lrQ
-lrQ
-lrQ
-tPb
-vSJ
-peN
-tPb
-tPb
-tPb
-tPb
-tPb
-tPb
-tPb
-tVb
-tVb
-tPb
-obL
-gfm
-iip
-iip
-vSJ
-nVt
-mNm
-vSJ
-wqB
-wqB
-eYM
+gvF
+jjU
+bYv
+nqk
+gvF
+mBu
+sQi
+sQi
+sQi
+sQi
+jKx
+cLd
+rdl
+que
+rRR
+rRR
+rRR
+que
+fyL
+xOG
+que
+que
+que
+que
+que
+que
+que
+aKd
+aKd
+que
+kGm
+wtj
+uCL
+uCL
+fyL
+mWE
+nNP
+fyL
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -83697,81 +83664,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qni
-qni
-qni
-hdj
-xRZ
-xRZ
-xRZ
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+hym
+hym
+hym
+sps
+njf
+njf
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+bQD
 adJ
-atq
-efO
-efO
-efO
-atq
-igP
-leU
-adJ
+gvF
+mnG
+mnG
+mnG
+gvF
+sQi
 adJ
 adJ
-igP
-obL
-tPb
-tPb
-cCG
-cCG
-cCG
-tPb
-vSJ
-hDQ
-tPb
-tPb
-tPb
-rhf
-tPb
-tPb
-tPb
-wmw
-mjk
-tPb
-obL
-nau
-frZ
-frZ
-vSJ
-sCH
-nVt
-vSJ
-wqB
-wqB
-eYM
+adJ
+adJ
+sQi
+kGm
+que
+que
+tpP
+tpP
+tpP
+que
+fyL
+jjt
+que
+que
+que
+jjt
+que
+que
+que
+aYQ
+wYx
+que
+kGm
+cjf
+pED
+pED
+fyL
+qQx
+mWE
+fyL
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -83954,81 +83921,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qni
-qni
-qni
-qni
-xRZ
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+hym
+hym
+hym
+hym
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
-dEt
-dEt
-dEt
+wnL
+wnL
+wnL
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
-igP
-obL
-tPb
-tPb
-cCG
-wQi
-cCG
-mrG
-vSJ
-gVg
-cAZ
-cAZ
-cAZ
-cAZ
-cAZ
-lmq
-tPb
-eUO
-eUO
-ceb
-lji
-obL
-obL
-obL
-vSJ
-sCH
-nVt
-vSJ
-wqB
-wqB
-wqB
+nNr
+nNr
+nNr
+sQi
+kGm
+que
+que
+tpP
+eHd
+tpP
+ksx
+fyL
+iLq
+cgy
+cgy
+cgy
+cgy
+cgy
+hsR
+que
+nOu
+nOu
+cZF
+kYo
+kGm
+kGm
+kGm
+fyL
+qQx
+mWE
+fyL
+fYV
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -84211,81 +84178,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xRZ
-xRZ
-qni
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
-adJ
-leU
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+njf
+njf
+hym
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
-leU
-eYM
-rIB
-eYM
-rIB
-eYM
-eYM
-obL
-tPb
-tPb
-bJA
-qLv
-pLl
-qOS
-kFL
-hha
-jgL
-jgL
-xVC
-jgL
-foh
-coH
-tPb
-tPb
-tPb
-hIJ
-nXK
-lmq
-cTB
-lmq
-vSJ
-sCH
-nVt
-vSJ
-wqB
-wqB
-wqB
+adJ
+adJ
+adJ
+nNr
+bIN
+nNr
+bIN
+nNr
+nNr
+kGm
+que
+que
+lrj
+dul
+nRD
+rdl
+wZS
+sTn
+hnL
+hnL
+jLh
+hnL
+kcR
+dqS
+que
+que
+que
+ybB
+gyu
+hsR
+aae
+hsR
+fyL
+qQx
+mWE
+fyL
+fYV
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -84468,81 +84435,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xRZ
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
-eYM
-qRW
-rIB
-eYM
-vSJ
-lNS
-tPb
-cCG
-lrQ
-cCG
-gfZ
-cMe
-tPb
-tPb
-tPb
-tPb
-tPb
-jgL
-coH
-tPb
-cLl
-tPb
-hIJ
-eFq
-vPn
-rfR
-quV
-vSJ
-sCH
-bKy
-vSJ
-wqB
-wqB
-wqB
+nNr
+nNr
+nNr
+nNr
+fqY
+bIN
+nNr
+fyL
+sTw
+que
+tpP
+rRR
+tpP
+jmo
+wIt
+que
+que
+que
+que
+que
+hnL
+dqS
+que
+jjt
+que
+ybB
+hsR
+xUj
+hFT
+uzE
+fyL
+qQx
+dLq
+fyL
+fYV
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -84725,81 +84692,81 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
-eYM
-lRa
-eYM
-eYM
-wqB
-vSJ
-xBr
-tPb
-cCG
-cCG
-cCG
-qOS
-vSJ
-tPb
-tPb
-tPb
-tPb
-tPb
-xVC
-coH
-tPb
-tPb
-lmq
-dTs
-dhV
-eFq
-eFq
-bil
-vSJ
-sCH
-vSJ
-vSJ
-wqB
-wqB
-eYM
+nNr
+nNr
+nNr
+nNr
+lka
+nNr
+nNr
+fYV
+fyL
+ohd
+que
+tpP
+tpP
+tpP
+rdl
+fyL
+que
+que
+que
+que
+que
+jLh
+dqS
+que
+que
+hsR
+oqx
+cgV
+gEh
+gEh
+gIe
+fyL
+qQx
+fyL
+fyL
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -84982,80 +84949,80 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
-eYM
-eYM
-eYM
-rIB
-wqB
-wqB
-vSJ
-obL
-qkG
-qkG
-qkG
-qkG
-obL
-vSJ
-nBr
-tPb
-daj
-pWQ
-jTa
-jgL
-coH
-tPb
-tPb
-lmq
-lmq
-uGl
-eFq
-eFq
-eFq
-vSJ
-nVt
-vSJ
-wqB
-wqB
-wqB
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+bIN
+fYV
+fYV
+fyL
+kGm
+vvI
+vvI
+vvI
+vvI
+kGm
+fyL
+vxC
+que
+qDf
+ttJ
+nvT
+hnL
+dqS
+que
+que
+hsR
+hsR
+imT
+gEh
+gEh
+gEh
+fyL
+mWE
+fyL
+fYV
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -85239,80 +85206,80 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
-eYM
-wqB
-eYM
-eYM
-eYM
-eYM
-eYM
-wqB
-wqB
-vSJ
-qOS
-tPb
-tPb
-tPb
-tPb
-tPb
-vSJ
-seS
-aix
-vSJ
-vSJ
-vSJ
-vSJ
-lGh
-tPb
-tPb
-lmq
-qgH
-uYB
-eFq
-eFq
-eFq
-tGT
-ohx
-vSJ
-wqB
-wqB
-eYM
+nNr
+fYV
+nNr
+nNr
+nNr
+nNr
+nNr
+fYV
+fYV
+fyL
+rdl
+que
+que
+que
+que
+que
+fyL
+aVs
+dNH
+fyL
+fyL
+fyL
+fyL
+aKD
+que
+que
+hsR
+hiL
+bAr
+gEh
+gEh
+gEh
+kZR
+dYF
+fyL
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -85496,80 +85463,80 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
-wqB
-wqB
-wqB
-eYM
-eYM
-wqB
-wqB
-wqB
-vSJ
-heL
-tPb
-eik
-kBT
-boD
-luQ
-vSJ
-tHr
-orw
-oSa
-mTy
-hMl
-vSJ
-tPb
-tPb
-cLl
-tPb
-hIJ
-eFq
-vPn
-rfR
-quV
-vSJ
-vSJ
-vSJ
-wqB
-wqB
-eYM
+fYV
+fYV
+fYV
+nNr
+nNr
+fYV
+fYV
+fYV
+fyL
+xNB
+que
+jUj
+hKm
+apS
+cOX
+fyL
+xTX
+oHR
+fmr
+gDl
+eyi
+fyL
+que
+que
+jjt
+que
+ybB
+hsR
+xUj
+hFT
+uzE
+fyL
+fyL
+fyL
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -85753,78 +85720,78 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-vSJ
-occ
-tPb
-eik
-nuU
-tZr
-afu
-vSJ
-ePh
-orw
-orw
-orw
-orw
-cKR
-tPb
-tPb
-tVb
-tVb
-hIJ
-dyR
-lmq
-tNd
-lmq
-vSJ
-wqB
-wqB
-wqB
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fyL
+wOd
+que
+jUj
+mtU
+nwu
+lqM
+fyL
+trm
+oHR
+oHR
+oHR
+oHR
+bKq
+que
+que
+aKd
+aKd
+ybB
+xhE
+hsR
+caI
+hsR
+fyL
+fYV
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -86010,77 +85977,77 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-vSJ
-ouK
-qkF
-eik
-pyb
-xOl
-afu
-cDK
-yft
-kJv
-blD
-dkL
-fbm
-vSJ
-rtU
-tPb
-wmw
-pKj
-pHW
-vSJ
-nLP
-nLP
-vSJ
-vSJ
-wqB
-wqB
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fyL
+xWr
+gdw
+jUj
+bDn
+xCY
+lqM
+bWh
+ykx
+anM
+jnj
+fFZ
+cas
+fyL
+jjt
+que
+aYQ
+ikq
+tOT
+fyL
+rqm
+rqm
+fyL
+fyL
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -86267,39 +86234,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -86308,35 +86275,35 @@ adJ
 adJ
 adJ
 adJ
-eYM
-wqB
-wqB
-wqB
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-nLP
-tPb
-tPb
-eUO
-eUO
-tPb
-vSJ
-wqB
-wqB
-wqB
-wqB
-wqB
+nNr
+fYV
+fYV
+fYV
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+fyL
+rqm
+que
+que
+nOu
+nOu
+que
+fyL
+fYV
+fYV
+fYV
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -86524,39 +86491,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -86566,33 +86533,33 @@ adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-vSJ
-tPb
-jjW
-tPb
-vSJ
-vSJ
-vSJ
-wqB
-wqB
-eYM
-eYM
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fyL
+que
+syc
+que
+fyL
+fyL
+fyL
+fYV
+fYV
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -86781,39 +86748,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -86825,30 +86792,30 @@ adJ
 adJ
 adJ
 adJ
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-vSJ
-vSJ
-vSJ
-vSJ
-vSJ
-wqB
-wqB
-wqB
-eYM
-eYM
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fyL
+fyL
+fyL
+fyL
+fyL
+fYV
+fYV
+fYV
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -87038,39 +87005,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-eTT
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -87083,29 +87050,29 @@ adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-wqB
-wqB
-wqB
-eYM
+nNr
+nNr
+fYV
+fYV
+fYV
+nNr
 adJ
 adJ
-eYM
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-wqB
-vSJ
-wqB
-wqB
-eYM
-eYM
-wqB
+nNr
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fYV
+fyL
+fYV
+fYV
+nNr
+nNr
+fYV
 adJ
 adJ
 adJ
@@ -87295,39 +87262,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-mRh
-mRh
-mRh
-mRh
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-mRh
-mRh
-mRh
-mRh
-xYG
-qlB
+bQD
+kKi
+lOn
+lOn
+lOn
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+lOn
+lOn
+lOn
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -87342,27 +87309,27 @@ adJ
 adJ
 adJ
 adJ
-eYM
-wqB
-wqB
-eYM
+nNr
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
 adJ
-wqB
-eYM
-eYM
-wqB
-wqB
-wqB
-wqB
-vSJ
-wqB
-eYM
-eYM
-wqB
-wqB
+fYV
+nNr
+nNr
+fYV
+fYV
+fYV
+fYV
+fyL
+fYV
+nNr
+nNr
+fYV
+fYV
 adJ
 adJ
 adJ
@@ -87552,39 +87519,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-xYG
-qlB
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -87600,8 +87567,8 @@ adJ
 adJ
 adJ
 adJ
-eYM
-eYM
+nNr
+nNr
 adJ
 adJ
 adJ
@@ -87609,13 +87576,13 @@ adJ
 adJ
 adJ
 adJ
-eYM
-eYM
-eYM
+nNr
+nNr
+nNr
 adJ
-wqB
-wqB
-eYM
+fYV
+fYV
+nNr
 adJ
 adJ
 adJ
@@ -87809,39 +87776,39 @@ adJ
 adJ
 adJ
 adJ
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
-qlB
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
 adJ
 adJ
 adJ
@@ -87873,7 +87840,7 @@ adJ
 adJ
 adJ
 adJ
-wqB
+fYV
 adJ
 adJ
 adJ

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -141,6 +141,12 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"afu" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "afG" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -189,6 +195,11 @@
 /obj/effect/decal/warning_stripes/blue,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin1)
+"aix" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "aiJ" = (
 /obj/structure/closet/syndicate/nuclear,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -358,7 +369,6 @@
 /obj/item/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "Camera";
-	pictures_left = 30;
 	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
@@ -379,6 +389,14 @@
 /obj/machinery/plantgenes,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
+"aqx" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "arh" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_sit)
@@ -494,6 +512,9 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"atq" = (
+/turf/simulated/wall/indestructible/syndicate,
+/area/ghost_bar)
 "atu" = (
 /turf/simulated/wall/indestructible/wood,
 /area/ninja/holding)
@@ -1009,6 +1030,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"aMU" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "aNi" = (
 /obj/structure/curtain/black{
 	pixel_y = -32;
@@ -1226,6 +1254,10 @@
 /obj/item/dice/d20,
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
+"aYV" = (
+/obj/structure/sign/poster/contraband/syndicate_recruitment,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "aYX" = (
 /obj/structure/chair/sofa/pew{
 	dir = 1
@@ -1424,6 +1456,12 @@
 /obj/item/storage/box/alienhandcuffs,
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
+"bil" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "bit" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo3"
@@ -1505,6 +1543,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
+"blD" = (
+/obj/machinery/kitchen_machine/oven/upgraded,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "bmv" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating/airless,
@@ -1553,6 +1597,10 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
+"boD" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "boO" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -1572,6 +1620,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"boY" = (
+/obj/machinery/economy/vending/hatdispenser,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "bpc" = (
 /obj/docking_port/stationary/transit{
 	dir = 2;
@@ -1816,6 +1870,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"bzF" = (
+/obj/item/clothing/head/cone,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "bCs" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -1943,6 +2003,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
+"bHi" = (
+/obj/structure/sign/bobross,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "bHy" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -1976,6 +2040,10 @@
 	water_overlay_image = null
 	},
 /area/centcom/ss220/evac)
+"bJA" = (
+/obj/structure/chair/comfy/black,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "bJO" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/marker_beacon/dock_marker/collision,
@@ -1992,6 +2060,12 @@
 /obj/machinery/photocopier/syndie,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
+"bKy" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "bLl" = (
 /obj/effect/turf_decal/miscellaneous/goldensiding{
 	dir = 10
@@ -2034,6 +2108,10 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
+"bMH" = (
+/obj/machinery/economy/slot_machine,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "bNg" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "SyndFB_prison_stroll_blast";
@@ -2566,6 +2644,12 @@
 /obj/item/gun/energy/pulse/pistol/m1911,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"cdT" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "cdV" = (
 /obj/structure/table/reinforced,
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/flashbang,
@@ -2581,6 +2665,11 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
+"ceb" = (
+/obj/structure/railing/corner,
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "cex" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -2715,6 +2804,10 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
+"cjQ" = (
+/obj/effect/mob_spawn/human/corpse/clown/corpse,
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "cjU" = (
 /obj/machinery/economy/vending/cigarette/free,
 /turf/simulated/floor/wood/fancy/oak,
@@ -2848,6 +2941,12 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin1)
+"coH" = (
+/obj/structure/chair/stool/bar{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "coJ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2904,6 +3003,12 @@
 	icon_state = "darkbluealt"
 	},
 /area/shuttle/administration)
+"csk" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "csQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/fluff/hugosheet,
@@ -3052,6 +3157,12 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
+"cAZ" = (
+/obj/structure/chair/stool/bar{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "cBB" = (
 /obj/structure/fans/tiny/invisible,
 /obj/structure/marker_beacon/dock_marker/collision,
@@ -3111,6 +3222,9 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"cCG" = (
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "cDb" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/adv,
@@ -3133,6 +3247,16 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
+"cDK" = (
+/obj/structure/sign/poster/official/fruit_bowl,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
+"cDO" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "cDV" = (
 /obj/structure/light_fake/spot{
 	dir = 1
@@ -3342,6 +3466,13 @@
 "cKO" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
+"cKR" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "cLj" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "syndishuttle_door_ext";
@@ -3360,6 +3491,11 @@
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate)
+"cLl" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/ghost_bar)
 "cLm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -3404,6 +3540,10 @@
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
+"cMe" = (
+/obj/structure/sign/barsign,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "cMK" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -3586,10 +3726,19 @@
 /obj/item/mecha_parts/mecha_equipment/generator/nuclear,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"cTB" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "cTG" = (
 /obj/machinery/economy/vending/coffee/free,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/bar)
+"cUj" = (
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "cUk" = (
 /obj/structure/chair/wood/wings,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -3753,6 +3902,13 @@
 	icon_state = "neutral"
 	},
 /area/centcom/ss220/evac)
+"daj" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/beer{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "daq" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -3919,6 +4075,14 @@
 	},
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
+"dhV" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/stairs/right{
+	dir = 1
+	},
+/area/ghost_bar)
 "diL" = (
 /obj/structure/flora/junglebush/large{
 	layer = 4.8
@@ -3958,6 +4122,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/bar)
+"dkL" = (
+/obj/machinery/smartfridge/foodcart{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "dli" = (
 /obj/machinery/cryopod/offstation/right,
 /obj/machinery/computer/cryopod{
@@ -4009,6 +4181,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership)
+"dnu" = (
+/obj/structure/urinal{
+	pixel_y = 28
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "dnK" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/beach/away/water{
@@ -4354,6 +4532,13 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
+"dyR" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "dyS" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/indestructible
@@ -4470,6 +4655,10 @@
 /obj/structure/rack/gunrack,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
+"dCl" = (
+/obj/structure/sign/goldenplaque,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "dCq" = (
 /obj/effect/turf_decal/siding/black{
 	dir = 1
@@ -4523,6 +4712,12 @@
 /obj/machinery/economy/vending/hydroseeds,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
+"dEt" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/ghost_bar)
 "dEN" = (
 /obj/effect/turf_decal/stripes/red/full,
 /obj/structure/light_fake/spot{
@@ -4555,6 +4750,11 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
+"dGy" = (
+/turf/simulated/floor/plasteel/stairs/right{
+	dir = 8
+	},
+/area/ghost_bar)
 "dGG" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Камера";
@@ -4951,6 +5151,12 @@
 	water_overlay_image = null
 	},
 /area/syndicate_mothership/outside)
+"dTs" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "dTw" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#6697cc";
@@ -5007,6 +5213,9 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
+"dYd" = (
+/turf/simulated/floor/plating,
+/area/ghost_bar)
 "dYf" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
@@ -5162,6 +5371,16 @@
 	icon_state = "darkyellowcornersalt"
 	},
 /area/syndicate_mothership/cargo)
+"efK" = (
+/obj/item/coin/antagtoken,
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
+"efO" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/turf/simulated/wall/indestructible/syndicate,
+/area/ghost_bar)
 "efX" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -5171,6 +5390,12 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/shuttle/supply)
+"egL" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "egO" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
@@ -5206,6 +5431,10 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
+"eik" = (
+/obj/structure/chair/office/dark,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "eim" = (
 /obj/structure/light_fake/small{
 	dir = 8
@@ -5293,6 +5522,11 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)
+"emX" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "eng" = (
 /obj/structure/chair/stool/bar/dark{
 	dir = 8
@@ -5524,6 +5758,14 @@
 /obj/item/lighter/zippo,
 /turf/simulated/floor/plasteel/freezer,
 /area/ninja/holding)
+"evk" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = -2
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "evo" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -5535,6 +5777,12 @@
 /obj/item/toy/plushie/marble_fox,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/bar)
+"evV" = (
+/obj/structure/closet/wardrobe/black,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "ewa" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/miscellaneous/goldensiding,
@@ -5553,6 +5801,10 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/carpet/orange,
 /area/centcom/ss220/general)
+"ewU" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "exx" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/soda/upgraded,
@@ -5836,6 +6088,9 @@
 	icon_state = "neutral"
 	},
 /area/centcom/ss220/evac)
+"eFq" = (
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "eFF" = (
 /obj/effect/turf_decal/miscellaneous/goldensiding{
 	dir = 5
@@ -6131,6 +6386,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
+"ePh" = (
+/obj/structure/sink{
+	pixel_y = 24
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "ePp" = (
 /obj/structure/table/reinforced{
 	color = "#996633"
@@ -6266,6 +6529,10 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
+"eTT" = (
+/obj/effect/landmark/spawner/bubblegum_arena,
+/turf/simulated/floor/indestructible/necropolis,
+/area/ruin/space/bubblegum_arena)
 "eUn" = (
 /obj/structure/rack/holorack,
 /obj/item/organ/internal/cyberimp/brain/anti_drop,
@@ -6303,6 +6570,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"eUO" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "eVk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine/longrange/syndie{
@@ -6398,6 +6671,9 @@
 	icon_state = "cafeteria"
 	},
 /area/centcom/ss220/bar)
+"eYM" = (
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "eYN" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 1;
@@ -6484,6 +6760,14 @@
 /obj/machinery/computer/mech_bay_power_console,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
+"fbm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/kitchen_machine/microwave/upgraded,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "fbq" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/beer/upgraded{
@@ -6516,6 +6800,11 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
+"fca" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/centcom,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "fcL" = (
 /obj/structure/fence/corner{
 	color = "#b0b7c6";
@@ -6621,6 +6910,9 @@
 	icon_state = "darkbluefull"
 	},
 /area/centcom/ss220/admin3)
+"fgL" = (
+/turf/simulated/floor/plasteel/stairs/right,
+/area/ghost_bar)
 "fgP" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/reedbush,
@@ -6851,6 +7143,11 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
+"foh" = (
+/obj/structure/table/reinforced,
+/obj/item/lighter/zippo/contractor,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "foF" = (
 /obj/effect/decal/nanotrasen_logo/n4,
 /turf/simulated/floor/plasteel,
@@ -6904,6 +7201,10 @@
 "frK" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/administration)
+"frZ" = (
+/obj/machinery/economy/arcade/claw,
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "fsg" = (
 /obj/item/flag/syndi,
 /obj/effect/turf_decal/miscellaneous/goldensiding/corner{
@@ -7284,6 +7585,10 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/control)
+"fKf" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "fLa" = (
 /obj/structure/railing{
 	dir = 8
@@ -7660,6 +7965,9 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/wizard_station)
+"gfm" = (
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "gfN" = (
 /obj/effect/bump_teleporter{
 	id = "Synd13";
@@ -7671,6 +7979,11 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
+"gfZ" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "ggq" = (
 /obj/effect/turf_decal/miscellaneous/goldensiding{
 	dir = 6
@@ -7870,6 +8183,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
+"goi" = (
+/obj/effect/mob_spawn/human/alive/ghost_bar,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "goZ" = (
 /obj/machinery/flasher{
 	id = "syndie_FB_cells";
@@ -8105,6 +8422,13 @@
 	},
 /turf/simulated/floor/carpet/cyan,
 /area/centcom/ss220/general)
+"gxG" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "gxS" = (
 /obj/structure/fence/corner{
 	color = "#b0b7c6";
@@ -8316,6 +8640,12 @@
 "gDW" = (
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
+"gDY" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "gEl" = (
 /obj/machinery/light/small/directional/east,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -8428,6 +8758,12 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
+"gJw" = (
+/obj/machinery/economy/vending/autodrobe,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "gJB" = (
 /obj/machinery/economy/vending/cola/free,
 /turf/simulated/floor/plasteel{
@@ -8500,6 +8836,12 @@
 "gKF" = (
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership/elite_squad)
+"gMc" = (
+/obj/machinery/economy/vending/tool/free,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "gMt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -8664,6 +9006,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"gVg" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "gVh" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/ore_box,
@@ -8862,6 +9210,12 @@
 	dir = 6
 	},
 /area/shuttle/syndicate)
+"hdj" = (
+/obj/structure/stone_tile/surrounding/burnt,
+/obj/structure/stone_tile/center/burnt,
+/obj/effect/landmark/spawner/bubblegum,
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "hdo" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo17"
@@ -8915,6 +9269,13 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/transport)
+"heL" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "heV" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'FOURTH WALL'.";
@@ -8959,6 +9320,13 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
+"hha" = (
+/obj/machinery/door/window{
+	dir = 8;
+	opacity = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "hhA" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -8971,6 +9339,13 @@
 "hhK" = (
 /turf/simulated/wall/indestructible/fakedoor,
 /area/ninja/holding)
+"hhQ" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "hii" = (
 /obj/structure/window/reinforced{
 	color = "red";
@@ -9087,6 +9462,12 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
+"hnb" = (
+/obj/machinery/computer/arcade/recruiter{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "hns" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel/dark,
@@ -9314,6 +9695,21 @@
 /obj/effect/mapping_helpers/light,
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
+"hva" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Toilet";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "hvm" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/portable/canister/oxygen,
@@ -9332,6 +9728,12 @@
 /obj/structure/window/full/basic,
 /turf/simulated/floor/grass/no_creep,
 /area/trader_station/sol)
+"hwh" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "hwj" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -9460,6 +9862,11 @@
 	icon_state = "warndarkgreyred"
 	},
 /area/syndicate_mothership)
+"hDQ" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/ghost_bar)
 "hDW" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/effect/mapping_helpers/light,
@@ -9637,6 +10044,10 @@
 	icon_state = "darkredalt"
 	},
 /area/syndicate_mothership/control)
+"hIJ" = (
+/obj/structure/railing,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "hIM" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -9754,6 +10165,30 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
+"hMl" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/raw_bacon,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/catfishmeat,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/obj/item/reagent_containers/food/snacks/spaghetti,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "hMm" = (
 /obj/structure/barricade{
 	icon = 'icons/turf/shuttle.dmi';
@@ -9898,6 +10333,14 @@
 /obj/item/kitchen/knife/combat,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
+"hPV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "hQe" = (
 /obj/structure/chair/sofa/bench/right{
 	cover_color = "#404144";
@@ -9956,6 +10399,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
+"hVa" = (
+/obj/machinery/computer/arcade/battle{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "hVc" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo18"
@@ -10018,6 +10467,19 @@
 	icon_state = "neutralfull"
 	},
 /area/shuttle/escape)
+"hWK" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "hXd" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "nukeop_outside";
@@ -10200,6 +10662,10 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
+"igP" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space/nearstation)
 "iht" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor/wood/oak,
@@ -10218,6 +10684,12 @@
 	icon_state = "darkyellowcornersalt"
 	},
 /area/syndicate_mothership/cargo)
+"iip" = (
+/obj/structure/chair/stool{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "iiw" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/oak,
@@ -10545,6 +11017,11 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"isq" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/external_no_weld,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "isB" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/medal/gold{
@@ -10807,6 +11284,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/syndicate_mothership/infteam)
+"iAD" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "iAT" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -11443,6 +11924,10 @@
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
+"jgL" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "jhd" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -11471,6 +11956,17 @@
 "jiu" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/admin3)
+"jjL" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"jjW" = (
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "jjX" = (
 /obj/machinery/recharge_station/upgraded,
 /turf/simulated/floor/plasteel/dark{
@@ -11579,6 +12075,15 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
+"jpA" = (
+/obj/structure/mopbucket,
+/obj/item/soap/syndie,
+/obj/item/mop,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "jpY" = (
 /obj/structure/light_fake/small{
 	dir = 1
@@ -12247,12 +12752,26 @@
 	icon_state = "hydrofloor"
 	},
 /area/centcom/ss220/evac)
+"jTa" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/shaker,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "jTq" = (
 /obj/machinery/mech_bay_recharge_port/upgraded{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/admin2)
+"jTG" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "jUW" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -12699,6 +13218,10 @@
 	name = "floor"
 	},
 /area/syndicate_mothership)
+"koB" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "kpq" = (
 /obj/structure/dresser,
 /turf/simulated/floor/carpet/green,
@@ -12907,6 +13430,10 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/general)
+"kzD" = (
+/obj/structure/sign/nosmoking_2,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "kAL" = (
 /obj/item/flashlight/lantern{
 	anchored = 1;
@@ -12930,6 +13457,17 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
+"kBT" = (
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"kBV" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "kBX" = (
 /obj/effect/spawner/window/plastitanium,
 /turf/simulated/floor/plating,
@@ -13073,6 +13611,10 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
+"kFL" = (
+/obj/structure/sign/poster/official/space_cops,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "kGA" = (
 /obj/machinery/cryopod/offstation/right,
 /turf/simulated/floor/wood/fancy/oak,
@@ -13177,10 +13719,40 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
+"kJd" = (
+/obj/machinery/economy/vending/shoedispenser,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "kJs" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"kJv" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/kitchen/knife,
+/obj/item/reagent_containers/food/condiment/enzyme{
+	pixel_y = 5
+	},
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "kJF" = (
 /obj/machinery/optable,
 /obj/machinery/light/directional/west,
@@ -13506,6 +14078,10 @@
 /obj/structure/chair/comfy/purp,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"leU" = (
+/obj/structure/marker_beacon/dock_marker,
+/turf/space,
+/area/space/centcomm)
 "leW" = (
 /obj/machinery/economy/vending/magivend,
 /turf/simulated/floor/carpet/black,
@@ -13584,6 +14160,9 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/syndicate_mothership/control)
+"lji" = (
+/turf/simulated/wall/indestructible,
+/area/ghost_bar)
 "ljl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -13630,6 +14209,9 @@
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
+"lmq" = (
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "lmy" = (
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/green,
@@ -13751,6 +14333,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/administration)
+"lrQ" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "lrX" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -13908,6 +14496,13 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership)
+"luQ" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "luW" = (
 /obj/structure/chair/comfy/purp{
 	dir = 1;
@@ -14240,6 +14835,13 @@
 /obj/structure/table/wood/fancy/orange,
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
+"lGh" = (
+/obj/machinery/economy/vending/cigarette,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "lGl" = (
 /obj/structure/bookcase/manuals,
 /obj/item/book/manual/wiki/sop_service,
@@ -14415,6 +15017,16 @@
 "lJY" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"lKi" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "lKj" = (
 /obj/structure/table,
 /obj/item/storage/firstaid,
@@ -14517,6 +15129,13 @@
 	icon_state = "darkyellowalt"
 	},
 /area/centcom/ss220/supply)
+"lMI" = (
+/obj/effect/decal/warning_stripes/northeastcorner,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "lMN" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo19"
@@ -14562,6 +15181,10 @@
 	icon_state = "navybluealt"
 	},
 /area/syndicate_mothership/control)
+"lNp" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "lNA" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -14583,6 +15206,13 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
+"lNS" = (
+/obj/structure/bookcase/random,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "lOi" = (
 /obj/structure/rack/holorack,
 /obj/effect/turf_decal/box/white,
@@ -14686,6 +15316,12 @@
 	icon_state = "cafeteria"
 	},
 /area/ninja/holding)
+"lRa" = (
+/obj/structure/signpost,
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/space/nearstation)
 "lRi" = (
 /obj/structure/light_fake,
 /obj/machinery/optable,
@@ -15115,6 +15751,11 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"mjk" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/storage/box/matches,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "mjx" = (
 /obj/structure/table/glass,
 /obj/item/pizzabox/pizza_bomb/autoarm{
@@ -15362,6 +16003,10 @@
 /obj/effect/decal/syndie_logo,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
+"mrG" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "mrL" = (
 /obj/structure/statue/sandstone/assistant{
 	anchored = 1;
@@ -15775,6 +16420,12 @@
 /obj/effect/decal/warning_stripes/red,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"mNm" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "mND" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plasteel{
@@ -15819,6 +16470,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin1)
+"mPY" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	name = "Badmin's Bar"
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "mQn" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -15849,6 +16506,9 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/centcom/ss220/supply)
+"mRh" = (
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "mRk" = (
 /obj/machinery/door/poddoor/multi_tile/four_tile_hor{
 	id_tag = "nukeop_ready"
@@ -15894,6 +16554,28 @@
 	icon_state = "grimy"
 	},
 /area/trader_station/sol)
+"mTy" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/potato,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/whitebeet,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/rice,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/icepepper,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
+/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/obj/item/reagent_containers/food/snacks/grown/cherries,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/deus,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "mTB" = (
 /turf/simulated/floor/beach/away/water{
 	water_overlay_image = null
@@ -16009,12 +16691,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin1)
+"mZU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "nar" = (
 /obj/machinery/cryopod/offstation{
 	dir = 2
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"nau" = (
+/obj/machinery/prize_counter,
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "naF" = (
 /obj/structure/table/wood,
 /obj/item/candle,
@@ -16223,6 +16917,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/syndicate_mothership/infteam)
+"niL" = (
+/obj/machinery/washing_machine,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "niY" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/stripes/line,
@@ -16381,6 +17084,11 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
+"npr" = (
+/obj/structure/lattice,
+/obj/machinery/light/small,
+/turf/space,
+/area/space/nearstation)
 "npy" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo15"
@@ -16529,6 +17237,14 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
+"nuU" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "nuW" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -16649,6 +17365,12 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/administration)
+"nBr" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "nBx" = (
 /obj/structure/table/reinforced,
 /obj/item/borg/upgrade/selfrepair,
@@ -16682,6 +17404,12 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
+"nCJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/stairs/left,
+/area/ghost_bar)
 "nCM" = (
 /obj/structure/light_fake{
 	dir = 1
@@ -16886,6 +17614,12 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
+"nJx" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "nKl" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/admin1)
@@ -16913,6 +17647,10 @@
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/general)
+"nLP" = (
+/obj/structure/sign/poster/official/random,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "nMa" = (
 /turf/simulated/floor/beach/away/coastline{
 	water_overlay_image = null
@@ -17123,6 +17861,9 @@
 "nUM" = (
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)
+"nVt" = (
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ghost_bar)
 "nVW" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
@@ -17170,6 +17911,12 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/evac)
+"nXK" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "nZe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/beer/upgraded{
@@ -17235,6 +17982,43 @@
 	water_overlay_image = null
 	},
 /area/syndicate_mothership/outside)
+"oaE" = (
+/obj/structure/rack,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/tank/internals/plasmaman/belt/full,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "obm" = (
 /obj/structure/chair/comfy/red{
 	dir = 8
@@ -17246,6 +18030,15 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
+"obL" = (
+/turf/simulated/wall/indestructible/fakeglass,
+/area/ghost_bar)
+"occ" = (
+/obj/machinery/economy/merch{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "ocR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17315,6 +18108,14 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
+"ohx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "ohV" = (
 /obj/machinery/computer/shuttle/sst,
 /turf/simulated/floor/carpet/black,
@@ -17498,6 +18299,12 @@
 /obj/effect/turf_decal/bot_white,
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
+"opP" = (
+/obj/machinery/economy/vending/clothing,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "oqn" = (
 /obj/machinery/door/airlock{
 	name = "Кошерная спальна"
@@ -17517,6 +18324,11 @@
 "orn" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/syndicate)
+"orw" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "orK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -17566,6 +18378,12 @@
 	icon_state = "darkbluealt"
 	},
 /area/centcom/ss220/admin1)
+"otz" = (
+/obj/structure/table,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "otG" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/blood,
@@ -17590,6 +18408,11 @@
 "ouy" = (
 /turf/simulated/floor/grass/jungle/no_creep,
 /area/wizard_station)
+"ouK" = (
+/obj/item/flashlight/lamp,
+/obj/structure/table/wood,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "ouY" = (
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -17855,6 +18678,12 @@
 /obj/structure/railing,
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
+"oEA" = (
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "oEC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery/red,
@@ -18169,6 +18998,33 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/evac)
+"oSa" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = null
+	},
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/wheat,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/vanillapod,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/sugarcane,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/oat,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/grapes,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/corn,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/chili,
+/obj/item/reagent_containers/food/snacks/grown/carrot,
+/obj/item/reagent_containers/food/snacks/grown/apple,
+/obj/item/reagent_containers/food/snacks/grown/ambrosia/vulgaris,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "oSk" = (
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
@@ -18378,6 +19234,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/elite_squad)
+"oZv" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ghost_bar)
 "oZO" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
@@ -18540,6 +19402,15 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
+"peN" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "pfz" = (
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/evac)
@@ -18615,6 +19486,21 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"pkG" = (
+/obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Toilet";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "plv" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/spawner/syndie,
@@ -18751,6 +19637,13 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
+"psK" = (
+/obj/machinery/economy/slot_machine,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "psX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -18842,6 +19735,10 @@
 	icon_state = "navyblue"
 	},
 /area/centcom/ss220/admin3)
+"pvO" = (
+/obj/structure/ghost_bar_cryopod,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "pwb" = (
 /obj/structure/bed{
 	dir = 4
@@ -18929,6 +19826,15 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"pyb" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/item/deck/tarot,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "pyl" = (
 /obj/structure/closet/crate/secure/bin{
 	color = "36373a"
@@ -19093,6 +19999,12 @@
 /obj/machinery/economy/vending/cigarette/free,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
+"pHW" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "pIL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Брифинг";
@@ -19173,6 +20085,11 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
+"pKj" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "pKm" = (
 /obj/item/kirbyplants,
 /obj/structure/curtain/black{
@@ -19185,6 +20102,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/elite_squad)
+"pLl" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "pLm" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -19367,6 +20290,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/evac)
+"pPq" = (
+/obj/structure/musician/piano,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "pPs" = (
 /obj/machinery/computer/camera_advanced{
 	dir = 1
@@ -19507,6 +20434,13 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership/infteam)
+"pWQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/soda{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "pXL" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/item/gun/medbeam,
@@ -19808,6 +20742,10 @@
 	icon_state = "darkyellowalt"
 	},
 /area/syndicate_mothership/cargo)
+"qgH" = (
+/obj/structure/railing/corner,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "qgL" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -19827,6 +20765,16 @@
 	icon_state = "warndarkgreycornerred"
 	},
 /area/syndicate_mothership)
+"qkF" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
+"qkG" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "qla" = (
 /obj/structure/chair/office/light,
 /turf/simulated/floor/plasteel{
@@ -19864,6 +20812,9 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/control)
+"qlB" = (
+/turf/simulated/wall/indestructible/necropolis,
+/area/ruin/space/bubblegum_arena)
 "qmm" = (
 /obj/machinery/economy/vending/snack/free{
 	name = "\improper Wizmore Chocolate Corp"
@@ -19880,6 +20831,10 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership/jail)
+"qni" = (
+/obj/structure/stone_tile/slab/cracked,
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "qnl" = (
 /obj/structure/mirror{
 	pixel_x = 30
@@ -20009,6 +20964,11 @@
 	icon_state = "darkgrey"
 	},
 /area/syndicate_mothership)
+"qsr" = (
+/obj/structure/table/wood,
+/obj/item/deck/unum,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "qsF" = (
 /obj/structure/curtain/black{
 	pixel_y = 32;
@@ -20025,6 +20985,13 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
+"que" = (
+/obj/structure/table,
+/obj/item/storage/fancy/crayons,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "quh" = (
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "SIT_outside"
@@ -20041,6 +21008,12 @@
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
+"quV" = (
+/obj/structure/chair/stool{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "qvc" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel{
@@ -20458,6 +21431,11 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/admin1)
+"qLv" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "qLF" = (
 /obj/machinery/economy/vending/coffee/free,
 /turf/simulated/floor/plasteel/dark,
@@ -20465,6 +21443,11 @@
 "qLO" = (
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
+"qLY" = (
+/turf/simulated/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ghost_bar)
 "qNg" = (
 /obj/structure/bookcase/random,
 /obj/effect/decal/cleanable/cobweb,
@@ -20528,6 +21511,10 @@
 	name = "floor"
 	},
 /area/syndicate_mothership/elite_squad)
+"qOS" = (
+/obj/structure/bookcase/random,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "qPk" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership;
@@ -20600,6 +21587,12 @@
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
+"qRW" = (
+/obj/structure/statue/sandstone/assistant,
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/space/nearstation)
 "qSC" = (
 /obj/structure/table/glass,
 /obj/item/clipboard{
@@ -20750,6 +21743,12 @@
 	},
 /turf/simulated/floor/mineral/abductor,
 /area/centcom/ss220/bar)
+"qXL" = (
+/obj/effect/decal/warning_stripes/white/partial,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "qYl" = (
 /obj/machinery/conveyor/east{
 	id = "QMLoad"
@@ -20921,6 +21920,11 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
+"rfR" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "rgd" = (
 /obj/structure/table/abductor,
 /obj/effect/spawner/lootdrop/CCfood/desert,
@@ -20970,6 +21974,11 @@
 /obj/mecha/working/ripley/firefighter,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"rhf" = (
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/ghost_bar)
 "rhB" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "ferry_away";
@@ -21388,6 +22397,12 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
+"rtU" = (
+/turf/simulated/floor/wood{
+	broken = 1;
+	icon_state = "wood-broken"
+	},
+/area/ghost_bar)
 "rus" = (
 /obj/structure/light_fake/spot{
 	dir = 4
@@ -21584,6 +22599,10 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
+"rDd" = (
+/obj/machinery/door/airlock/external_no_weld,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "rDf" = (
 /obj/machinery/economy/vending/chinese/free,
 /turf/simulated/floor/plasteel/dark,
@@ -21605,6 +22624,9 @@
 	},
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
+"rDY" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "rEF" = (
 /obj/machinery/economy/vending/security,
 /turf/simulated/floor/plasteel{
@@ -21665,6 +22687,11 @@
 /obj/item/flag/nt,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/evac)
+"rIB" = (
+/turf/simulated/floor/plating/airless{
+	icon_state = "asteroidplating"
+	},
+/area/space/nearstation)
 "rIO" = (
 /obj/structure/chair/sofa/bench/right{
 	cover_color = "#68452a";
@@ -21743,6 +22770,10 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/trader_station/sol)
+"rLG" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/carpet/arcade,
+/area/ghost_bar)
 "rLQ" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -21998,6 +23029,12 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/evac)
+"rUm" = (
+/obj/machinery/economy/vending/suitdispenser,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "rUo" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -22320,6 +23357,10 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
+"seS" = (
+/obj/machinery/economy/vending/boozeomat,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "sfM" = (
 /obj/structure/table,
 /obj/item/storage/fancy/crayons,
@@ -22704,6 +23745,37 @@
 	icon_state = "darkfull"
 	},
 /area/syndicate_mothership/cargo)
+"sCy" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/tank/internals/emergency_oxygen/double/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/clothing/mask/breath/vox,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
+"sCH" = (
+/turf/simulated/floor/plating{
+	icon_state = "asteroidplating"
+	},
+/area/ghost_bar)
 "sCI" = (
 /obj/machinery/computer/security{
 	dir = 4;
@@ -22828,6 +23900,11 @@
 	icon_state = "grimy"
 	},
 /area/centcom/ss220/general)
+"sFG" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "sFV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -23035,6 +24112,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"sNv" = (
+/obj/structure/closet/wardrobe/xenos,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/ghost_bar)
 "sNA" = (
 /obj/structure/fence{
 	invulnerable = 1
@@ -23510,6 +24591,12 @@
 /obj/effect/landmark/spawner/syndicate_infiltrator_leader,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/infteam)
+"tin" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "tiB" = (
 /obj/structure/light_fake/small{
 	dir = 1
@@ -23653,6 +24740,11 @@
 	icon_state = "darkredcornersalt"
 	},
 /area/syndicate_mothership/jail)
+"tqJ" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/deck/cards/black,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "tqQ" = (
 /obj/structure/sink/directional/north,
 /turf/simulated/floor/plasteel{
@@ -24004,6 +25096,10 @@
 	icon_state = "blackfull"
 	},
 /area/syndicate_mothership)
+"tEY" = (
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/plating/asteroid/ancient/airless,
+/area/space/nearstation)
 "tEZ" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -24017,6 +25113,12 @@
 	icon_state = "darkred"
 	},
 /area/syndicate_mothership/infteam)
+"tGT" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Port Asteroid Maintenance"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "tHa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -24030,6 +25132,15 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
+"tHr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "tHw" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -24222,6 +25333,12 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/bar)
+"tNd" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "tNi" = (
 /obj/structure/table,
 /turf/simulated/floor/plasteel{
@@ -24250,6 +25367,9 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/evac)
+"tPb" = (
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "tPc" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/indestructible
@@ -24392,6 +25512,12 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
+"tVb" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "tVr" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -24513,6 +25639,19 @@
 /obj/effect/landmark/abductor/scientist,
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
+"tZr" = (
+/obj/structure/table/wood,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/obj/item/pen/multi,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "tZB" = (
 /obj/machinery/computer/shuttle/ert{
 	dir = 8
@@ -24849,6 +25988,10 @@
 /obj/docking_port/mobile/assault_pod,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
+"uou" = (
+/obj/effect/decal/warning_stripes/north,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "uow" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24860,6 +26003,10 @@
 /obj/structure/flora/grass/jungle,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
+"uoP" = (
+/obj/structure/railing,
+/turf/simulated/floor/plasteel/dark,
+/area/ghost_bar)
 "uoU" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo4"
@@ -24945,6 +26092,17 @@
 	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/gamma/space)
+"uss" = (
+/obj/structure/table/wood,
+/turf/simulated/floor/plating/asteroid/ancient,
+/area/ghost_bar)
+"usH" = (
+/obj/structure/dresser,
+/obj/machinery/light/small,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/ghost_bar)
 "utc" = (
 /obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
@@ -25254,6 +26412,11 @@
 	},
 /turf/simulated/floor/fakespace,
 /area/centcom/ss220/bar)
+"uGl" = (
+/turf/simulated/floor/plasteel/stairs/medium{
+	dir = 1
+	},
+/area/ghost_bar)
 "uGR" = (
 /obj/structure/chair/comfy/red,
 /turf/simulated/floor/carpet/arcade,
@@ -25532,6 +26695,12 @@
 /obj/structure/sink/directional/west,
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/evac)
+"uRl" = (
+/obj/structure/chair/stool/bar{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "uRt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -25722,6 +26891,14 @@
 	icon_state = "warndarkgreycornerred"
 	},
 /area/syndicate_mothership/infteam)
+"uYB" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/stairs/left{
+	dir = 1
+	},
+/area/ghost_bar)
 "uYN" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -25857,6 +27034,18 @@
 /obj/machinery/photocopier/syndie,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/infteam)
+"vgK" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Toilet";
+	opacity = 1
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "vgR" = (
 /obj/machinery/computer/card/centcom{
 	dir = 1
@@ -26689,6 +27878,16 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
+"vOw" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/freezer,
+/area/ghost_bar)
 "vOJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -26720,6 +27919,10 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"vPn" = (
+/obj/structure/chair/stool,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "vPu" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/siding/wood,
@@ -26818,6 +28021,9 @@
 	icon_state = "darkbluealt"
 	},
 /area/shuttle/administration)
+"vSJ" = (
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "vTX" = (
 /obj/machinery/economy/vending/boozeomat,
 /turf/simulated/floor/plasteel/freezer,
@@ -27231,6 +28437,10 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership)
+"wkT" = (
+/obj/structure/sign/vacuum/external,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "wlp" = (
 /obj/machinery/economy/vending/chinese/free,
 /turf/simulated/floor/carpet/black,
@@ -27251,6 +28461,11 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"wmw" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/ashtray/plastic,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "wmC" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -27302,6 +28517,9 @@
 	icon_state = "grimy"
 	},
 /area/syndicate_mothership/elite_squad)
+"wqB" = (
+/turf/simulated/mineral/ancient/outer,
+/area/space/nearstation)
 "wqZ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -27929,6 +29147,12 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
+"wQi" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "wQK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -27951,6 +29175,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/administration)
+"wRr" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol,
+/turf/simulated/wall/indestructible/riveted,
+/area/ghost_bar)
 "wRu" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/tree/jungle,
@@ -28082,6 +29310,12 @@
 	icon_state = "grimy"
 	},
 /area/trader_station/sol)
+"wYf" = (
+/obj/structure/railing,
+/turf/simulated/floor/plasteel/stairs/left{
+	dir = 8
+	},
+/area/ghost_bar)
 "wYt" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/carpet/black,
@@ -28999,7 +30233,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "xzc" = (
-/mob/living/carbon/human/monkey,
+/mob/living/carbon/human/monkey/magic,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
 "xzF" = (
@@ -29043,6 +30277,10 @@
 	icon_state = "rampbottom"
 	},
 /area/syndicate_mothership/elite_squad)
+"xBr" = (
+/obj/structure/bookcase/random,
+/turf/simulated/floor/carpet/green,
+/area/ghost_bar)
 "xBZ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkfull"
@@ -29278,6 +30516,11 @@
 	icon_state = "whitebluecorner"
 	},
 /area/centcom/ss220/general)
+"xOl" = (
+/obj/structure/table/wood,
+/obj/item/storage/pill_bottle/dice,
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "xOp" = (
 /obj/structure/table/wood{
 	color = "#996633"
@@ -29335,10 +30578,20 @@
 /obj/structure/flora/bush,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/control)
+"xRZ" = (
+/obj/structure/stone_tile/slab/burnt,
+/turf/simulated/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/space/bubblegum_arena)
 "xSq" = (
 /obj/machinery/economy/vending/dinnerware,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
+"xSt" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "xSv" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -29394,6 +30647,11 @@
 	icon_state = "darkred"
 	},
 /area/syndicate_mothership/infteam)
+"xVC" = (
+/obj/structure/table/reinforced,
+/obj/item/ashtray/glass,
+/turf/simulated/floor/carpet/black,
+/area/ghost_bar)
 "xVK" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -29465,6 +30723,9 @@
 "xYo" = (
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
+"xYG" = (
+/turf/simulated/floor/indestructible/necropolis,
+/area/ruin/space/bubblegum_arena)
 "xZd" = (
 /obj/machinery/economy/vending/nta/green,
 /turf/simulated/floor/plasteel/dark{
@@ -29590,6 +30851,15 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/escape)
+"ydG" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
+/turf/simulated/floor/wood,
+/area/ghost_bar)
 "yex" = (
 /obj/item/syndicatedetonator{
 	desc = "Радиус взрыва: 255x255x255";
@@ -29653,6 +30923,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/elite_squad)
+"yft" = (
+/obj/machinery/processor,
+/turf/simulated/floor/plasteel{
+	icon_state = "cafeteria"
+	},
+/area/ghost_bar)
 "yfK" = (
 /obj/machinery/economy/vending/cola/free,
 /turf/simulated/floor/carpet/black,
@@ -78052,6 +79328,39 @@ adJ
 adJ
 adJ
 adJ
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
 adJ
 adJ
 adJ
@@ -78060,6 +79369,9 @@ adJ
 adJ
 adJ
 adJ
+eYM
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -78067,50 +79379,14 @@ adJ
 adJ
 adJ
 adJ
+eYM
+wqB
+eYM
+wqB
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -78309,12 +79585,51 @@ adJ
 adJ
 adJ
 adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
 adJ
 adJ
 adJ
 adJ
 adJ
 adJ
+eYM
+eYM
+wqB
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -78322,6 +79637,14 @@ adJ
 adJ
 adJ
 adJ
+eYM
+eYM
+wqB
+wqB
+eYM
+eYM
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -78333,55 +79656,8 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -78566,15 +79842,67 @@ adJ
 adJ
 adJ
 adJ
+qlB
+xYG
+mRh
+mRh
+mRh
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+mRh
+mRh
+mRh
+xYG
+qlB
 adJ
 adJ
 adJ
 adJ
 adJ
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
 adJ
+tEY
+eYM
+eYM
+eYM
+eYM
+eYM
+eYM
+eYM
+eYM
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -78585,60 +79913,8 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+cjQ
+wqB
 adJ
 adJ
 adJ
@@ -78823,68 +80099,68 @@ adJ
 adJ
 adJ
 adJ
+qlB
+xYG
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+xYG
+qlB
 adJ
 adJ
 adJ
 adJ
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+eYM
+eYM
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+eYM
+eYM
+wqB
+wqB
+wqB
+eYM
+eYM
+wqB
+eYM
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -79080,68 +80356,68 @@ adJ
 adJ
 adJ
 adJ
+qlB
+xYG
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+xYG
+qlB
 adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+eYM
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+eYM
+eYM
+eYM
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -79337,80 +80613,80 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+adJ
+adJ
+igP
+wqB
+wqB
+wqB
+vSJ
+vSJ
+obL
+obL
+obL
+obL
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+wqB
+wqB
+wqB
+wqB
+wqB
+eYM
+eYM
+eYM
+eYM
+eYM
+eYM
+adJ
+adJ
+efK
+eYM
+eYM
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -79594,81 +80870,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+igP
+wqB
+wqB
+vSJ
+niL
+sFG
+sFG
+sFG
+sFG
+hPV
+fca
+cUj
+iAD
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+wqB
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -79851,81 +81127,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+igP
+vSJ
+gMc
+sFG
+gxG
+evV
+sFG
+lKi
+vSJ
+cUj
+cdT
+vSJ
+jpA
+evk
+evk
+vSJ
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+vSJ
+obL
+obL
+vSJ
+vSJ
+wqB
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -80108,81 +81384,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+leU
+adJ
+adJ
+adJ
+leU
+adJ
+adJ
+adJ
+adJ
+adJ
+igP
+vSJ
+boY
+sFG
+que
+sCy
+sFG
+gJw
+vSJ
+dnu
+cUj
+vSJ
+cUj
+cUj
+cUj
+vSJ
+wqB
+wqB
+wqB
+wqB
+wqB
+vSJ
+vSJ
+csk
+uss
+bzF
+vSJ
+wqB
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -80365,81 +81641,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+atq
+atq
+atq
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+igP
+vSJ
+rUm
+sFG
+otz
+oaE
+sFG
+opP
+vSJ
+dnu
+cUj
+cUj
+cUj
+cUj
+cUj
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+wRr
+oZv
+aqx
+aqx
+nVt
+vSJ
+wqB
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -80622,80 +81898,80 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+atq
+kBV
+atq
+atq
+igP
+leU
+adJ
+igP
+adJ
+igP
+vSJ
+kJd
+sFG
+sFG
+sFG
+sFG
+usH
+vSJ
+hWK
+vOw
+hva
+pkG
+vgK
+koB
+aYV
+nVt
+sCH
+sCH
+sCH
+sCH
+sCH
+sCH
+sCH
+sCH
+sCH
+vSJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -80879,79 +82155,79 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+rDY
+rDY
+nJx
+atq
+igP
+igP
+igP
+igP
+igP
+npr
+vSJ
+obL
+obL
+dGy
+qLY
+obL
+obL
+vSJ
+vSJ
+vSJ
+kzD
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+mZU
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+nVt
+vSJ
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -81136,79 +82412,79 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+goi
+rDY
+nJx
+atq
+vSJ
+obL
+obL
+obL
+obL
+vSJ
+wkT
+lMI
+tPb
+tPb
+tPb
+tPb
+tPb
+emX
+nCJ
+eFq
+uoP
+cDO
+xSt
+ydG
+hwh
+jTG
+tPb
+bMH
+psK
+obL
+oEA
+hnb
+hVa
+vSJ
+nVt
+vSJ
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -81393,79 +82669,79 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+hhQ
+rDY
+rDY
+rDd
+qXL
+sFG
+dYd
+dYd
+sFG
+dYd
+isq
+uou
+tPb
+tPb
+tPb
+tPb
+tPb
+tPb
+fgL
+eFq
+uoP
+tPb
+jjL
+tqJ
+wmw
+tin
+tPb
+uRl
+uRl
+obL
+egL
+egL
+egL
+vSJ
+sCH
+vSJ
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -81650,79 +82926,79 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xRZ
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+pvO
+rDY
+rDY
+rDd
+qXL
+dYd
+dYd
+sFG
+dYd
+sFG
+isq
+uou
+tPb
+wQi
+wQi
+wQi
+tPb
+vSJ
+dCl
+dGy
+wYf
+tPb
+cLl
+lmq
+lmq
+tPb
+tPb
+tPb
+tPb
+mPY
+gfm
+gfm
+gfm
+vSJ
+sCH
+vSJ
+vSJ
+wqB
 adJ
 adJ
 adJ
@@ -81907,80 +83183,80 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xRZ
+xRZ
+xRZ
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+rDY
+rDY
+rDY
+atq
+gDY
+obL
+obL
+obL
+obL
+vSJ
+vSJ
+heL
+tPb
+qsr
+qLv
+ewU
+aMU
+vSJ
+pPq
+tPb
+pHW
+tPb
+tPb
+tPb
+tPb
+tPb
+tPb
+tPb
+tPb
+gfm
+gfm
+gfm
+rLG
+vSJ
+nVt
+vSJ
+vSJ
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -82164,81 +83440,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qni
+qni
+xRZ
+xRZ
+xRZ
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+fKf
+sNv
+lNp
+atq
+igP
+igP
+igP
+igP
+igP
+npr
+bHi
+qOS
+tPb
+lrQ
+lrQ
+lrQ
+tPb
+vSJ
+peN
+tPb
+tPb
+tPb
+tPb
+tPb
+tPb
+tPb
+tVb
+tVb
+tPb
+obL
+gfm
+iip
+iip
+vSJ
+nVt
+mNm
+vSJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -82421,81 +83697,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qni
+qni
+qni
+hdj
+xRZ
+xRZ
+xRZ
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+qlB
+adJ
+atq
+efO
+efO
+efO
+atq
+igP
+leU
+adJ
+adJ
+adJ
+igP
+obL
+tPb
+tPb
+cCG
+cCG
+cCG
+tPb
+vSJ
+hDQ
+tPb
+tPb
+tPb
+rhf
+tPb
+tPb
+tPb
+wmw
+mjk
+tPb
+obL
+nau
+frZ
+frZ
+vSJ
+sCH
+nVt
+vSJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -82678,81 +83954,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qni
+qni
+qni
+qni
+xRZ
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+dEt
+dEt
+dEt
+adJ
+adJ
+adJ
+eYM
+eYM
+eYM
+igP
+obL
+tPb
+tPb
+cCG
+wQi
+cCG
+mrG
+vSJ
+gVg
+cAZ
+cAZ
+cAZ
+cAZ
+cAZ
+lmq
+tPb
+eUO
+eUO
+ceb
+lji
+obL
+obL
+obL
+vSJ
+sCH
+nVt
+vSJ
+wqB
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -82935,81 +84211,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xRZ
+xRZ
+qni
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+leU
+adJ
+adJ
+adJ
+leU
+eYM
+rIB
+eYM
+rIB
+eYM
+eYM
+obL
+tPb
+tPb
+bJA
+qLv
+pLl
+qOS
+kFL
+hha
+jgL
+jgL
+xVC
+jgL
+foh
+coH
+tPb
+tPb
+tPb
+hIJ
+nXK
+lmq
+cTB
+lmq
+vSJ
+sCH
+nVt
+vSJ
+wqB
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -83192,81 +84468,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xRZ
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+eYM
+eYM
+eYM
+qRW
+rIB
+eYM
+vSJ
+lNS
+tPb
+cCG
+lrQ
+cCG
+gfZ
+cMe
+tPb
+tPb
+tPb
+tPb
+tPb
+jgL
+coH
+tPb
+cLl
+tPb
+hIJ
+eFq
+vPn
+rfR
+quV
+vSJ
+sCH
+bKy
+vSJ
+wqB
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -83449,81 +84725,81 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+eYM
+eYM
+eYM
+eYM
+lRa
+eYM
+eYM
+wqB
+vSJ
+xBr
+tPb
+cCG
+cCG
+cCG
+qOS
+vSJ
+tPb
+tPb
+tPb
+tPb
+tPb
+xVC
+coH
+tPb
+tPb
+lmq
+dTs
+dhV
+eFq
+eFq
+bil
+vSJ
+sCH
+vSJ
+vSJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -83706,80 +84982,80 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+eYM
+eYM
+eYM
+eYM
+eYM
+eYM
+rIB
+wqB
+wqB
+vSJ
+obL
+qkG
+qkG
+qkG
+qkG
+obL
+vSJ
+nBr
+tPb
+daj
+pWQ
+jTa
+jgL
+coH
+tPb
+tPb
+lmq
+lmq
+uGl
+eFq
+eFq
+eFq
+vSJ
+nVt
+vSJ
+wqB
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -83963,80 +85239,80 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+eYM
+wqB
+eYM
+eYM
+eYM
+eYM
+eYM
+wqB
+wqB
+vSJ
+qOS
+tPb
+tPb
+tPb
+tPb
+tPb
+vSJ
+seS
+aix
+vSJ
+vSJ
+vSJ
+vSJ
+lGh
+tPb
+tPb
+lmq
+qgH
+uYB
+eFq
+eFq
+eFq
+tGT
+ohx
+vSJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -84220,80 +85496,80 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+wqB
+wqB
+wqB
+eYM
+eYM
+wqB
+wqB
+wqB
+vSJ
+heL
+tPb
+eik
+kBT
+boD
+luQ
+vSJ
+tHr
+orw
+oSa
+mTy
+hMl
+vSJ
+tPb
+tPb
+cLl
+tPb
+hIJ
+eFq
+vPn
+rfR
+quV
+vSJ
+vSJ
+vSJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -84477,78 +85753,78 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+vSJ
+occ
+tPb
+eik
+nuU
+tZr
+afu
+vSJ
+ePh
+orw
+orw
+orw
+orw
+cKR
+tPb
+tPb
+tVb
+tVb
+hIJ
+dyR
+lmq
+tNd
+lmq
+vSJ
+wqB
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -84734,77 +86010,77 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+vSJ
+ouK
+qkF
+eik
+pyb
+xOl
+afu
+cDK
+yft
+kJv
+blD
+dkL
+fbm
+vSJ
+rtU
+tPb
+wmw
+pKj
+pHW
+vSJ
+nLP
+nLP
+vSJ
+vSJ
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -84991,76 +86267,76 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+wqB
+wqB
+wqB
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+nLP
+tPb
+tPb
+eUO
+eUO
+tPb
+vSJ
+wqB
+wqB
+wqB
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -85248,75 +86524,75 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+vSJ
+tPb
+jjW
+tPb
+vSJ
+vSJ
+vSJ
+wqB
+wqB
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -85505,74 +86781,74 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+vSJ
+vSJ
+vSJ
+vSJ
+vSJ
+wqB
+wqB
+wqB
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -85762,74 +87038,74 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+qlB
+xYG
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+eTT
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+xYG
+qlB
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+eYM
+eYM
+wqB
+wqB
+wqB
+eYM
+adJ
+adJ
+eYM
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+wqB
+vSJ
+wqB
+wqB
+eYM
+eYM
+wqB
 adJ
 adJ
 adJ
@@ -86019,6 +87295,39 @@ adJ
 adJ
 adJ
 adJ
+qlB
+xYG
+mRh
+mRh
+mRh
+mRh
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+mRh
+mRh
+mRh
+mRh
+xYG
+qlB
 adJ
 adJ
 adJ
@@ -86033,60 +87342,27 @@ adJ
 adJ
 adJ
 adJ
+eYM
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+wqB
+eYM
+eYM
+wqB
+wqB
+wqB
+wqB
+vSJ
+wqB
+eYM
+eYM
+wqB
+wqB
 adJ
 adJ
 adJ
@@ -86276,6 +87552,39 @@ adJ
 adJ
 adJ
 adJ
+qlB
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+xYG
+qlB
 adJ
 adJ
 adJ
@@ -86291,6 +87600,8 @@ adJ
 adJ
 adJ
 adJ
+eYM
+eYM
 adJ
 adJ
 adJ
@@ -86298,48 +87609,13 @@ adJ
 adJ
 adJ
 adJ
+eYM
+eYM
+eYM
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+wqB
+wqB
+eYM
 adJ
 adJ
 adJ
@@ -86533,6 +87809,39 @@ adJ
 adJ
 adJ
 adJ
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
+qlB
 adJ
 adJ
 adJ
@@ -86564,40 +87873,7 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+wqB
 adJ
 adJ
 adJ


### PR DESCRIPTION
## Что этот PR делает
Порт недостающего с оффов после обновы
 - Арена Бубли
 - Госткафе (хз зачем, надо будет ХОТЯ БЫ портануть нормальный со Скайрата)
 - Магическая мартышка у мага

## Почему это хорошо для игры
Устраняем недостаток функционала

## Изображения изменений
Мапдифф

## Тестирование
Побегал по госткафе, умным взглядом поглядел на арену

## Changelog

:cl:
tweak: Актуализация Центком уровня после обновы с оффами
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
