### PR TITLE
DELETE: Gategun MK2

### DIFF
--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -10,16 +10,11 @@
 	origin_tech = "combat=5;magnets=3;powerstorage=4"
 	selfcharge = TRUE // Selfcharge is enabled and disabled, and used as the away mission tracker
 	can_charge = 0
-	emagged = FALSE
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
 	onTransitZ(new_z = loc.z)
-
-/obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
-	if(emagged)
-		return
 
 	if(is_away_level(new_z))
 		if(ismob(loc))
@@ -38,7 +33,6 @@
 		var/mob/M = loc
 		M.unEquip(src)
 
-
 // GUNS
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	name = "Exploreverse Mk I"
@@ -48,3 +42,43 @@
 	origin_tech = "combat=2;magnets=2;powerstorage=3"
 	force = 10
 
+/obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2
+	name = "Exploreverse Mk II"
+	desc = "Второй прототип оружия с миниатюрным реактором и ручным восполнением для исследований в крайне отдаленных секторах. \
+	\nДанная модель оснащена системой ручного восполнения энергии типа \"Za.E.-8 A.L'sya\", \
+	позволяющий в короткие сроки восполнить необходимую электроэнергию с помощью ручного труда, личной энергии и дергания за рычаг подключенного к системе зарядки. \
+	\nСистему автозарядки невозможно использовать, в связи с протоколами безопасности, \
+	опустошающие заряд при нахождении вне предназначенных мест использования устройств. \
+	\nТеперь еще более нелепый дизайн с торчащими проводами!"
+	icon_state = "laser_gate_mk2"
+	origin_tech = "combat=3;magnets=2;powerstorage=4;programming=2;engineering=4"
+	force = 10
+
+/obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2/attack_self(mob/living/user)
+	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [name], но он не поддается!")
+	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но он заблокирован.")
+	var/msg_recharge_all = span_notice("[user.name] усердно давит на рычаг зарядки [name]...")
+	var/msg_recharge_user = span_notice("Вы со всей силы давите на рычаг зарядки [name], пытаясь зарядить её...")
+
+	if(!is_away_level(loc.z) && !emagged)
+		user.visible_message(msg_for_all, msg_for_user)
+		return FALSE
+
+	if(cell.charge >= cell.maxcharge)
+		user.visible_message(msg_for_all, msg_for_user)
+		return FALSE
+
+	if(user.nutrition <= NUTRITION_LEVEL_STARVING)
+		user.visible_message(span_warning("[user.name] слабо давит на [name], но он ослаб!"), span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но не можете из-за усталости!"))
+		return FALSE
+
+	user.visible_message(msg_recharge_all, msg_recharge_user)
+	playsound(loc, 'sound/effects/sparks3.ogg', 10, 1)
+	do_sparks(1, 1, src)
+	if(!do_after_once(user, 3 SECONDS, target = src))
+		return
+	cell.give(166)
+	on_recharge()
+	user.adjust_nutrition(-25)
+
+	. = ..()

--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -56,9 +56,6 @@
 			explosion(loc, -1, 0, 2)
 			qdel(src)
 
-/obj/item/gun/energy/laser/awaymission_aeg/emp_act(severity)
-	. = ..()
-	emag_act()
 
 // GUNS
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
@@ -66,41 +63,6 @@
 	desc = "Первый прототип оружия с миниатюрным реактором для исследований в крайне отдаленных секторах. \
 	\nДанную модель невозможно подключить к зарядной станции, во избежание истощения подключенных источников питания, \
 	в связи с протоколами безопасности, опустошающие заряд при нахождении вне предназначенных мест использования устройств."
-	origin_tech = "combat=3;magnets=3;powerstorage=4"
+	origin_tech = "combat=2;magnets=2;powerstorage=3"
 	force = 10
 
-/obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2
-	name = "Exploreverse Mk II"
-	desc = "Второй прототип оружия с миниатюрным реактором и ручным восполнением для исследований в крайне отдаленных секторах. \
-	\nДанная модель оснащена системой ручного восполнения энергии типа \"Za.E.-8 A.L'sya\", \
-	позволяющий в короткие сроки восполнить необходимую электроэнергию с помощью ручного труда, личной энергии и дергания за рычаг подключенного к системе зарядки. \
-	\nСистему автозарядки невозможно использовать, в связи с протоколами безопасности, \
-	опустошающие заряд при нахождении вне предназначенных мест использования устройств. \
-	\nТеперь еще более нелепый дизайн с торчащими проводами!"
-	icon_state = "laser_gate_mk2"
-	origin_tech = "combat=5;magnets=3;powerstorage=5;programming=3;engineering=5"
-	force = 10
-
-/obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2/attack_self(mob/living/user)
-	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [name], но он не поддается!")
-	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но он заблокирован.")
-
-	if(!is_away_level(loc.z) && !emagged)
-		user.visible_message(msg_for_all, msg_for_user)
-		return FALSE
-
-	if(cell.charge >= cell.maxcharge)
-		user.visible_message(msg_for_all, msg_for_user)
-		return FALSE
-
-	if(user.nutrition <= NUTRITION_LEVEL_HYPOGLYCEMIA)
-		user.visible_message(span_warning("[user.name] слабо давит на [name], но он ослаб!"), span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но не можете из-за усталости!"))
-		return FALSE
-
-	playsound(loc, 'sound/effects/sparks3.ogg', 10, 1)
-	do_sparks(1, 1, src)
-
-	cell.give(25)
-	user.adjust_nutrition(-2)
-
-	. = ..()

--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -16,6 +16,7 @@
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
 	onTransitZ(new_z = loc.z)
 
+/obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
 	if(is_away_level(new_z))
 		if(ismob(loc))
 			to_chat(loc, span_notice("Ваш [name] активируется, начиная потреблять энергию от ближайшего беспроводного источника питания."))

--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -38,24 +38,6 @@
 		var/mob/M = loc
 		M.unEquip(src)
 
-/obj/item/gun/energy/laser/awaymission_aeg/emag_act(mob/user)
-	. = ..()
-	if(emagged)
-		return
-	if(user)
-		if(prob(50))
-			user.visible_message(span_warning("От [name] летят искры!"), span_notice("Вы взломали [name], что привело к перезаписи протоколов безопасности. Устройство может быть использовано вне ограничений"))
-			playsound(loc, 'sound/effects/sparks4.ogg', 30, 1)
-			do_sparks(5, 1, src)
-			emagged = TRUE
-			selfcharge = TRUE
-		else
-			user.visible_message(span_warning("От [name] летят искры... Он сейчас взорвётся!"), span_notice("Ой... Что-то пошло не так!"))
-			do_sparks(5, 1, src)
-			update_mob()
-			explosion(loc, -1, 0, 2)
-			qdel(src)
-
 
 // GUNS
 /obj/item/gun/energy/laser/awaymission_aeg/rnd

--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -19,12 +19,12 @@
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
 	if(is_away_level(new_z))
 		if(ismob(loc))
-			to_chat(loc, span_notice("Ваш [name] активируется, начиная потреблять энергию от ближайшего беспроводного источника питания."))
+			to_chat(loc, span_notice("Ваш [src] активируется, начиная потреблять энергию от ближайшего беспроводного источника питания."))
 		selfcharge = TRUE
 	else
 		if(selfcharge)
 			if(ismob(loc))
-				to_chat(loc, span_danger("Ваш [name] деактивируется, так как он находится вне зоны действия источника питания.</span>"))
+				to_chat(loc, span_danger("Ваш [src] деактивируется, так как он находится вне зоны действия источника питания.</span>"))
 			cell.charge = 0
 			selfcharge = FALSE
 			update_icon()
@@ -56,10 +56,10 @@
 	force = 10
 
 /obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2/attack_self(mob/living/user)
-	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [name], но он не поддается!")
-	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но он заблокирован.")
-	var/msg_recharge_all = span_notice("[user.name] усердно давит на рычаг зарядки [name]...")
-	var/msg_recharge_user = span_notice("Вы со всей силы давите на рычаг зарядки [name], пытаясь зарядить её...")
+	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [src], но он не поддается!")
+	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [src], но он заблокирован.")
+	var/msg_recharge_all = span_notice("[user.name] усердно давит на рычаг зарядки [src]...")
+	var/msg_recharge_user = span_notice("Вы со всей силы давите на рычаг зарядки [src], пытаясь зарядить её...")
 
 	if(!is_away_level(loc.z) && !emagged)
 		user.visible_message(msg_for_all, msg_for_user)
@@ -70,7 +70,7 @@
 		return FALSE
 
 	if(user.nutrition <= NUTRITION_LEVEL_STARVING)
-		user.visible_message(span_warning("[user.name] слабо давит на [name], но он ослаб!"), span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но не можете из-за усталости!"))
+		user.visible_message(span_warning("[user.name] слабо давит на [src], но он ослаб!"), span_notice("Вы пытаетесь надавить на рычаг зарядки [src], но не можете из-за усталости!"))
 		return FALSE
 
 	user.visible_message(msg_recharge_all, msg_recharge_user)
@@ -81,5 +81,4 @@
 	cell.give(166)
 	on_recharge()
 	user.adjust_nutrition(-25)
-
 	. = ..()

--- a/modular_ss220/awaymission_gun/code/research_designs/weapon_designs.dm
+++ b/modular_ss220/awaymission_gun/code/research_designs/weapon_designs.dm
@@ -8,3 +8,14 @@
 	build_path = /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	locked = 0
 	category = list("Weapons")
+
+/datum/design/gate_gun_mk2
+	name = "Gate Energy Gun MK2"
+	desc = "An energy gun with an experimental miniaturized reactor. Only works in the gate" //не отображаемое описание, т.к. печатается без кейса
+	id = "gate_energy_gun_mk2"
+	req_tech = list("combat" = 5, "magnets" = 3, "powerstorage" = 5, "programming" = 3, "engineering" = 5)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 8000, MAT_GLASS = 2000, MAT_URANIUM = 2000, MAT_TITANIUM = 500, MAT_SILVER = 1000)
+	build_path = /obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2
+	locked = 0
+	category = list("Weapons")

--- a/modular_ss220/awaymission_gun/code/research_designs/weapon_designs.dm
+++ b/modular_ss220/awaymission_gun/code/research_designs/weapon_designs.dm
@@ -8,14 +8,3 @@
 	build_path = /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	locked = 0
 	category = list("Weapons")
-
-/datum/design/gate_gun_mk2
-	name = "Gate Energy Gun MK2"
-	desc = "An energy gun with an experimental miniaturized reactor. Only works in the gate" //не отображаемое описание, т.к. печатается без кейса
-	id = "gate_energy_gun_mk2"
-	req_tech = list("combat" = 5, "magnets" = 3, "powerstorage" = 5, "programming" = 3, "engineering" = 5)
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 8000, MAT_GLASS = 2000, MAT_URANIUM = 2000, MAT_TITANIUM = 500, MAT_SILVER = 1000)
-	build_path = /obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2
-	locked = 0
-	category = list("Weapons")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Удаляет гейтган МК2 с его абсолютно сломанной механикой бесконечного боезапаса.

Удаляет емаг гейтгана при ЭМИ воздействии на него.

UPD: и сам емаг в помойку, у агентов есть спец предмет для такого в аплинке.

## Почему это хорошо для игры

Я не хочу скатить билд в парашизу, где можно печатать полновесный летал в рнд

## Изображения изменений

## Тестирование
Удалил МК2 пушку из анналов истории. Тесты не проводились, но в таком ПРе они и не нужны.

## Changelog

del: Удалил возможность емагнуть гейтган впринципе. Ограничил ручную зарядку МК2 гейтгана на более длительный и расходный по еде вариант.
