### PR TITLE
Tweak: Cyberiad wire splice positions

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -204,9 +204,7 @@
 	},
 /area/station/security/main)
 "acj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -1325,9 +1323,7 @@
 	},
 /area/station/security/armory/secure)
 "ahU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -1339,9 +1335,7 @@
 	},
 /area/station/security/armory/secure)
 "ahV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=Armory_North";
 	location = "Armory_South"
@@ -4353,6 +4347,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "asL" = (
@@ -5128,9 +5123,7 @@
 /obj/machinery/hologram/holopad{
 	pixel_x = -16
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10315,16 +10308,12 @@
 /obj/structure/sign/vacuum/external{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aMD" = (
 /obj/machinery/status_display/directional/south,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aME" = (
@@ -12705,9 +12694,7 @@
 /area/station/public/dorms)
 "aVr" = (
 /obj/machinery/gateway,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -13253,9 +13240,7 @@
 	name = "Chapel Mass Driver";
 	pixel_x = 25
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -13927,9 +13912,7 @@
 	},
 /area/station/command/vault)
 "aZm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -14043,9 +14026,7 @@
 	},
 /area/station/public/dorms)
 "aZF" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
@@ -15192,9 +15173,7 @@
 	},
 /area/station/service/chapel)
 "bdR" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15279,9 +15258,7 @@
 	},
 /area/station/service/hydroponics)
 "beg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -15922,9 +15899,7 @@
 /obj/machinery/gateway{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -15934,9 +15909,7 @@
 /obj/machinery/gateway{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -19143,9 +19116,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -20021,9 +19992,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Cell"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -22055,9 +22024,7 @@
 /area/station/maintenance/apmaint)
 "bIK" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -22737,9 +22704,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "bLZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bMa" = (
@@ -28014,7 +27979,6 @@
 /area/station/science/storage)
 "cig" = (
 /obj/effect/spawner/random_spawners/grille_often,
-/obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -31625,9 +31589,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "cwN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -34948,9 +34910,7 @@
 	},
 /area/station/science/misc_lab)
 "cIK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
@@ -36732,9 +36692,7 @@
 /area/station/engineering/supermatter_room)
 "cPG" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -37246,9 +37204,7 @@
 /obj/machinery/power/tesla_coil{
 	anchored = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -37341,9 +37297,7 @@
 /area/station/maintenance/asmaint)
 "cRz" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -37790,9 +37744,7 @@
 /area/station/engineering/hallway)
 "cSK" = (
 /obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/general_air_control/large_tank_control{
 	autolink_sensors = list("tox_sensor"="Tank");
 	dir = 1;
@@ -37824,9 +37776,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/gravitygenerator)
 "cSO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 1
 	},
@@ -38254,9 +38204,7 @@
 /area/station/maintenance/assembly_line)
 "cUd" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -38476,6 +38424,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "cUQ" = (
@@ -38767,9 +38716,7 @@
 	},
 /area/station/engineering/atmos/storage)
 "cVP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -38929,9 +38876,7 @@
 	},
 /area/station/turret_protected/aisat/interior)
 "cWB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
@@ -39613,9 +39558,7 @@
 	},
 /area/station/engineering/utility)
 "cYW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -39694,9 +39637,7 @@
 	anchored = 1;
 	state = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "cZj" = (
@@ -40023,9 +39964,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "dah" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
 	name = "Gas to Filter"
@@ -41940,9 +41879,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "dgV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -41956,9 +41893,7 @@
 	},
 /area/station/engineering/supermatter_room)
 "dgW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 8
 	},
@@ -42404,9 +42339,7 @@
 /area/station/engineering/atmos/control)
 "diV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -43314,9 +43247,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "dms" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -45265,7 +45196,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "dyw" = (
@@ -46037,7 +45967,6 @@
 	},
 /area/station/service/chapel/office)
 "dLo" = (
-/obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -47500,9 +47429,7 @@
 /area/station/medical/morgue)
 "ema" = (
 /obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
 "emr" = (
@@ -48906,9 +48833,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "eMw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -50846,9 +50771,7 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/bar/atrium)
 "fAn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -51342,9 +51265,7 @@
 /turf/simulated/floor/plating,
 /area/station/service/bar/atrium)
 "fIU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "fJa" = (
@@ -52049,9 +51970,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "fXQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/door_control/shutter/west{
 	id = "teleshutter";
 	name = "Teleporter Shutters Access Control";
@@ -52120,9 +52039,7 @@
 	},
 /area/station/science/xenobiology)
 "fYx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/start/chemist,
 /obj/structure/chair/stool,
 /turf/simulated/floor/engine,
@@ -54363,9 +54280,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "gNQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -54423,9 +54338,7 @@
 /area/station/service/hydroponics)
 "gOm" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
@@ -55020,13 +54933,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/wire_splicing/thirty,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "gYf" = (
@@ -57521,9 +57434,7 @@
 	},
 /area/station/science/robotics/chargebay)
 "hPR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -58036,9 +57947,7 @@
 	dir = 8;
 	network = list("SS13","Singularity","Engineering")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "hZZ" = (
@@ -59500,9 +59409,7 @@
 	},
 /area/station/command/office/hos)
 "iFb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
 	name = "Cooling Loop to Gas"
