### PR TITLE
Fix: Delta mini fixes

### DIFF
--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -27266,7 +27266,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/secure_data/laptop,
+/obj/item/paper_bin{
+	pixel_y = 4;
+	pixel_x = 6
+	},
+/obj/item/pen/multi{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/ashtray/glass{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba,
+/obj/item/lighter/zippo/engraved{
+	pixel_x = -5
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/magistrate)
 "cen" = (
@@ -27843,7 +27858,14 @@
 /area/station/turret_protected/aisat)
 "cgL" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/computer/secure_data/laptop,
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/pen/multi{
+	pixel_x = -4;
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/courtroom)
 "cgM" = (
@@ -50848,18 +50870,6 @@
 /area/station/engineering/controlroom)
 "eMB" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 14;
-	pixel_x = -5
-	},
-/obj/item/paper_bin{
-	pixel_y = 4;
-	pixel_x = 6
-	},
-/obj/item/pen/multi{
-	pixel_y = 6;
-	pixel_x = 6
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -50869,14 +50879,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/item/ashtray/glass{
-	pixel_x = -8;
-	pixel_y = -4
-	},
-/obj/item/clothing/mask/cigarette/cigar/cohiba,
-/obj/item/lighter/zippo/engraved{
-	pixel_x = -5
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -50888,6 +50890,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/computer/secure_data/laptop,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/magistrate)
 "eMP" = (
@@ -57314,7 +57317,6 @@
 "gQg" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
-/obj/item/gavelhammer,
 /obj/item/stamp/magistrate{
 	pixel_x = 7;
 	pixel_y = 8
@@ -57324,6 +57326,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14;
+	pixel_x = -5
+	},
+/obj/item/gavelhammer,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/magistrate)
 "gQm" = (
@@ -64312,13 +64319,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/wood/fancy/black,
-/obj/item/paper_bin,
-/obj/item/pen/multi,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/secure_data/laptop,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/courtroom)
 "iYU" = (

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -27261,14 +27261,12 @@
 /area/station/legal/courtroom)
 "cem" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/secure_data/laptop{
-	dir = 8
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/secure_data/laptop,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/magistrate)
 "cen" = (
@@ -27845,9 +27843,7 @@
 /area/station/turret_protected/aisat)
 "cgL" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/computer/secure_data/laptop{
-	dir = 4
-	},
+/obj/machinery/computer/secure_data/laptop,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/courtroom)
 "cgM" = (
@@ -58864,7 +58860,7 @@
 "hqM" = (
 /obj/machinery/door/airlock{
 	name = "Bedroom";
-	id_tag = "PrivateRoom1"
+	id_tag = "PrivateRoom2"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Ноутбук у магистрата и в суде направлен вниз
Исправлен доступ в спальне дормов (был одинаковый на обеих)
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Исправления, очевидно
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/104691597/0aaaf22b-e741-4755-8655-953377bf2ecd)
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Не требуется
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Ноутбук в суде и офисе магистрата теперь направлен вниз
fix: ID шлюза спальни теперь работает правильно
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
