### PR TITLE
fix: wizard box icon

### DIFF
--- a/modular_ss220/aesthetics/boxes/code/boxes.dm
+++ b/modular_ss220/aesthetics/boxes/code/boxes.dm
@@ -270,6 +270,10 @@
 	icon = 'modular_ss220/aesthetics/boxes/icons/boxes.dmi'
 	icon_state = "wizard_box"
 
+/obj/item/storage/box/wizard/hardsuit
+	icon = 'modular_ss220/aesthetics/boxes/icons/boxes.dmi'
+	icon_state = "wizard_box"
+
 /obj/item/storage/box/breaching
 	icon = 'modular_ss220/aesthetics/boxes/icons/boxes.dmi'
 	icon_state = "flashbang_box"


### PR DESCRIPTION
wizard/hardsuit icon state correction

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
У коробки был неверный айкон стейт. Теперь будет верным.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Магическая коробка будет не настолько магической и маглы смогут её видеть.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->
Проверил в игре
## Changelog

:cl:
fix: wizard box icon
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
