### PR TITLE
FIX: Gategun

### DIFF
--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -54,6 +54,8 @@
 /obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2/attack_self(mob/living/user)
 	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [src], но он не поддается!")
 	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [src], но он заблокирован.")
+	var/msg_recharge_all = span_notice("[user.name] усердно давит на рычаг зарядки [src]...")
+	var/msg_recharge_user = span_notice("Вы со всей силы давите на рычаг зарядки [src], пытаясь зарядить её...")
 
 	if(!is_away_level(loc.z))
 		user.visible_message(msg_for_all, msg_for_user)

--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -10,7 +10,6 @@
 	origin_tech = "combat=5;magnets=3;powerstorage=4"
 	selfcharge = TRUE // Selfcharge is enabled and disabled, and used as the away mission tracker
 	can_charge = 0
-	emagged = FALSE
 
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
@@ -18,17 +17,15 @@
 	onTransitZ(new_z = loc.z)
 
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
-	if(emagged)
-		return
 
 	if(is_away_level(new_z))
 		if(ismob(loc))
-			to_chat(loc, span_notice("Ваш [name] активируется, начиная потреблять энергию от ближайшего беспроводного источника питания."))
+			to_chat(loc, span_notice("Ваш [src] активируется, начиная аккумулировать энергию из материи сущего."))
 		selfcharge = TRUE
 	else
 		if(selfcharge)
 			if(ismob(loc))
-				to_chat(loc, span_danger("Ваш [name] деактивируется, так как он находится вне зоны действия источника питания.</span>"))
+				to_chat(loc, span_danger("Ваш [src] деактивируется, так как он подавляется системами станции.</span>"))
 			cell.charge = 0
 			selfcharge = FALSE
 			update_icon()
@@ -38,54 +35,27 @@
 		var/mob/M = loc
 		M.unEquip(src)
 
-/obj/item/gun/energy/laser/awaymission_aeg/emag_act(mob/user)
-	. = ..()
-	if(emagged)
-		return
-	if(user)
-		if(prob(50))
-			user.visible_message(span_warning("От [name] летят искры!"), span_notice("Вы взломали [name], что привело к перезаписи протоколов безопасности. Устройство может быть использовано вне ограничений"))
-			playsound(loc, 'sound/effects/sparks4.ogg', 30, 1)
-			do_sparks(5, 1, src)
-			emagged = TRUE
-			selfcharge = TRUE
-		else
-			user.visible_message(span_warning("От [name] летят искры... Он сейчас взорвётся!"), span_notice("Ой... Что-то пошло не так!"))
-			do_sparks(5, 1, src)
-			update_mob()
-			explosion(loc, -1, 0, 2)
-			qdel(src)
-
-/obj/item/gun/energy/laser/awaymission_aeg/emp_act(severity)
-	. = ..()
-	emag_act()
-
 // GUNS
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
-	name = "Exploreverse Mk I"
-	desc = "Первый прототип оружия с миниатюрным реактором для исследований в крайне отдаленных секторах. \
-	\nДанную модель невозможно подключить к зарядной станции, во избежание истощения подключенных источников питания, \
-	в связи с протоколами безопасности, опустошающие заряд при нахождении вне предназначенных мест использования устройств."
-	origin_tech = "combat=3;magnets=3;powerstorage=4"
-	force = 10
+	name = "Exploreverse Mk.I"
+	desc = "Прототип оружия с миниатюрным реактором для исследований в крайне отдаленных секторах. \
+	\n Данная модель использует экспериментальную систему обратного восполнения, работающую на принципе огромной аккумуляции энергии, но крайне уязвимую к радиопомехам, которыми кишит сектор станции, попростую не работая там."
+	origin_tech = "combat=2;powerstorage=3"
 
 /obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2
