### PR TITLE
Fix: Remove Those Pluses

### DIFF
--- a/code/game/machinery/vendors/generic_vendors.dm
+++ b/code/game/machinery/vendors/generic_vendors.dm
@@ -982,7 +982,7 @@
 	icon_state = "Cola_Machine"
 	icon_lightmask = "Cola_Machine"
 	icon_panel = "thin_vendor"
-	slogan_list = list("Роб+аст с+офтдринкс: крепче, чем тулбоксом по голове!")
+	slogan_list = list("Робаст Софтдринкс: крепче, чем тулбоксом по голове!")
 	ads_list = list("Освежает!",
 					"Надеюсь, вас одолела жажда!",
 					"Продано больше миллиона бутылок!",


### PR DESCRIPTION
## Что этот PR делает
Убирает плюсики из слогана Робаст Софтдринкса

## Почему это хорошо для игры
Автомат больше не говорит "РобПЛЮСаст сПЛЮСофтдринкс"

## Тестирование
Не тестировал

## Changelog

:cl: Romains
fix: Убраны плюсики из слогана Робаст Софтдринкса
/:cl: