### PR TITLE
[FIX] Разрешаем грипперам медборгов трогать химию.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -234,8 +234,10 @@
 		SStgui.update_uis(src)
 		return
 
-	if(isrobot(user))
-		return
+	// SS220 EDIT START
+	//if(isrobot(user))
+	// 	return
+	// SS220 EDIT END
 
 	if((istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks)) && user.a_intent != INTENT_HARM)
 		if(panel_open)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -234,10 +234,8 @@
 		SStgui.update_uis(src)
 		return
 
-	// SS220 EDIT START
-	//if(isrobot(user))
+	//if(isrobot(user)) // SS220 EDIT
 	// 	return
-	// SS220 EDIT END
 
 	if((istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks)) && user.a_intent != INTENT_HARM)
 		if(panel_open)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -62,10 +62,8 @@
 		stat |= NOPOWER
 
 /obj/machinery/chem_heater/attackby(obj/item/I, mob/user)
-	// SS220 EDIT START
-	//if(isrobot(user))
+	//if(isrobot(user)) // SS220 EDIT
 	//	return
-	// SS220 EDIT END
 
 	if(istype(I, /obj/item/reagent_containers/glass) && user.a_intent != INTENT_HARM)
 		if(beaker)

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -62,8 +62,10 @@
 		stat |= NOPOWER
 
 /obj/machinery/chem_heater/attackby(obj/item/I, mob/user)
-	if(isrobot(user))
-		return
+	// SS220 EDIT START
+	//if(isrobot(user))
+	//	return
+	// SS220 EDIT END
 
 	if(istype(I, /obj/item/reagent_containers/glass) && user.a_intent != INTENT_HARM)
 		if(beaker)

--- a/modular_ss220/silicons/code/items/gripper.dm
+++ b/modular_ss220/silicons/code/items/gripper.dm
@@ -273,3 +273,7 @@
 /obj/machinery/reagentgrinder/attack_ai(mob/user)
 	add_hiddenprint(user)
 	return attack_hand(user)
+
+/obj/structure/morgue/attack_ai(mob/user)
+	add_hiddenprint(user)
+	return attack_hand(user)

--- a/modular_ss220/silicons/code/items/gripper.dm
+++ b/modular_ss220/silicons/code/items/gripper.dm
@@ -270,47 +270,6 @@
 	// All robot inventory items have NODROP, so they should return FALSE.
 	return module_gripper_drop()
 
-
-// Переинициализация из-за того что ОФФы впихнули проверку на борга там, где борг и так не мог пользоваться этим,
-// т.к. хваталки у него не работала.
-/obj/machinery/chem_heater/attackby(obj/item/I, mob/user)
-	if(isrobot(user) && istype(I, /obj/item/reagent_containers/glass))
-		if(beaker)
-			to_chat(user, "<span class='notice'>A beaker is already loaded into the machine.</span>")
-			return
-
-		if(user.drop_item())
-			beaker = I
-			I.forceMove(src)
-			to_chat(user, "<span class='notice'>You add the beaker to the machine!</span>")
-			icon_state = "mixer1b"
-			SStgui.update_uis(src)
-			return
-
-	return ..()
-
-/obj/machinery/chem_dispenser/attackby(obj/item/I, mob/user, params)
-	if(isrobot(user) && (istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks)))
-		if(panel_open)
-			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
-			return
-		if(!user.drop_item())
-			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
-			return
-		I.forceMove(src)
-		if(beaker)
-			user.put_in_hands(beaker)
-			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
-		else
-			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
-		beaker = I
-
-		SStgui.update_uis(src) // update all UIs attached to src
-		update_icon(UPDATE_ICON_STATE)
-		return
-
-	return ..()
-
 /obj/machinery/reagentgrinder/attack_ai(mob/user)
 	add_hiddenprint(user)
 	return attack_hand(user)

--- a/modular_ss220/silicons/code/items/gripper.dm
+++ b/modular_ss220/silicons/code/items/gripper.dm
@@ -265,3 +265,44 @@
 	// The gripper is special because it has a normal item inside that we can drop.
 	// All robot inventory items have NODROP, so they should return FALSE.
 	return module_gripper_drop()
+
+
+// Переинициализация из-за того что ОФФы впихнули проверку на борга там, где борг и так не мог пользоваться этим,
+// т.к. хваталки у него не работала.
+/obj/machinery/chem_heater/attackby(obj/item/I, mob/user)
+	if(isrobot(user) && istype(I, /obj/item/reagent_containers/glass))
+		if(beaker)
+			to_chat(user, "<span class='notice'>A beaker is already loaded into the machine.</span>")
+			return
+
+		if(user.drop_item())
+			beaker = I
+			I.forceMove(src)
+			to_chat(user, "<span class='notice'>You add the beaker to the machine!</span>")
+			icon_state = "mixer1b"
+			SStgui.update_uis(src)
+			return
+
+	return ..()
+
+/obj/machinery/chem_dispenser/attackby(obj/item/I, mob/user, params)
+	if(isrobot(user) && (istype(I, /obj/item/reagent_containers/glass) || istype(I, /obj/item/reagent_containers/food/drinks)))
+		if(panel_open)
+			to_chat(user, "<span class='notice'>Close the maintenance panel first.</span>")
+			return
+		if(!user.drop_item())
+			to_chat(user, "<span class='warning'>[I] is stuck to you!</span>")
+			return
+		I.forceMove(src)
+		if(beaker)
+			user.put_in_hands(beaker)
+			to_chat(user, "<span class='notice'>You swap [I] with [beaker].</span>")
+		else
+			to_chat(user, "<span class='notice'>You set [I] on the machine.</span>")
+		beaker = I
+
+		SStgui.update_uis(src) // update all UIs attached to src
+		update_icon(UPDATE_ICON_STATE)
+		return
+
+	return ..()

--- a/modular_ss220/silicons/code/items/gripper.dm
+++ b/modular_ss220/silicons/code/items/gripper.dm
@@ -69,7 +69,11 @@
 					/obj/item/camera_film,
 					/obj/item/paper,
 					/obj/item/photo,
-					/obj/item/toy/plushie)
+					/obj/item/toy/plushie,
+					/obj/item/disk/data,
+					/obj/item/disk/design_disk,
+					/obj/item/disk/plantgene,
+					)
 
 /obj/item/gripper/nuclear
 	name = "Nuclear gripper"

--- a/modular_ss220/silicons/code/items/gripper.dm
+++ b/modular_ss220/silicons/code/items/gripper.dm
@@ -306,3 +306,7 @@
 		return
 
 	return ..()
+
+/obj/machinery/reagentgrinder/attack_ai(mob/user)
+	add_hiddenprint(user)
+	return attack_hand(user)


### PR DESCRIPTION
## Что этот PR делает

Разрешает трогать бикеры боргам в остальной химии (половину они и так могли трогать, а 2-х других машинерий увы).
Буквально копипастит код который был в наследнике, только на этот раз с разрешением для борга.
Помимо этого карго борги теперь могут полноценно брать диски исследований как и каргонцы.
Борги снова могут заглянуть в морг и убирать туда трупы.

## Почему это хорошо для игры

А то бикеры есть, а химии набрать гадости нет.
Люди больше не будут жаловаться.

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

![image](https://github.com/ss220club/Paradise-SS220/assets/41479614/54101d0a-b176-430f-9baf-b0b9f06483ca)

## Changelog

:cl:
fix: Медборги могут взаимодействовать с химическим оборудованием
feat: Сервис/Карго борги могут брать диски для исследований.
feat: Борги снова могут заглянуть в морг 
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
