### PR TITLE
FIX: novice positions

### DIFF
--- a/modular_ss220/jobs/code/cards_ids.dm
+++ b/modular_ss220/jobs/code/cards_ids.dm
@@ -2,20 +2,20 @@
 GLOBAL_LIST_INIT(Jobs_SS220, list("intern", "cadet", "trainee", "student"))
 GLOBAL_LIST_INIT(Jobs_titles_SS220, list("Intern", "Security Cadet", "Trainee Engineer", "Student Scientist"))
 
-/proc/get_all_medical_novice_tittles()
+/proc/get_all_medical_novice_titles()
 	return list("Intern", "Medical Assistant", "Student Medical Doctor")
 
-/proc/get_all_security_novice_tittles()
+/proc/get_all_security_novice_titles()
 	return list("Security Cadet", "Security Assistant", "Security Graduate")
 
-/proc/get_all_engineering_novice_tittles()
+/proc/get_all_engineering_novice_titles()
 	return list("Trainee Engineer", "Engineer Assistant", "Technical Assistant", "Engineer Student", "Technical Student", "Technical Trainee")
 
-/proc/get_all_science_novice_tittles()
+/proc/get_all_science_novice_titles()
 	return list("Student Scientist", "Scientist Assistant", "Scientist Pregraduate", "Scientist Graduate", "Scientist Postgraduate")
 
-/proc/get_all_novice_tittles()
-	return get_all_medical_novice_tittles() + get_all_security_novice_tittles() + get_all_engineering_novice_tittles() + get_all_science_novice_tittles()
+/proc/get_all_novice_titles()
+	return get_all_medical_novice_titles() + get_all_security_novice_titles() + get_all_engineering_novice_titles() + get_all_science_novice_titles()
 
 /mob/living/carbon/human/sec_hud_set_ID()
 	var/image/holder = hud_list[ID_HUD]