@@ -59710,9 +59617,7 @@
 /area/station/hallway/secondary/exit)
 "iIG" = (
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "iIQ" = (
@@ -62831,9 +62736,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "jUf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -65422,9 +65325,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "kSn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
@@ -66161,9 +66062,7 @@
 	},
 /area/station/science/robotics)
 "lgQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "lgS" = (
@@ -66619,23 +66518,14 @@
 /area/station/maintenance/port)
 "lrw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/apmaint)
 "lrF" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/flashbangs,
@@ -68136,9 +68026,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -68503,9 +68391,7 @@
 "lYM" = (
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
 "lYX" = (
@@ -69781,9 +69667,7 @@
 	},
 /area/station/service/kitchen)
 "muD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -71902,9 +71786,7 @@
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "nlj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -72513,6 +72395,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "nwj" = (
@@ -73531,7 +73414,6 @@
 "nRS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
@@ -73562,9 +73444,7 @@
 	dir = 1;
 	state = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -73808,9 +73688,7 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
 "nWZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
@@ -75320,9 +75198,7 @@
 	},
 /area/station/science/rnd)
 "ozh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -76343,17 +76219,23 @@
 	},
 /area/station/science/toxins/mixing)
 "oRC" = (
-/obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
+/area/station/maintenance/aft)
 "oRH" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
@@ -76812,9 +76694,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
 "oYC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable{
@@ -77020,9 +76900,7 @@
 	},
 /area/station/science/rnd)
 "pdE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -77429,9 +77307,7 @@
 	},
 /area/station/medical/medbay)
 "pkX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -78482,9 +78358,7 @@
 	},
 /area/station/command/office/cmo)
 "pCK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -79031,9 +78905,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "pPi" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -79140,9 +79012,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -82462,6 +82332,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "qXR" = (
@@ -82588,9 +82459,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "raN" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/end,
 /obj/structure/transit_tube/cap{
 	dir = 1
 	},
@@ -83239,9 +83108,7 @@
 	},
 /area/station/engineering/gravitygenerator)
 "rnW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -84588,7 +84455,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "rSS" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
@@ -85084,9 +84951,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "sdw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "sdE" = (
@@ -85943,9 +85808,7 @@
 	},
 /area/station/command/office/ce)
 "ssU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -86974,9 +86837,7 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
 "sKF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -88928,9 +88789,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "tvj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -89765,9 +89624,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
 "tMs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/random_spawners/blood_often,
 /obj/random/mech,
 /turf/simulated/floor/plating,
@@ -90537,9 +90394,7 @@
 /turf/simulated/floor/bluegrid,
 /area/station/aisat/hall)
 "tYm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -91987,9 +91842,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "uzM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Disposals";
 	dir = 1
@@ -92431,9 +92284,7 @@
 	},
 /area/station/medical/sleeper)
 "uHD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -93733,9 +93584,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "vfY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -94146,9 +93995,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/simulated/floor/plasteel{
 	icon_state = "redfull"
@@ -94217,9 +94064,7 @@
 	},
 /area/station/maintenance/asmaint)
 "vrF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -96444,9 +96289,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "why" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /turf/simulated/floor/plating,
@@ -99038,9 +98881,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -99356,9 +99197,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/assembly_line)
 "xmZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -100726,9 +100565,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "xMI" = (
@@ -121417,7 +121254,7 @@ cgQ
 gYs
 cgQ
 xLj
-oRC
+sCF
 cwx
 cwx
 cwx
@@ -121932,7 +121769,7 @@ gzN
 kSp
 fCJ
 lfC
-fCJ
+lrw
 eXA
 vUq
 fCJ
@@ -139673,7 +139510,7 @@ bJh
 cyZ
 inv
 cpC
-daB
+oRC
 cep
 cAe
 aaa
@@ -139930,8 +139767,8 @@ wna
 cyZ
 ciQ
 cpC
-lrw
-ctZ
+uzL
+cep
 cxO
 aaa
 bFC
@@ -140188,7 +140025,7 @@ cul
 tsO
 cpC
 oym
-bWb
+ctZ
 cxO
 aab
 bFC
@@ -141228,7 +141065,7 @@ bFE
 bFC
 aab
 cAe
-mEx
+wHh
 vic
 ogH
 sto
@@ -149119,7 +148956,7 @@ aGX
 aGX
 aGX
 sCE
-ehK
+gXX
 baz
 aUL
 aXg
@@ -150404,7 +150241,7 @@ aKZ
 qYO
 aQI
 sCE
-gXX
+ehK
 aYP
 aYz
 sgZ

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -24030,6 +24030,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "bRZ" = (
@@ -82332,7 +82333,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
-/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "qXR" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Немного изменяет позиции оголённых проводов (вытащил из под плиток, убрал однотайловые ловушки, нагромождение в одном месте)

## Почему это хорошо для игры
Оголённая проводка не должна быть убийцей всего и вся, особенно если её не видно

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Кибериада: Позиции оголённых проводов изменены, а также местами вытащена из под плитки
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
