### PR TITLE
refactor: slot preservation time to config

### DIFF
--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -566,6 +566,11 @@ overflow_server = "byond://yourdomain.com:1111"
 # List of ckeys who will not get rerouted to the overflow server
 overflow_whitelist = ["keyhere", "anotherhere"]
 
+# SS220 addition
+# Slot saving  time for client reconnection (in seconds)
+reservation_time = 10
+
+
 
 ################################################################
 

--- a/modular_ss220/queue/_queue.dme
+++ b/modular_ss220/queue/_queue.dme
@@ -2,3 +2,4 @@
 
 #include "code/new_player_procs.dm"
 #include "code/queue_bypass.dm"
+#include "code/overflow_configuration.dm"

--- a/modular_ss220/queue/code/new_player_procs.dm
+++ b/modular_ss220/queue/code/new_player_procs.dm
@@ -21,7 +21,8 @@
 /mob/new_player/Logout()
 	. = ..()
 
-	addtimer(CALLBACK(SSqueue, TYPE_PROC_REF(/datum/controller/subsystem/queue, reserve_queue_slot), last_known_ckey), 10 MINUTES)
+	if(SSqueue.queue_enabled)
+		addtimer(CALLBACK(SSqueue, TYPE_PROC_REF(/datum/controller/subsystem/queue, reserve_queue_slot), last_known_ckey), GLOB.configuration.overflow.reservation_time)
 
 
 /datum/controller/subsystem/queue/proc/reserve_queue_slot(reserved_ckey)

--- a/modular_ss220/queue/code/overflow_configuration.dm
+++ b/modular_ss220/queue/code/overflow_configuration.dm
@@ -1,0 +1,7 @@
+/datum/configuration_section/overflow_configuration
+	var/reservation_time = 1 MINUTES
+
+/datum/configuration_section/overflow_configuration/load_data(list/data)
+	. = ..()
+
+	CONFIG_LOAD_NUM(reservation_time, data["reservation_time"])


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Снижаем стандартное время резервации слота на сервере для вышедшего игрока до 10 секунд(Уже на сервере поставлю 1 минуту наверное)
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Выносим переменную в конфиг
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