@@ -28,10 +28,10 @@ GLOBAL_LIST_INIT(Jobs_titles_SS220, list("Intern", "Security Cadet", "Trainee En
 	var/assignmentName = get_ID_assignment(if_no_id = "Unknown")
 	var/rankName = get_ID_rank(if_no_id = "Unknown")
 
-	var/novmed = get_all_medical_novice_tittles()
-	var/novsec = get_all_security_novice_tittles()
-	var/noveng = get_all_engineering_novice_tittles()
-	var/novrnd = get_all_science_novice_tittles()
+	var/novmed = get_all_medical_novice_titles()
+	var/novsec = get_all_security_novice_titles()
+	var/noveng = get_all_engineering_novice_titles()
+	var/novrnd = get_all_science_novice_titles()
 
 	if((assignmentName in novmed) || (rankName in novmed))
 		return "intern"

--- a/modular_ss220/jobs/code/cards_ids.dm
+++ b/modular_ss220/jobs/code/cards_ids.dm
@@ -1,5 +1,6 @@
 // Для отрисовки ХУД'ов.
 GLOBAL_LIST_INIT(Jobs_SS220, list("intern", "cadet", "trainee", "student"))
+GLOBAL_LIST_INIT(Jobs_tittles_SS220, list("Intern", "Security Cadet", "Trainee Engineer", "Student Scientist"))
 
 /proc/get_all_medical_novice_tittles()
 	return list("Intern", "Medical Assistant", "Student Medical Doctor")

--- a/modular_ss220/jobs/code/cards_ids.dm
+++ b/modular_ss220/jobs/code/cards_ids.dm
@@ -1,6 +1,6 @@
 // Для отрисовки ХУД'ов.
 GLOBAL_LIST_INIT(Jobs_SS220, list("intern", "cadet", "trainee", "student"))
-GLOBAL_LIST_INIT(Jobs_tittles_SS220, list("Intern", "Security Cadet", "Trainee Engineer", "Student Scientist"))
+GLOBAL_LIST_INIT(Jobs_titles_SS220, list("Intern", "Security Cadet", "Trainee Engineer", "Student Scientist"))
 
 /proc/get_all_medical_novice_tittles()
 	return list("Intern", "Medical Assistant", "Student Medical Doctor")

--- a/modular_ss220/jobs/code/job/engineering_jobs.dm
+++ b/modular_ss220/jobs/code/job/engineering_jobs.dm
@@ -1,15 +1,15 @@
 /datum/job/engineer/New()
 	. = ..()
-	alt_titles |= get_all_engineering_novice_tittles()
+	alt_titles |= get_all_engineering_novice_titles()
 
 /datum/station_department/engineering/New()
 	. = ..()
-	department_roles |= get_all_engineering_novice_tittles()
+	department_roles |= get_all_engineering_novice_titles()
 
 /datum/outfit/job/engineer/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	if(H.mind && H.mind.role_alt_title)
-		if(H.mind.role_alt_title in get_all_engineering_novice_tittles())
+		if(H.mind.role_alt_title in get_all_engineering_novice_titles())
 			uniform = /obj/item/clothing/under/rank/engineer/trainee
 			if(H.gender == FEMALE)
 				uniform = /obj/item/clothing/under/rank/engineer/trainee/skirt

--- a/modular_ss220/jobs/code/job/medical_jobs.dm
+++ b/modular_ss220/jobs/code/job/medical_jobs.dm
@@ -1,15 +1,15 @@
 /datum/job/doctor/New()
 	. = ..()
-	alt_titles |= get_all_medical_novice_tittles()
+	alt_titles |= get_all_medical_novice_titles()
 
 /datum/station_department/medical/New()
 	. = ..()
-	department_roles |= get_all_medical_novice_tittles()
+	department_roles |= get_all_medical_novice_titles()
 
 /datum/outfit/job/doctor/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	if(H.mind && H.mind.role_alt_title)
-		if(H.mind.role_alt_title in get_all_medical_novice_tittles())
+		if(H.mind.role_alt_title in get_all_medical_novice_titles())
 			uniform = /obj/item/clothing/under/rank/medical/intern
 			if(H.gender == FEMALE)
 				uniform = /obj/item/clothing/under/rank/medical/intern/skirt

--- a/modular_ss220/jobs/code/job/science_jobs.dm
+++ b/modular_ss220/jobs/code/job/science_jobs.dm
@@ -1,15 +1,15 @@
 /datum/job/scientist/New()
 	. = ..()
-	alt_titles |= get_all_science_novice_tittles()
+	alt_titles |= get_all_science_novice_titles()
 
 /datum/station_department/science/New()
 	. = ..()
-	department_roles |= get_all_science_novice_tittles()
+	department_roles |= get_all_science_novice_titles()
 
 /datum/outfit/job/scientist/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	if(H.mind && H.mind.role_alt_title)
-		if(H.mind.role_alt_title in get_all_science_novice_tittles())
+		if(H.mind.role_alt_title in get_all_science_novice_titles())
 			uniform = /obj/item/clothing/under/rank/scientist/student
 			if(H.gender == FEMALE)
 				uniform = /obj/item/clothing/under/rank/scientist/student/skirt

--- a/modular_ss220/jobs/code/job/security_jobs.dm
+++ b/modular_ss220/jobs/code/job/security_jobs.dm
@@ -1,15 +1,15 @@
 /datum/job/officer/New()
 	. = ..()
-	alt_titles = get_all_security_novice_tittles() // =, а не |=, т.к. отсутствуют альт. названия
+	alt_titles = get_all_security_novice_titles() // =, а не |=, т.к. отсутствуют альт. названия
 
 /datum/station_department/security/New()
 	. = ..()
-	department_roles |= get_all_security_novice_tittles()
+	department_roles |= get_all_security_novice_titles()
 
 /datum/outfit/job/officer/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	if(H.mind && H.mind.role_alt_title)
-		if(H.mind.role_alt_title in get_all_security_novice_tittles())
+		if(H.mind.role_alt_title in get_all_security_novice_titles())
 			uniform = /obj/item/clothing/under/rank/security/cadet
 			if(H.gender == FEMALE)
 				uniform = /obj/item/clothing/under/rank/security/cadet/skirt

--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -2,13 +2,13 @@
 	. = ..()
 	var/list/job_radio_dict = list()
 
-	for(var/i in get_all_medical_novice_tittles())
+	for(var/i in get_all_medical_novice_titles())
 		job_radio_dict.Add(list("[i]" = "medradio"))
-	for(var/i in get_all_security_novice_tittles())
+	for(var/i in get_all_security_novice_titles())
 		job_radio_dict.Add(list("[i]" = "secradio"))
-	for(var/i in get_all_engineering_novice_tittles())
+	for(var/i in get_all_engineering_novice_titles())
 		job_radio_dict.Add(list("[i]" = "engradio"))
-	for(var/i in get_all_science_novice_tittles())
+	for(var/i in get_all_science_novice_titles())
 		job_radio_dict.Add(list("[i]" = "scirradio"))
 
 	all_jobs |= job_radio_dict
@@ -17,8 +17,8 @@
 	. = ..()
 
 	if(hidden_from_job_prefs)
-		for(var/job_title in GLOB.Jobs_tittles_SS220)
+		for(var/job_title in GLOB.Jobs_titles_SS220)
 			if(job_title in alt_titles)
 				return FALSE
-		if(title in GLOB.Jobs_tittles_SS220)
+		if(title in GLOB.Jobs_titles_SS220)
 			return FALSE

--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -22,7 +22,3 @@
 				return FALSE
 		if(title in GLOB.Jobs_tittles_SS220)
 			return FALSE
-
-	return .
-
-

--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -17,8 +17,8 @@
 	. = ..()
 
 	if(hidden_from_job_prefs)
-		for(var/job_tittle in GLOB.Jobs_tittles_SS220)
-			if(job_tittle in alt_titles)
+		for(var/job_title in GLOB.Jobs_tittles_SS220)
+			if(job_title in alt_titles)
 				return FALSE
 		if(title in GLOB.Jobs_tittles_SS220)
 			return FALSE

--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -12,3 +12,17 @@
 		job_radio_dict.Add(list("[i]" = "scirradio"))
 
 	all_jobs |= job_radio_dict
+
+/datum/job/is_position_available()
+	. = ..()
+
+	if(hidden_from_job_prefs)
+		for(var/job_tittle in GLOB.Jobs_tittles_SS220)
+			if(job_tittle in alt_titles)
+				return FALSE
+		if(title in GLOB.Jobs_tittles_SS220)
+			return FALSE
+
+	return .
+
+


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Убираем роли новичков из общего пула даже для педалей

## Почему это хорошо для игры

Это альтернативная должность с иконкой. Не более. Он не должен быть доп. слотом, т.к. все против этого.

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/41479614/c1cb39f8-8466-4604-89c0-ce397d115e73)

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Убраны должности новичков из общего пула профессий.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
