### PR TITLE
fix: shrek narrator name collision

### DIFF
--- a/modular_ss220/text_to_speech/code/seeds/silero.dm
+++ b/modular_ss220/text_to_speech/code/seeds/silero.dm
@@ -4546,7 +4546,7 @@
 	gender = TTS_GENDER_MALE
 
 /datum/tts_seed/silero/srek_narrator
-	name = "Narrator"
+	name = "Shrek Narrator"
 	value = "Srek_Narrator"
 	category = TTS_CATEGORY_SHREK
 	gender = TTS_GENDER_MALE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Я не заметил что имя голоса у нарратора из Шрека и нарратора из варкрафта совпадает.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #1234" (где 1234 - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Чиню то что голос рассказчика из Шрека заменялся голосом рассказчика из варкрафта
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
