### PR TITLE
fix: role to ping for new round to config

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -178,7 +178,7 @@
 	if(escaped_on_pod_5)
 		SSblackbox.record_feedback("nested tally", "round_end_stats", escaped_on_pod_5, list("escapees", "on_pod_5"))
 
-	GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "A round of [name] has ended - [surviving_total] survivors, [ghosts] ghosts.<br> <@&1100491296658956410>") // SS220 Addition
+	GLOB.discord_manager.send2discord_simple(DISCORD_WEBHOOK_PRIMARY, "A round of [name] has ended - [surviving_total] survivors, [ghosts] ghosts. <@&[GLOB.configuration.discord.new_round_waiting_role]>") // SS220 Addition
 	if(SSredis.connected)
 		// Send our presence to required channels
 		var/list/presence_data = list()

--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -197,6 +197,8 @@ mentor_role_id = ""
 forward_all_ahelps = true
 
 
+new_round_waiting_role_id = ""
+
 ################################################################
 
 

--- a/modular_ss220/_misc/_misc.dme
+++ b/modular_ss220/_misc/_misc.dme
@@ -3,3 +3,4 @@
 #include "code/global_procs.dm"
 #include "code/ss220_general_config.dm"
 #include "code/icons.dm"
+#include "code/discord_configuration.dm"

--- a/modular_ss220/_misc/code/discord_configuration.dm
+++ b/modular_ss220/_misc/code/discord_configuration.dm
@@ -1,0 +1,6 @@
+/datum/configuration_section/discord_configuration
+	/// Admin role to ping if no admins are online. Disables if empty string
+	var/new_round_waiting_role = ""
+
+/datum/configuration_section/discord_configuration/load_data(list/data)
+	CONFIG_LOAD_STR(new_round_waiting_role, data["new_round_waiting_role_id"])


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Переносим роль которую должен пинговать сервер в конце раунда в конфиг
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Теперь каждый сервер будет пинговать своих ждунов
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
