### PR TITLE
Tweak: Cyberiad garden

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -14998,13 +14998,7 @@
 /turf/simulated/floor/wood/oak,
 /area/station/service/clown)
 "bdu" = (
-/obj/structure/table/glass,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/hatchet,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -15919,8 +15913,14 @@
 	},
 /area/station/service/expedition)
 "bgM" = (
+/obj/structure/table/glass,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/hatchet,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/firealarm/directional/west,
-/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -13411,7 +13411,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aXI" = (
+/obj/machinery/light/small/directional/west,
 /obj/structure/table/glass,
+/obj/item/reagent_containers/spray/pestspray{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 4;
+	pixel_x = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/garden)
 "aXL" = (
@@ -13888,9 +13897,9 @@
 	},
 /area/station/command/vault)
 "aZj" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/table/glass,
 /obj/item/cultivator,
+/obj/item/shovel/spade,
 /obj/item/hatchet,
 /obj/item/crowbar,
 /obj/item/plant_analyzer,
@@ -14989,7 +14998,13 @@
 /turf/simulated/floor/wood/oak,
 /area/station/service/clown)
 "bdu" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/table/glass,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/hatchet,
+/obj/item/crowbar,
+/obj/item/plant_analyzer,
+/obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"
@@ -15022,10 +15037,12 @@
 /area/station/hallway/primary/central/north)
 "bdx" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/spray/plantbgone,
-/obj/item/reagent_containers/spray/pestspray,
-/obj/item/reagent_containers/glass/bottle/nutrient/ez,
-/obj/item/reagent_containers/glass/bottle/nutrient/rh,
+/obj/item/reagent_containers/glass/bottle/nutrient/ez{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/glass/bottle/nutrient/rh{
+	pixel_x = -4
+	},
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -15902,13 +15919,8 @@
 	},
 /area/station/service/expedition)
 "bgM" = (
-/obj/structure/table/glass,
-/obj/item/hatchet,
-/obj/item/cultivator,
-/obj/item/crowbar,
-/obj/item/plant_analyzer,
-/obj/item/reagent_containers/glass/bucket,
 /obj/machinery/firealarm/directional/west,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "green"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
 - Добавил 2 лопатки в ассистушный сад Кибериады
 - Немного подвигал объекты
 
## Почему это хорошо для игры
Запрос от рандома, показалось логичным

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/8225b303-22ba-4f3f-b915-158acb7b9acd)

## Тестирование
trust me bro)

## Changelog

:cl:
tweak: Кибериада: В ассистентский сад добавлены 2 лопатки и чуть подвигал объекты 
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
