### PR TITLE
Fix:remove xen_mobs from golden extract

### DIFF
--- a/modular_ss220/maps220/code/mobs.dm
+++ b/modular_ss220/maps220/code/mobs.dm
@@ -860,7 +860,6 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 21
 	attack_sound = 'modular_ss220/mobs/sound/creatures/zombie_attack.ogg'
-	gold_core_spawnable = HOSTILE_SPAWN
 	alert_cooldown_time = 8 SECONDS
 	alert_sounds = list(
 		'modular_ss220/mobs/sound/creatures/zombie_idle1.ogg',,

--- a/modular_ss220/maps220/code/mobs.dm
+++ b/modular_ss220/maps220/code/mobs.dm
@@ -1046,6 +1046,7 @@
 	vision_range = 8
 	attack_sound = 'sound/weapons/bite.ogg'
 	loot = list(/obj/item/stack/sheet/bone)
+	gold_core_spawnable = HOSTILE_SPAWN
 	alert_sounds = list(
 		'modular_ss220/aesthetics_sounds/sound/mobs/vortigaunt/alert01.ogg',
 		'modular_ss220/aesthetics_sounds/sound/mobs/vortigaunt/alert01b.ogg',
@@ -1140,7 +1141,6 @@
 	wander = FALSE
 	attack_sound = 'sound/weapons/genhit3.ogg'
 	loot = list(/obj/item/crowbar/freeman/ultimate)
-	gold_core_spawnable = NO_SPAWN
 
 /obj/structure/xen_pylon/freeman
 	shield_range = 30

--- a/modular_ss220/maps220/code/objects.dm
+++ b/modular_ss220/maps220/code/objects.dm
@@ -581,6 +581,7 @@
 	var/shield_count = 0
 	faction = list("xen")
 	tts_seed = "Vortiger"
+	gold_core_spawnable = NO_SPAWN
 
 /mob/living/simple_animal/hostile/blackmesa/xen/update_overlays()
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Убрал /xen мобов из экстрактов. Оставил буллсквидов, песиков и вортигеров. 

## Почему это хорошо для игры

Произошла чудовищная ошибка.

## Изображения изменений
Нету.

## Тестирование
Локалка.

## Changelog

:cl:
fix: Из золотых экстрактов теперь можно получить враждебных буллсквидов, песиков и вортигеров.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
