### PR TITLE
Carrotshiv remove

### DIFF
--- a/_maps/map_files220/generic/Admin_Zone.dmm
+++ b/_maps/map_files220/generic/Admin_Zone.dmm
@@ -2904,7 +2904,7 @@
 /area/admin)
 "QP" = (
 /obj/structure/table/wood,
-/obj/item/kitchen/knife,
+/obj/item/kitchen/knife/shiv/carrot,
 /turf/simulated/floor/plasteel{
 	icon_state = "hierophant1"
 	},

--- a/_maps/map_files220/generic/Admin_Zone.dmm
+++ b/_maps/map_files220/generic/Admin_Zone.dmm
@@ -2904,7 +2904,7 @@
 /area/admin)
 "QP" = (
 /obj/structure/table/wood,
-/obj/item/kitchen/knife/carrotshiv,
+/obj/item/kitchen/knife,
 /turf/simulated/floor/plasteel{
 	icon_state = "hierophant1"
 	},

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -31652,7 +31652,7 @@
 /area/shuttle/escape)
 "wgG" = (
 /obj/structure/rack,
-/obj/item/kitchen/knife/carrotshiv,
+/obj/item/kitchen/knife,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
 "wgM" = (

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -31652,7 +31652,7 @@
 /area/shuttle/escape)
 "wgG" = (
 /obj/structure/rack,
-/obj/item/kitchen/knife,
+/obj/item/kitchen/knife/shiv/carrot,
 /turf/simulated/floor/wood/oak,
 /area/wizard_station)
 "wgM" = (

--- a/modular_ss220/aesthetics_sounds/code/items.dm
+++ b/modular_ss220/aesthetics_sounds/code/items.dm
@@ -38,6 +38,10 @@
 	drop_sound = 'modular_ss220/aesthetics_sounds/sound/handling/drop/generic1.ogg'
 	pickup_sound = 'modular_ss220/aesthetics_sounds/sound/handling/pickup/generic1.ogg'
 
+/obj/item/kitchen/knife/shiv/carrot
+	drop_sound = 'modular_ss220/aesthetics_sounds/sound/handling/drop/generic1.ogg'
+	pickup_sound = 'modular_ss220/aesthetics_sounds/sound/handling/pickup/generic1.ogg'
+
 /* CLOTHING */
 /obj/item/clothing
 	drop_sound = 'modular_ss220/aesthetics_sounds/sound/handling/drop/clothing.ogg'

--- a/modular_ss220/aesthetics_sounds/code/items.dm
+++ b/modular_ss220/aesthetics_sounds/code/items.dm
@@ -38,10 +38,6 @@
 	drop_sound = 'modular_ss220/aesthetics_sounds/sound/handling/drop/generic1.ogg'
 	pickup_sound = 'modular_ss220/aesthetics_sounds/sound/handling/pickup/generic1.ogg'
 
-/obj/item/kitchen/knife/carrotshiv
-	drop_sound = 'modular_ss220/aesthetics_sounds/sound/handling/drop/generic1.ogg'
-	pickup_sound = 'modular_ss220/aesthetics_sounds/sound/handling/pickup/generic1.ogg'
-
 /* CLOTHING */
 /obj/item/clothing
 	drop_sound = 'modular_ss220/aesthetics_sounds/sound/handling/drop/clothing.ogg'


### PR DESCRIPTION
## Что этот PR делает

Кажется из-за ошибки или устаревшего названия в моде aesthetics_sounds появился дубликат обычного ножа - knife/carrotshiv, но не со звуками ножа, упоминается он только там. Удалил и в мапах заменил обычным ножом

## Почему это хорошо для игры

Удаление дубликата предмета с неправильными звуками

## Changelog

:cl:
del: Carrotshiv remove
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
