### PR TITLE
Tweak: Change channel name for discord authorization

### DIFF
--- a/modular_ss220/discord_link/code/discord.dm
+++ b/modular_ss220/discord_link/code/discord.dm
@@ -41,7 +41,7 @@
 		return
 
 	qdel(query_replace_token)
-	to_chat(usr, span_darkmblue("Для завершения, вставьте это: <br>") + span_boldannounce("/привязать token:[token]") + span_darkmblue("<br>В канал <b>#дом-бота</b> в Discord-сообществе!"))
+	to_chat(usr, span_darkmblue("Для завершения, вставьте это: <br>") + span_boldannounce("/привязать token:[token]") + span_darkmblue("<br>В канал <b><a href='https://discord.com/channels/1097181193939730453/1162068725168623696'>#ss13-бот</a></b> в Discord-сообществе!"))
 
 /mob/new_player/Topic(href, href_list)
 	if(src != usr)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
 - Добавлена прямая ссылка на канал
 - Изменено название канала в соответствии с изменениям в ДСе

## Почему это хорошо для игры
Меньше конфуза

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/899b39d6-9ac5-4c86-a00e-a644246b4a16)

## Тестирование
Проверил в игре

## Changelog

:cl:
tweak: Изменено название канала отображаемое при привязка ДСа, а также добавлена прямая ссылка на канал
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
