### PR TITLE
Fix: Cyberiad bunch of fixes (disposal, atmos in north-west tunnels)

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -502,13 +502,6 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/security/main)
-"adz" = (
-/obj/machinery/conveyor/west{
-	dir = 10;
-	id = "garbage"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "adB" = (
 /obj/docking_port/stationary{
 	dwidth = 8;
@@ -6878,6 +6871,13 @@
 /obj/effect/landmark/start/internal_affairs,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
+"aAH" = (
+/obj/effect/spawner/random_barrier/obstruction,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "aAI" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -9408,6 +9408,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/fpmaint)
 "aIV" = (
@@ -9689,6 +9692,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/damageturf,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/fpmaint)
 "aJX" = (
@@ -10378,12 +10382,18 @@
 	},
 /area/station/maintenance/fpmaint)
 "aMU" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
 /area/station/maintenance/fpmaint)
 "aMW" = (
 /obj/effect/decal/cleanable/blood/writing,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aMX" = (
@@ -10393,6 +10403,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "rampbottom"
@@ -13534,6 +13545,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aYc" = (
@@ -14558,6 +14570,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "bbT" = (
@@ -21135,6 +21148,7 @@
 /obj/machinery/conveyor/west{
 	id = "garbage"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bFd" = (
@@ -28065,7 +28079,13 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/ntrep)
 "ciI" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/west{
+	dir = 10;
+	id = "garbage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ciJ" = (
@@ -29150,15 +29170,9 @@
 	},
 /area/station/medical/surgery/primary)
 "cmK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light/small/directional/south,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/power/apc/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "cmQ" = (
@@ -45194,6 +45208,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "dyw" = (
@@ -49167,6 +49184,9 @@
 /obj/structure/closet/crate/freezer,
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "eUq" = (
@@ -49196,6 +49216,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "eUC" = (
@@ -53100,11 +53121,12 @@
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "gsg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/mouse/rat,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "gsh" = (
@@ -53751,6 +53773,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -54404,6 +54429,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
+"gOT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "gPb" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -55032,6 +55063,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "gZn" = (
@@ -55618,13 +55652,6 @@
 /obj/item/toy/crayon/mime,
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
-"hjR" = (
-/obj/machinery/conveyor/east{
-	id = "garbage"
-	},
-/obj/machinery/recycler,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "hjX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -57171,6 +57198,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "hLC" = (
@@ -59163,6 +59191,7 @@
 /area/station/medical/surgery/secondary)
 "izV" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "iBD" = (
@@ -60074,6 +60103,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"iRI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fpmaint)
 "iRT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -61984,6 +62020,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "jEV" = (
@@ -64133,6 +64170,9 @@
 "kwO" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "kwP" = (
@@ -65788,9 +65828,6 @@
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -67842,13 +67879,32 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "lQp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mail_sorting{
+	dir = 1
+	},
+/obj/machinery/door/window/classic/normal{
+	layer = 3;
+	req_one_access_txt = "50";
+	dir = 1;
+	name = "Delivery Chute"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "lQx" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
@@ -69195,6 +69251,16 @@
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/bluegrid,
 /area/station/telecomms/chamber)
+"mll" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/meat/slab,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
+	},
+/area/station/maintenance/fpmaint)
 "mlv" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet,
@@ -69575,6 +69641,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "mtc" = (
@@ -69659,11 +69726,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/service/kitchen)
-"muD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "mvk" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -70622,6 +70684,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
@@ -72399,6 +72464,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "nwj" = (
@@ -73893,6 +73961,9 @@
 /area/station/hallway/primary/aft)
 "oap" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "oaI" = (
@@ -76705,11 +76776,7 @@
 "oYC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/directional/south,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "oYM" = (
@@ -76919,16 +76986,13 @@
 	},
 /area/station/engineering/secure_storage)
 "pey" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "peF" = (
@@ -81034,6 +81098,9 @@
 /area/station/engineering/atmos/control)
 "qCH" = (
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "qCJ" = (
@@ -81922,9 +81989,9 @@
 /area/space/nearstation)
 "qPt" = (
 /obj/machinery/conveyor/east{
-	dir = 6;
-	id = "QMLoad2"
+	id = "garbage"
 	},
+/obj/machinery/recycler,
 /obj/structure/sign/securearea{
 	name = "\improper STAY CLEAR HEAVY MACHINERY";
 	pixel_y = 32
@@ -83036,6 +83103,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "rmu" = (
@@ -83516,7 +83586,12 @@
 /turf/simulated/wall,
 /area/station/maintenance/apmaint)
 "rzr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -84093,14 +84168,14 @@
 /area/space/nearstation)
 "rMp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/small/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "rMq" = (
@@ -85418,6 +85493,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -88257,6 +88335,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "tkc" = (
@@ -88300,9 +88381,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "tky" = (
@@ -88857,6 +88936,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"twp" = (
+/obj/machinery/conveyor/east{
+	id = "garbage"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "twu" = (
 /obj/machinery/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -89198,6 +89283,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "tDV" = (
@@ -89455,6 +89541,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "tJk" = (
@@ -90712,15 +90801,15 @@
 /area/station/hallway/primary/port)
 "ueC" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4
-	},
-/mob/living/simple_animal/mouse/rat,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/disposal)
 "ueH" = (
@@ -91081,24 +91170,14 @@
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/asmaint)
 "uly" = (
-/obj/machinery/disposal/deliveryChute,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 8;
+	stack_amt = 10;
+	output_dir = 2
 	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/classic/normal{
-	layer = 3;
-	req_one_access_txt = "50"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mail_sorting,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "ulC" = (
@@ -92353,6 +92432,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "uJB" = (
@@ -92853,10 +92933,10 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "uUe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/alarm/directional/north,
+/mob/living/simple_animal/mouse/rat,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "uUf" = (
@@ -93700,10 +93780,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
-"vhD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/station/maintenance/port)
 "vhN" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced{
@@ -96573,12 +96649,13 @@
 	},
 /area/station/engineering/supermatter_room)
 "wnR" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 8;
-	stack_amt = 10;
-	output_dir = 2
+/obj/machinery/conveyor/east{
+	dir = 6;
+	id = "QMLoad2"
 	},
-/obj/effect/spawner/random_spawners/cobweb_right_frequent,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "wnU" = (
@@ -96736,6 +96813,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -98117,6 +98197,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "wQQ" = (
@@ -98905,6 +98988,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -100119,6 +100205,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "xGE" = (
@@ -100350,6 +100439,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "xJD" = (
@@ -100666,6 +100758,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -116894,7 +116989,7 @@ jRQ
 hoJ
 bCf
 oNT
-bCf
+iBU
 aab
 aaa
 aaa
@@ -117152,7 +117247,7 @@ fSH
 esK
 xhq
 bCf
-iBU
+aab
 aaa
 aaa
 aaa
@@ -117408,8 +117503,8 @@ kzB
 bCf
 lbs
 mZf
-msR
-aic
+bCf
+iBU
 aaa
 aaa
 aaa
@@ -117663,9 +117758,9 @@ ygC
 cgQ
 cgQ
 bCf
-fza
+twp
 bEX
-muD
+msR
 aic
 cxX
 aaa
@@ -117920,10 +118015,10 @@ coL
 cgQ
 bsi
 bCf
-hjR
+fza
 bEX
 tMs
-iBU
+aic
 uQe
 aaa
 aaa
@@ -118178,7 +118273,7 @@ gYs
 cgQ
 bCf
 qPt
-adz
+bEX
 uzM
 iBU
 fHD
@@ -118433,7 +118528,7 @@ rgR
 coL
 tGO
 sXJ
-hoJ
+bCf
 wnR
 ciI
 oYC
@@ -118690,7 +118785,7 @@ xhx
 vZX
 vZX
 pJY
-bGQ
+hoJ
 uly
 gsg
 cmK
@@ -118947,7 +119042,7 @@ kQo
 coL
 lNb
 iMM
-bCf
+bGQ
 uUe
 rzr
 lQp
@@ -122518,7 +122613,7 @@ rSI
 cqQ
 pvp
 jnc
-vhD
+blQ
 fea
 bxb
 xKE
@@ -123258,7 +123353,7 @@ abN
 aaa
 aMA
 aLF
-aOo
+mll
 aOo
 fHs
 aMA
@@ -123772,7 +123867,7 @@ aaa
 aaa
 aGi
 aLD
-aOo
+mll
 sym
 aMA
 aaa
@@ -124029,7 +124124,7 @@ aQg
 aMA
 aMA
 aMA
-aOs
+aAH
 aOr
 aMA
 aaa
@@ -124286,7 +124381,7 @@ aHr
 aIR
 aGb
 aMA
-oap
+iRI
 aQl
 aMA
 aMA
@@ -124801,7 +124896,7 @@ aIS
 aPj
 aMA
 aMA
-aOs
+aAH
 aMA
 aOr
 qUp
@@ -125054,11 +125149,11 @@ axb
 aEQ
 aGl
 aQP
-aPi
+gOT
 aKc
 aLJ
 aMY
-oap
+iRI
 aLK
 aMA
 aQh


### PR DESCRIPTION
## Что этот PR делает
- Протянуты недостающие трубы в северо-западных техах
- Починена работа переработчика в диспоушале
- Убрана грязюка со стены в техах карго

## Почему это хорошо для игры
Меньше багов

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Проверял в игре

## Changelog

:cl:
tweak: Кибериада: Протянуты недостающие трубы в северо-западных техах
fix: Кибериада: Починена работа переработчика в диспоушале
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
