### PR TITLE
Fix: Radio exploit

### DIFF
--- a/modular_ss220/devices/code/items/radio.dm
+++ b/modular_ss220/devices/code/items/radio.dm
@@ -36,15 +36,13 @@
  *	Radio QoL improvement
  *	So players can Alt+click to enable dynamic and Ctrl+Shift+click to enable speaker
 */
-/obj/item/radio/examine(mob/user)
+/obj/item/radio/headset/examine(mob/user)
 	. = ..()
 	if(in_range(src, user) || loc == user)
 		. += span_info("Alt-click on \the [name] to toggle broadcasting.")
 		. += span_info("Ctrl-Shift-click on \the [src] to toggle speaker.")
 
-/obj/item/radio/AltClick(obj/item/I, mob/user)
-	if(!istype(I, /obj/item/radio/headset))
-		return
+/obj/item/radio/headset/AltClick(mob/user)
 	if(!Adjacent(user))
 		return
 	if(!iscarbon(usr) && !isrobot(usr))
@@ -55,9 +53,7 @@
 	broadcasting = !broadcasting
 	to_chat(user, span_notice("You toggle broadcasting [broadcasting ? "on" : "off"]."))
 
-/obj/item/radio/CtrlShiftClick(obj/item/I, mob/user)
-	if(!istype(I, /obj/item/radio/headset))
-		return
+/obj/item/radio/headset/CtrlShiftClick(mob/user)
 	if(!Adjacent(user))
 		return
 	if(!iscarbon(usr) && !isrobot(usr))

--- a/modular_ss220/devices/code/items/radio.dm
+++ b/modular_ss220/devices/code/items/radio.dm
@@ -42,7 +42,9 @@
 		. += span_info("Alt-click on \the [name] to toggle broadcasting.")
 		. += span_info("Ctrl-Shift-click on \the [src] to toggle speaker.")
 
-/obj/item/radio/AltClick(mob/user)
+/obj/item/radio/AltClick(obj/item/I, mob/user)
+	if(!istype(I, /obj/item/radio/headset))
+		return
 	if(!Adjacent(user))
 		return
 	if(!iscarbon(usr) && !isrobot(usr))
@@ -53,7 +55,9 @@
 	broadcasting = !broadcasting
 	to_chat(user, span_notice("You toggle broadcasting [broadcasting ? "on" : "off"]."))
 
-/obj/item/radio/CtrlShiftClick(mob/user)
+/obj/item/radio/CtrlShiftClick(obj/item/I, mob/user)
+	if(!istype(I, /obj/item/radio/headset))
+		return
 	if(!Adjacent(user))
 		return
 	if(!iscarbon(usr) && !isrobot(usr))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Больше нельзя включать рацию где не положено

## Почему это хорошо для игры

## Изображения изменений

## Тестирование
Посмотрел в игре

## Changelog

:cl:
fix: Больше нельзя включать рацию там, где не положено
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
