### PR TITLE
Feat: Respawn return

### DIFF
--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -69,6 +69,7 @@
 #include "sm_space_drop/sm_space_drop.dme"
 #include "text_to_speech/_tts.dme"
 #include "title_screen/_title_screen.dme"
+#include "verbs/_verbs.dme"
 #include "whitelist/_whitelist.dme"
 #include "outfits/_outfits.dme"
 #include "world_view_bigger/_world_view_bigger.dme"

--- a/modular_ss220/verbs/_verbs.dm
+++ b/modular_ss220/verbs/_verbs.dm
@@ -1,0 +1,4 @@
+/datum/modpack/verbs
+	name = "Verbs"
+	desc = "Кастомные вербы, а также возвращение некоторых вырезанных."
+	author = "dj-34"

--- a/modular_ss220/verbs/_verbs.dme
+++ b/modular_ss220/verbs/_verbs.dme
@@ -1,0 +1,3 @@
+#include "_verbs.dm"
+
+#include "code/verbs.dm"

--- a/modular_ss220/verbs/code/verbs.dm
+++ b/modular_ss220/verbs/code/verbs.dm
@@ -1,0 +1,38 @@
+/*
+	Respawn to OOC
+	May be returned in the future by offs (because it's commented in code\modules\mob)
+*/
+/mob/verb/abandon_mob()
+	set name = "Respawn"
+	set category = "OOC"
+
+	if(!GLOB.configuration.general.respawn_enabled)
+		to_chat(usr, "<span class='warning'>Respawning is disabled.</span>")
+		return
+
+	if(stat != DEAD || !SSticker)
+		to_chat(usr, "<span class='boldnotice'>You must be dead to use this!</span>")
+		return
+
+	log_game("[key_name(usr)] has respawned.")
+
+	to_chat(usr, "<span class='boldnotice'>Make sure to play a different character, and please roleplay correctly!</span>")
+
+	if(!client)
+		log_game("[key_name(usr)] respawn failed due to disconnect.")
+		return
+	client.screen.Cut()
+	client.screen += client.void
+
+	if(!client)
+		log_game("[key_name(usr)] respawn failed due to disconnect.")
+		return
+
+	var/mob/new_player/M = new /mob/new_player()
+	if(!client)
+		log_game("[key_name(usr)] respawn failed due to disconnect.")
+		qdel(M)
+		return
+
+	M.key = key
+	return


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
- Возвращает кнопку Respawn
- Создаёт отдельный модуль "Verbs" на будущее, если вдруг пригодится вернуть что-то ещё (впрочем, сомневаюсь),
или добавить своё

## Почему это хорошо для игры
У игроков появляется опция респавна

## Изображения изменений
Ма бой
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/15155ee2-127d-4267-ad32-3cce492d66da)

## Тестирование
Проверил в игре

## Changelog

:cl:
tweak: Возвращена кнопка Respawn в OOC
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
