### PR TITLE
Fix: Newspaper text

### DIFF
--- a/code/modules/newscaster/obj/newspaper.dm
+++ b/code/modules/newscaster/obj/newspaper.dm
@@ -43,7 +43,7 @@
 		return
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_user = user
-		var/dat
+		var/dat = {"<meta charset="UTF-8">"}
 		pages = 0
 		switch(screen)
 			if(SCREEN_COVER) //Cover
@@ -164,7 +164,7 @@
 			to_chat(user, "<span class='notice'>There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?</span>")
 		else
 			var/s = strip_html(input(user, "Write something", "Newspaper", ""))
-			s = sanitize(copytext(s, 1, MAX_MESSAGE_LEN))	// SS220 EDIT - ORIGINAL: copytext
+			s = sanitize(copytext(s, 1, MAX_MESSAGE_LEN))
 			if(!s || !Adjacent(user))
 				return
 			scribble_page = curr_page

--- a/code/modules/newscaster/obj/newspaper.dm
+++ b/code/modules/newscaster/obj/newspaper.dm
@@ -43,7 +43,7 @@
 		return
 	if(ishuman(user))
 		var/mob/living/carbon/human/human_user = user
-		var/dat = {"<meta charset="UTF-8">"}
+		var/dat = {"<meta charset="UTF-8">"} // SS220 ADDITION
 		pages = 0
 		switch(screen)
 			if(SCREEN_COVER) //Cover


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Чинит кириллицу в газетах

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Потому что

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/69762909/3d664cf6-fee1-4950-a943-25fc0974da0a)

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Газеты теперь корректно отображают кириллицу
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