-	name = "Exploreverse Mk II"
-	desc = "Второй прототип оружия с миниатюрным реактором и ручным восполнением для исследований в крайне отдаленных секторах. \
-	\nДанная модель оснащена системой ручного восполнения энергии типа \"Za.E.-8 A.L'sya\", \
-	позволяющий в короткие сроки восполнить необходимую электроэнергию с помощью ручного труда, личной энергии и дергания за рычаг подключенного к системе зарядки. \
-	\nСистему автозарядки невозможно использовать, в связи с протоколами безопасности, \
-	опустошающие заряд при нахождении вне предназначенных мест использования устройств. \
+	name = "Exploreverse Mk.II"
+	desc = "Второй прототип оружия с миниатюрным реактором и забавным рычагом для исследований в крайне отдаленных секторах. \
+	\nДанная модель оснащена системой ручного восполнения энергии \"Za.E.-8 A.L'sya\", \
+	позволяющей в короткие сроки восполнить необходимую электроэнергию с помощью ручного труда и конвертации личной энергии подключенного к системе зарядки. \
 	\nТеперь еще более нелепый дизайн с торчащими проводами!"
 	icon_state = "laser_gate_mk2"
-	origin_tech = "combat=5;magnets=3;powerstorage=5;programming=3;engineering=5"
-	force = 10
+	origin_tech = "combat=3;magnets=2;powerstorage=2;programming=3;"
 
 /obj/item/gun/energy/laser/awaymission_aeg/rnd/mk2/attack_self(mob/living/user)
-	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [name], но он не поддается!")
-	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но он заблокирован.")
+	var/msg_for_all = span_warning("[user.name] усердно давит на рычаг зарядки [src], но он не поддается!")
+	var/msg_for_user = span_notice("Вы пытаетесь надавить на рычаг зарядки [src], но он заблокирован.")
 
-	if(!is_away_level(loc.z) && !emagged)
+	if(!is_away_level(loc.z))
 		user.visible_message(msg_for_all, msg_for_user)
 		return FALSE
 
@@ -93,14 +63,17 @@
 		user.visible_message(msg_for_all, msg_for_user)
 		return FALSE
 
-	if(user.nutrition <= NUTRITION_LEVEL_HYPOGLYCEMIA)
-		user.visible_message(span_warning("[user.name] слабо давит на [name], но он ослаб!"), span_notice("Вы пытаетесь надавить на рычаг зарядки [name], но не можете из-за усталости!"))
+	if(user.nutrition <= NUTRITION_LEVEL_STARVING)
+		user.visible_message(span_warning("[user.name] слабо давит на [src], но бесполезно: слишком мало сил!"), span_notice("Вы пытаетесь надавить на рычаг зарядки [src], но не можете из-за голода и усталости!"))
 		return FALSE
 
+	user.visible_message(msg_recharge_all, msg_recharge_user)
 	playsound(loc, 'sound/effects/sparks3.ogg', 10, 1)
 	do_sparks(1, 1, src)
 
-	cell.give(25)
-	user.adjust_nutrition(-2)
-
+	if(!do_after_once(user, 3 SECONDS, target = src))
+		return
+	cell.give(166)
+	on_recharge()
+	user.adjust_nutrition(-25)
 	. = ..()


### PR DESCRIPTION


## Что этот PR делает

Заново создана на основе https://github.com/ss220club/Paradise-SS220/pull/597/files

Полностью фиксит гейтган мк1 и мк2:

- Переработано описание гейтганов на более короткое и понятное
- Убрана лазейка, позволяющая апгрейднуть технологии с 5 до 6 тупо из протолата
- Убрана возможность емага. ЭМИ так же теперь не емагает пушку.
- Убрана приписка force = 10, ибо она и так наследуется.
- Убрана возможность зарядки мк2 в бою, не давая более анлимит боеприпасов. Переработано потребление хавки при зарядке.

## Почему это хорошо для игры

Безлимит пушки на станции забесплатно в рнд - плохо, супер плохо. Безлимит пушка в гейте так же ломает баланс гейтов, превращая их в тир. Слишком малое потребление хавки совершенно не влияет, даже не стимулируя брать еду. Зарядка мк2 все еще дает супер скорую зарядку пушки, но теперь непосредственно в бою заряжать пушку не удастся. 

## Изображения изменений
их нет

## Тестирование
уже тестировал ранее и в дополнительном не нуждается

## Changelog

:cl:
tweak: Поменял описание гейт ганов
tweak: Поменял способ зарядки мк2
del: Удалил возможность емага
del: Убрал лазейку в технологиях
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
