### PR TITLE
Fix: Detective's Flask

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -8394,8 +8394,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/flask/detflask{
 	pixel_x = 16;
-	pixel_y = 4;
-	initialized = 1
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фикс сломанной фляги детектива на Кибериаде. Теперь в ней спавнится 30 юнитов виски и в неё можно заливать химикаты

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Детектив снова может пить

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Запустил локалку и проверил

## Changelog

:cl:Romains
fix: Починил флягу детектива на Кибериаде
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
