### PR TITLE
Fix: Delta brig evidence closet and chargers

### DIFF
--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -19243,12 +19243,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "bJK" = (
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
 /obj/machinery/alarm/directional/east,
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
 "bJO" = (
@@ -54223,11 +54219,6 @@
 /turf/space,
 /area/space)
 "hoh" = (
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/security/general{
 	dir = 4
 	},
@@ -54236,6 +54227,7 @@
 	dir = 4;
 	name = "Evidence"
 	},
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
 "hoj" = (
@@ -75257,11 +75249,6 @@
 	dir = 4;
 	name = "Evidence"
 	},
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/security/general{
 	dir = 4
 	},
@@ -75271,6 +75258,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
 "oxu" = (
@@ -83914,11 +83902,6 @@
 	dir = 8;
 	name = "Evidence"
 	},
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/security/general{
 	dir = 8
 	},
@@ -83927,6 +83910,7 @@
 	c_tag = "Brig Evidence";
 	dir = 8
 	},
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
 "rwY" = (
@@ -91148,11 +91132,6 @@
 	},
 /area/station/hallway/primary/starboard)
 "tYs" = (
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
 /obj/effect/mapping_helpers/airlock/windoor/access/all/security/general{
 	dir = 8
 	},
@@ -91161,6 +91140,7 @@
 	dir = 8;
 	name = "Evidence"
 	},
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
 "tYw" = (
@@ -97509,11 +97489,6 @@
 	},
 /area/station/medical/storage)
 "wjk" = (
-/obj/structure/closet/secure_closet{
-	anchored = 1;
-	name = "Evidence Storage";
-	req_access_txt = "4"
-	},
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
 	d2 = 4;
@@ -97525,6 +97500,7 @@
 	icon_state = "1-4"
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/evidence)
 "wjm" = (

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -57750,6 +57750,9 @@
 "itF" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "itL" = (
@@ -94319,6 +94322,9 @@
 "vbK" = (
 /obj/structure/closet/bombclosetsecurity,
 /obj/effect/decal/warning_stripes/red/hollow,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "vbQ" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Убрал шкафы на замках из комнаты улик, добавил два зарядника в оружейку
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Возможно.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->
![image](https://github.com/ss220club/Paradise-SS220/assets/144079671/ea8c04af-9437-42f0-91f2-c7637093e04a)
![image](https://github.com/ss220club/Paradise-SS220/assets/144079671/52221736-f646-4193-9e17-5a4c6b505fb9)

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->
ноуп
## Changelog

:cl:
add: Дельта: в оружейной добавлено два зарядника для оружия.
fix: Дельта: в комнате для улик в бриге теперь простые шкафы.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
