### PR TITLE
[TM ONLY] fix: remove cleanables from jani hood on destroy

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -105,6 +105,9 @@
 		plane = GAME_PLANE // so they can be seen above walls
 
 /obj/effect/decal/cleanable/Destroy()
+	var/datum/atom_hud/data/janitor/jani_hud = GLOB.huds[DATA_HUD_JANITOR]
+	jani_hud.remove_from_hud(src)
+
 	if(smoothing_flags)
 		QUEUE_SMOOTH_NEIGHBORS(src)
 	return ..()


### PR DESCRIPTION

## Что этот PR делает

Исправляет проблему с GC при удалении `cleanable`

## Почему это хорошо для игры

Значительно меньше лагов

## Изображения изменений
В коде

## Тестирование
Компилируется

CL не надо
