### PR TITLE
Смена логики попаданий снарядов по лежачим

### DIFF
--- a/modular_ss220/balance/code/items/projectiles.dm
+++ b/modular_ss220/balance/code/items/projectiles.dm
@@ -1,2 +1,17 @@
+/obj/item/projectile
+	///If TRUE, hit mobs even if they're on the floor and not our target
+	var/hit_prone_targets = FALSE
+
+/obj/item/projectile/set_angle(new_angle)
+	. = ..()
+	hit_prone_targets = TRUE
+
+/obj/item/ammo_casing/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/firer_source_atom)
+	. = ..()
+	if(!BB)
+		return
+	if(user.a_intent != INTENT_HELP)
+		BB.hit_prone_targets = TRUE
+
 /mob/living/carbon/human/projectile_hit_check(obj/item/projectile/P)
-	return !density
+	return !P.hit_prone_targets && !density


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Теперь, чтобы попасть по лежачей цели нужно:
- Либо накликать на куклу
- Либо быть не в режиме помощи (хелп): дизарм, граб или харм позволят снаряду попадать по лежачим на своей траектории

Также, теперь отраженные снаряды всегда попадают в лежачих.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Легче накликать по лежачим, блоб не контрится лежачими АЕГовцами

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Пострелял с риота по скреллам, пострелял в себя с рефлекторного блоба

## Changelog

:cl:
add: Если вы не в режиме помощи, то снаряды теперь попадают в лежачих на своей траектории
add: Отраженные снаряды теперь попадают в лежачих
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
