### PR TITLE
Tweak: Give IPC's they own survival box

### DIFF
--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -4,4 +4,4 @@
 #include "code/items/weapons.dm"
 #include "code/jobs/warden.dm"
 #include "code/mobs/aliens/larva.dm"
-#include "code/species/nucleation.dm"
+#include "code/species/machine.dm"

--- a/modular_ss220/balance/code/species/machine.dm
+++ b/modular_ss220/balance/code/species/machine.dm
@@ -1,0 +1,12 @@
+/datum/species/machine
+	speciesbox = /obj/item/storage/box/survival_ipc
+
+// Survival box for IPC
+/obj/item/storage/box/survival_ipc
+	icon = 'modular_ss220/aesthetics/boxes/icons/boxes.dmi'
+	icon_state = "machine_box"
+
+/obj/item/storage/box/survival_ipc/populate_contents()
+	new /obj/item/weldingtool(src)
+	new /obj/item/stack/cable_coil/five(src)
+	new /obj/item/flashlight/flare/glowstick/emergency(src)

--- a/modular_ss220/balance/code/species/nucleation.dm
+++ b/modular_ss220/balance/code/species/nucleation.dm
@@ -1,2 +1,0 @@
-/datum/species/nucleation
-	blacklisted = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->
_Я хоть нормальную папку выбрал под модуль?_

## Что этот PR делает
"Затрагивает" баланс, хотел отослать оффам, но у них нет спрайта коробки для КПБ, увы xdd
- Даёт КПБ собственный набор выживания: 5 мотков провода, 1 сварка, 1 глоустик
- Вырезаем полностью код Нуклеаций из модуля, так как в билде их больше нет

Closes https://github.com/ss220club/Paradise-SS220/issues/657

## Почему это хорошо для игры
Больше не даём коробки выживания с хер пойми чем для машины

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/869d5250-a83b-4091-8a4f-7b9840eb26c9)
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/19893b71-0093-4dbe-acf5-f09a6538fcfd)

## Тестирование
Проверил в игре

## Changelog

:cl:
tweak: КПБ добавлены собственные коробки выживания с сваркой, проводами и глоустиком
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
