### PR TITLE
Fix: Outpost QM's office door to glass type

### DIFF
--- a/_maps/map_files220/generic/Lavaland.dmm
+++ b/_maps/map_files220/generic/Lavaland.dmm
@@ -2351,7 +2351,7 @@
 	},
 /area/mine/outpost/storage)
 "eT" = (
-/obj/machinery/door/airlock/command/qm{
+/obj/machinery/door/airlock/command/qm/glass{
 	name = "Quartermaster's Office"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10571,7 +10571,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/command/qm{
+/obj/machinery/door/airlock/command/qm/glass{
 	name = "Quartermaster's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Чиню линтер

## Почему это хорошо для игры
Я ебланчик

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Двери офиса КМа на шахтёрском аванпосте теперь стеклянные и затемняются
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
