### PR TITLE
fix: byond redirect

### DIFF
--- a/modular_ss220/queue/code/new_player_procs.dm
+++ b/modular_ss220/queue/code/new_player_procs.dm
@@ -16,7 +16,7 @@
 			SSqueue.queue_bypass_list |= ckey
 			return
 
-		src << link(GLOB.configuration.overflow.overflow_server_location)
+		src << link("byond://[GLOB.configuration.overflow.overflow_server_location]")
 
 /mob/new_player/Logout()
 	. = ..()


### PR DESCRIPTION
## Что этот PR делает
Добавляем в ссылку byond что бы он закрывал текущий клиент
