### PR TITLE
Tweak: Recolor comfy chairs, fix corp armrest

### DIFF
--- a/modular_ss220/aesthetics/chairs/code/chairs.dm
+++ b/modular_ss220/aesthetics/chairs/code/chairs.dm
@@ -14,17 +14,20 @@
 	icon = 'icons/obj/chairs.dmi'
 
 // Recoloring comfy's
-/obj/structure/chair/comfy/brown
-	color = rgb(141, 70, 0)
-
 /obj/structure/chair/comfy/beige
 	color = rgb(240, 240, 200)
 
-/obj/structure/chair/comfy/teal
-	color = rgb(115, 215, 215)
-
 /obj/structure/chair/comfy/black
 	color = rgb(60, 60, 55)
+
+/obj/structure/chair/comfy/red
+	color = rgb(165, 65, 65)
+
+/obj/structure/chair/comfy/brown
+	color = rgb(141, 70, 0)
+
+/obj/structure/chair/comfy/green
+	color = rgb(80, 170, 85)
 
 /obj/structure/chair/comfy/lime
 	color = rgb(185, 210, 115)
@@ -32,14 +35,14 @@
 /obj/structure/chair/comfy/yellow
 	color = rgb(225, 215, 125)
 
-/obj/structure/chair/comfy/purp
-	color = rgb(100, 65, 120)
-
 /obj/structure/chair/comfy/blue
 	color = rgb(80, 125, 220)
 
-/obj/structure/chair/comfy/red
-	color = rgb(165, 65, 65)
+/obj/structure/chair/comfy/teal
+	color = rgb(115, 215, 215)
+
+/obj/structure/chair/comfy/purp
+	color = rgb(100, 65, 120)
 
 /obj/structure/chair/office/dark
 	icon = 'modular_ss220/aesthetics/chairs/icons/chairs.dmi'

--- a/modular_ss220/aesthetics/chairs/code/chairs.dm
+++ b/modular_ss220/aesthetics/chairs/code/chairs.dm
@@ -27,7 +27,10 @@
 	color = rgb(60, 60, 55)
 
 /obj/structure/chair/comfy/lime
-	color = rgb(155, 190, 100)
+	color = rgb(185, 210, 115)
+
+/obj/structure/chair/comfy/yellow
+	color = rgb(225, 215, 125)
 
 /obj/structure/chair/comfy/purp
 	color = rgb(100, 65, 120)

--- a/modular_ss220/aesthetics/chairs/code/chairs.dm
+++ b/modular_ss220/aesthetics/chairs/code/chairs.dm
@@ -15,7 +15,7 @@
 
 // Recoloring comfy's
 /obj/structure/chair/comfy/brown
-	color = rgb(70, 45, 30)
+	color = rgb(141, 70, 0)
 
 /obj/structure/chair/comfy/beige
 	color = rgb(240, 240, 200)
@@ -33,7 +33,7 @@
 	color = rgb(100, 65, 120)
 
 /obj/structure/chair/comfy/blue
-	color = rgb(110, 165, 250)
+	color = rgb(80, 125, 220)
 
 /obj/structure/chair/comfy/red
 	color = rgb(165, 65, 65)

--- a/modular_ss220/aesthetics/chairs/code/chairs.dm
+++ b/modular_ss220/aesthetics/chairs/code/chairs.dm
@@ -7,6 +7,9 @@
 /obj/structure/chair/comfy/corp
 	icon = 'icons/obj/chairs.dmi'
 
+/obj/structure/chair/comfy/corp/GetArmrest()
+	return mutable_appearance('icons/obj/chairs.dmi', "[icon_state]_armrest")
+
 /obj/structure/chair/comfy/shuttle
 	icon = 'icons/obj/chairs.dmi'
 

--- a/modular_ss220/aesthetics/chairs/code/chairs.dm
+++ b/modular_ss220/aesthetics/chairs/code/chairs.dm
@@ -10,6 +10,31 @@
 /obj/structure/chair/comfy/shuttle
 	icon = 'icons/obj/chairs.dmi'
 
+// Recoloring comfy's
+/obj/structure/chair/comfy/brown
+	color = rgb(70, 45, 30)
+
+/obj/structure/chair/comfy/beige
+	color = rgb(240, 240, 200)
+
+/obj/structure/chair/comfy/teal
+	color = rgb(115, 215, 215)
+
+/obj/structure/chair/comfy/black
+	color = rgb(60, 60, 55)
+
+/obj/structure/chair/comfy/lime
+	color = rgb(155, 190, 100)
+
+/obj/structure/chair/comfy/purp
+	color = rgb(100, 65, 120)
+
+/obj/structure/chair/comfy/blue
+	color = rgb(110, 165, 250)
+
+/obj/structure/chair/comfy/red
+	color = rgb(165, 65, 65)
+
 /obj/structure/chair/office/dark
 	icon = 'modular_ss220/aesthetics/chairs/icons/chairs.dmi'
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
 - Исправляет вырвиглазные цвета, немного (jokerge) десатурируя их
 - Исправляет отсутствие armrest у comfy/corp

## Почему это хорошо для игры
Хорошо, когда кресло не выбивается цветом из общей картины

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/08f38162-f3e6-478a-9d03-09ef41741113)

## Тестирование
Посмотрел в игре

## Changelog

:cl:
tweak: Поменял цвет кресел, чтобы не выбивались вырвиглазным цветом
fix: Вернул armrest у chair/comfy/corp
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
