### PR TITLE
fix: Быстрый фикс разделения админов прайма и мейна

### DIFF
--- a/modular_ss220/whitelist/code/wl_admin.dm
+++ b/modular_ss220/whitelist/code/wl_admin.dm
@@ -1,5 +1,5 @@
 /datum/controller/subsystem/dbcore/NewQuery(sql_query, arguments)
-	if(!GLOB.configuration.overflow.reroute_cap)
+	if(GLOB.configuration.overflow.reroute_cap != 0.5)
 		return ..()
 	var/regex/r = regex("\\b(admin)\\b")
 	sql_query = r.Replace(sql_query, "admin_wl")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Сейчас при выдаче админки игра решает прайм это или не прайм значением reroute_cap, которое также отвечает за кап игроков на сервере, нереально отвратительный фикс но сейчас есть более приоритетные задачи.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Админы мейна не получают админку на мейне

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
