### PR TITLE
Tweak: Cyberiad brig tweaks

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -3653,8 +3653,8 @@
 /area/station/security/main)
 "apJ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -4578,7 +4578,7 @@
 	},
 /area/station/security/brig)
 "atA" = (
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/silver{
 	name = "Prison Showers"
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -54899,10 +54899,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/access_button{
+/obj/machinery/access_button/north{
 	autolink_id = "perma_btn_ext";
 	name = "Prison Wing Access Button";
-	pixel_y = 21;
 	req_one_access_txt = "2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -55599,8 +55598,7 @@
 	},
 /obj/machinery/flasher_button{
 	id = "prison";
-	pixel_x = -10;
-	pixel_y = 20
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -64356,7 +64354,7 @@
 	},
 /area/station/command/office/hos)
 "kBe" = (
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/bathroom{
 	name = "Prison Toilets"
 	},
 /obj/machinery/door/firedoor,
@@ -72952,9 +72950,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"nEQ" = (
-/turf/simulated/wall,
-/area/station/security/prison/cell_block/A)
 "nET" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -78288,10 +78283,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes,
-/obj/machinery/access_button{
+/obj/machinery/access_button/south{
 	autolink_id = "perma_btn_int";
 	name = "Prison Wing Access Button";
-	pixel_y = -21;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
@@ -81154,20 +81148,20 @@
 	int_button_link_id = "perma_btn_int";
 	int_door_link_id = "perma_door_int";
 	name = "Prison Access Console";
-	pixel_x = -22;
-	pixel_y = 22
+	pixel_x = -27;
+	pixel_y = 25
 	},
 /obj/machinery/door_control/shutter/north{
 	desc = "A remote control-switch to lock down the prison wing's blast doors";
 	id = "Prison Gate";
 	name = "Prison Wing Lockdown";
-	pixel_x = -32;
+	pixel_x = -38;
 	req_one_access_txt = "2"
 	},
 /obj/machinery/flasher_button{
 	id = "prison";
-	pixel_x = -20;
-	pixel_y = 31
+	pixel_x = -38;
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -81878,10 +81872,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes,
-/obj/machinery/access_button{
+/obj/machinery/access_button/north{
 	autolink_id = "perma_btn_int";
 	name = "Prison Wing Access Button";
-	pixel_y = 21;
 	req_one_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
@@ -85287,7 +85280,7 @@
 /area/station/command/meeting_room)
 "siM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock{
+/obj/machinery/door/airlock/bathroom{
 	name = "Prison Toilets"
 	},
 /obj/machinery/door/firedoor,
@@ -92240,10 +92233,9 @@
 	name = "Prison Wing"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/access_button{
+/obj/machinery/access_button/south{
 	autolink_id = "perma_btn_ext";
 	name = "Prison Wing Access Button";
-	pixel_y = -21;
 	req_one_access_txt = "2"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -131823,7 +131815,7 @@ aAx
 aoU
 aqU
 atb
-nEQ
+aAx
 hIC
 avY
 aAx
@@ -132851,7 +132843,7 @@ aAx
 aoX
 ajN
 ate
-nEQ
+aAx
 aum
 axJ
 aAx


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
 - Замена wall recharger на настольный recharger на столе в бриге
 - Перестановка кнопок на КПП пермабрига
 - Покраска парочки дверей в пермабриге

## Почему это хорошо для игры
Меньше раздражающих моментов

## Изображения изменений
Мапдифф

## Тестирование
В игре глядел

## Changelog

:cl:
tweak: Кибериада: Настенная зарядка в бриге на столе заменена на настольную зарядку, перестановка кнопок на КПП пермабрига, покрашены парочка дверей в пермабриге
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
