### PR TITLE
Feat: Maps actualization & fixes

### DIFF
--- a/_maps/map_files220/MetaStation/MetaStation.dmm
+++ b/_maps/map_files220/MetaStation/MetaStation.dmm
@@ -818,6 +818,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -3169,13 +3174,8 @@
 /turf/space,
 /area/space/nearstation)
 "auq" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/break_room)
+/turf/simulated/wall/r_wall,
+/area/station/engineering/ai_transit_tube)
 "aus" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8911,10 +8911,11 @@
 "aPw" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Requests Console";
-	pixel_y = 30
+	department = "Quartermaster's Desk";
+	departmentType = 5;
+	name = "Quartermaster Requests Console";
+	pixel_y = 30;
+	announcementConsole = 1
 	},
 /obj/machinery/photocopier/faxmachine/longrange{
 	pixel_y = 4;
@@ -15338,7 +15339,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "bik" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -16562,7 +16563,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "blA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plating,
@@ -17077,9 +17078,7 @@
 /obj/item/storage/photo_album{
 	pixel_y = -4
 	},
-/obj/item/camera{
-	pixel_y = 4
-	},
+/obj/item/camera,
 /obj/item/radio/intercom/private{
 	pixel_x = -28
 	},
@@ -19137,7 +19136,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "bsE" = (
 /obj/machinery/light/small/directional/south,
 /obj/vehicle/janicart,
@@ -19182,7 +19181,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "bsK" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_4)
@@ -20942,7 +20941,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "bxy" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
@@ -45666,7 +45665,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "dJx" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel{
@@ -49154,7 +49153,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "fqX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -51303,7 +51302,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "gpV" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Mass Driver Door";
@@ -53278,7 +53277,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "hkF" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_2)
@@ -54250,7 +54249,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "hED" = (
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
@@ -56001,10 +56000,7 @@
 /obj/structure/table/reinforced,
 /obj/item/scalpel,
 /obj/item/autopsy_scanner,
-/obj/item/camera/autopsy{
-	pixel_x = -2;
-	pixel_y = -2
-	},
+/obj/item/camera/autopsy,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -61694,6 +61690,16 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -63659,11 +63665,6 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -65102,7 +65103,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "mBn" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/solar/starboard)
@@ -66006,9 +66007,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
@@ -66333,7 +66334,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "ncC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/classic/normal{
@@ -69580,11 +69581,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "oMn" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -71657,11 +71663,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "pKs" = (
@@ -72876,7 +72877,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "qkD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -74479,7 +74480,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "rab" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77094,7 +77095,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "slT" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -79607,12 +79608,7 @@
 /obj/structure/rack,
 /obj/item/hand_labeler,
 /obj/item/folder/red,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "detective's camera";
-	pixel_x = -2;
-	pixel_y = 3
-	},
+/obj/item/camera/detective,
 /obj/item/taperecorder{
 	pixel_x = -1
 	},
@@ -80285,7 +80281,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "tOF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -82327,10 +82323,15 @@
 	id_tag = "transittube";
 	name = "Transit Tube Blast Door"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "uRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -87372,7 +87373,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "xrS" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -87611,11 +87612,13 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/break_room)
+/area/station/engineering/ai_transit_tube)
 "xyc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -132146,7 +132149,7 @@ bjN
 bjN
 bnt
 xrx
-auq
+bpn
 lQJ
 gYM
 hHE
@@ -132405,12 +132408,12 @@ nmh
 aLw
 pKi
 aiE
-bnt
-bnt
-bnt
-bnt
-bnt
-bnt
+auq
+auq
+auq
+auq
+auq
+auq
 iRu
 mpP
 skc
@@ -132919,7 +132922,7 @@ bnt
 xYR
 nCm
 tyW
-bnt
+auq
 hkm
 tNQ
 mAZ
@@ -133180,7 +133183,7 @@ wUa
 bsI
 bxx
 bly
-bnt
+auq
 qZz
 iRu
 fmo
@@ -133437,7 +133440,7 @@ wUa
 dIn
 sls
 hEA
-bnt
+auq
 ncA
 iRu
 yif
@@ -133694,7 +133697,7 @@ sTM
 jKS
 aXO
 aXO
-bnt
+auq
 qkC
 iRu
 ciD

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -3100,10 +3100,7 @@
 /area/station/security/lobby)
 "anZ" = (
 /obj/structure/table,
-/obj/item/camera{
-	pixel_x = 3;
-	pixel_y = -4
-	},
+/obj/item/camera,
 /obj/item/taperecorder{
 	pixel_x = -4;
 	pixel_y = 2
@@ -3395,10 +3392,7 @@
 /area/station/security/prison/cell_block/A)
 "apa" = (
 /obj/structure/table,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "Camera"
-	},
+/obj/item/camera,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
 "apc" = (
@@ -6081,11 +6075,7 @@
 /obj/item/camera_film{
 	pixel_y = 7
 	},
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "detectives camera";
-	pixel_y = 2
-	},
+/obj/item/camera/detective,
 /turf/simulated/floor/wood/oak,
 /area/station/security/detective)
 "ayB" = (
@@ -7616,10 +7606,7 @@
 /area/station/hallway/primary/fore)
 "aDb" = (
 /obj/structure/table,
-/obj/item/camera{
-	pixel_x = 3;
-	pixel_y = -4
-	},
+/obj/item/camera,
 /obj/machinery/door_control/shutter/north{
 	id = "brig_courtroom";
 	name = "Brig Courtroom Shutter Control";
@@ -12852,7 +12839,7 @@
 	dir = 9;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "aWh" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -23589,9 +23576,10 @@
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Requests Console";
+	department = "Quartermaster's Desk";
+	departmentType = 5;
+	name = "Quartermaster Requests Console";
+	announcementConsole = 1;
 	pixel_x = -30
 	},
 /turf/simulated/floor/carpet,
@@ -29422,11 +29410,7 @@
 /area/station/security/range)
 "cnW" = (
 /obj/structure/table,
-/obj/item/camera{
-	name = "Autopsy Camera";
-	pixel_x = 4;
-	pixel_y = 8
-	},
+/obj/item/camera/autopsy,
 /obj/item/scalpel{
 	pixel_y = 2
 	},
@@ -29995,7 +29979,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "cqK" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse,
@@ -33027,7 +33011,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "cCq" = (
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
@@ -36154,7 +36138,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "cOf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38577,7 +38561,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "cVI" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -38769,7 +38753,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "cWz" = (
 /obj/machinery/light/small/directional/south,
 /obj/item/radio/intercom/directional/south,
@@ -39862,7 +39846,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "dah" = (
@@ -40232,7 +40215,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "dbI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public{
@@ -41766,7 +41749,7 @@
 	dir = 5;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "dgU" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/stripes/line{
@@ -41830,7 +41813,7 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "dhp" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -43171,7 +43154,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "dmz" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/supermatter_room)
@@ -43609,10 +43592,7 @@
 "dnM" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "Camera"
-	},
+/obj/item/camera,
 /obj/item/book/codex_gigas,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -44234,7 +44214,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "dqD" = (
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
@@ -46258,7 +46238,7 @@
 /turf/simulated/floor/plasteel/stairs/right{
 	dir = 8
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "dTI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -46688,7 +46668,7 @@
 /area/station/hallway/primary/aft)
 "ecH" = (
 /turf/simulated/wall,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ecI" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/chair/office/dark{
@@ -47157,7 +47137,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "eic" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/decal/cleanable/dirt,
@@ -53584,9 +53564,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "gDJ" = (
@@ -54908,7 +54885,7 @@
 	dir = 10;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "gYO" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -55219,9 +55196,6 @@
 /obj/machinery/atmospherics/binary/volume_pump/on{
 	dir = 1;
 	name = "Space Loop Out"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -58828,7 +58802,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ivY" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/camera{
@@ -58960,7 +58934,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ixM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -61483,7 +61457,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluefull"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "jxs" = (
 /turf/simulated/floor/plating,
 /area/station/engineering/utility)
@@ -62891,12 +62865,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "kak" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/space,
+/area/space/nearstation)
 "kaB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -64863,7 +64835,7 @@
 	vent_link_id = "eng_sm_vent"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "kLR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -67213,6 +67185,13 @@
 	icon_state = "darkyellowcorners"
 	},
 /area/station/engineering/atmos/control)
+"lGD" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
+	},
+/turf/space,
+/area/space/nearstation)
 "lGP" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -67628,7 +67607,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -71384,7 +71363,6 @@
 "ngQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "ngS" = (
@@ -72306,7 +72284,7 @@
 /area/station/security/brig)
 "nvN" = (
 /turf/simulated/wall/r_wall,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "nvO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -74125,7 +74103,7 @@
 "ogH" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ogI" = (
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
@@ -74338,7 +74316,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ojz" = (
 /obj/structure/sign/poster/contraband/random/west,
 /obj/effect/decal/cleanable/dirt,
@@ -74415,7 +74393,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "okB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -75369,7 +75347,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "floorgrime"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "oDE" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -82136,7 +82114,7 @@
 /obj/structure/disposalpipe/segment/corner,
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
+	dir = 9
 	},
 /turf/space,
 /area/space/nearstation)
@@ -83381,7 +83359,7 @@
 "rxp" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "rxK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84732,7 +84710,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "rZF" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -85808,7 +85786,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "stp" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -88399,7 +88377,7 @@
 /turf/simulated/floor/plasteel/stairs/left{
 	dir = 8
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "tmS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -89952,7 +89930,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "tSx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90927,7 +90905,7 @@
 	dir = 10;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ujX" = (
 /obj/effect/spawner/random_spawners/fungus_maybe,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -95434,7 +95412,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "vQT" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -95563,7 +95541,7 @@
 	dir = 8;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "vSH" = (
 /obj/structure/closet/crate/can,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -98314,6 +98292,16 @@
 	icon_state = "green"
 	},
 /area/station/service/hydroponics)
+"wXK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "wYg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98807,7 +98795,7 @@
 	dir = 4;
 	icon_state = "darkbluecorners"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "xgn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -101935,7 +101923,7 @@
 	dir = 6;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ykt" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -127700,9 +127688,9 @@ dar
 dev
 sLy
 dcq
-aab
-aab
-aab
+lGD
+kak
+kak
 qVf
 ucU
 xxh
@@ -127957,10 +127945,10 @@ dar
 wzQ
 jPX
 dcq
-aab
+rMi
 cZS
 cZS
-kmr
+dij
 fEE
 dij
 dij
@@ -128214,7 +128202,7 @@ dar
 iyc
 dcq
 dcq
-dij
+kmr
 cZS
 sRi
 hfb
@@ -128471,10 +128459,10 @@ dar
 yme
 tIg
 snV
-cde
+wXK
 cde
 dbt
-kak
+daM
 daM
 xsl
 dop

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -12434,7 +12434,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "bcq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -18235,7 +18235,7 @@
 "bAF" = (
 /obj/machinery/light/small/directional/east,
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "bAI" = (
 /obj/machinery/alarm/directional/south,
 /obj/machinery/light/small/directional/south,
@@ -21751,8 +21751,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bLU" = (
@@ -21764,6 +21768,12 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
@@ -21777,6 +21787,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
@@ -23026,19 +23042,22 @@
 /turf/simulated/wall,
 /area/space/nearstation)
 "bPU" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
 /turf/space,
 /area/space/nearstation)
 "bPV" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/horizontal,
-/turf/space,
-/area/space/nearstation)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/aisat)
 "bPW" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved{
 	dir = 8
 	},
@@ -23614,7 +23633,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bRQ" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/space,
 /area/space/nearstation)
@@ -24366,10 +24385,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bTR" = (
@@ -24378,12 +24399,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -24410,12 +24425,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bTU" = (
@@ -24426,12 +24435,6 @@
 	dir = 8
 	},
 /obj/structure/transit_tube_pod,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bTV" = (
@@ -24581,6 +24584,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/space,
 /area/space/nearstation)
@@ -24760,6 +24769,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/space,
 /area/space/nearstation)
 "bVj" = (
@@ -24809,6 +24824,12 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/space,
 /area/space/nearstation)
@@ -24985,19 +25006,13 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bWb" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/diagonal,
 /turf/space,
 /area/space/nearstation)
 "bWd" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/space,
 /area/space/nearstation)
 "bWl" = (
@@ -25316,6 +25331,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/space,
 /area/space/nearstation)
 "bXH" = (
@@ -25399,14 +25416,14 @@
 	},
 /area/station/turret_protected/aisat)
 "bXR" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved{
 	dir = 4
 	},
 /turf/space,
 /area/space/nearstation)
 "bXS" = (
-/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
@@ -25508,6 +25525,12 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/space,
 /area/space/nearstation)
@@ -25625,6 +25648,12 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/space,
 /area/space/nearstation)
@@ -25809,19 +25838,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
-"bZw" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
 "bZx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28029,11 +28045,16 @@
 /area/station/command/teleporter)
 "chw" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
 	},
 /turf/space,
 /area/space/nearstation)
@@ -29558,12 +29579,6 @@
 /area/station/command/teleporter)
 "cnH" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/transit_tube/junction{
 	dir = 4
 	},
@@ -29691,12 +29706,6 @@
 /area/station/engineering/control)
 "coi" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/transit_tube/crossing{
 	dir = 8
 	},
@@ -30663,12 +30672,6 @@
 /area/station/engineering/control)
 "csr" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/transit_tube/horizontal,
 /turf/space,
 /area/space/nearstation)
@@ -30722,19 +30725,6 @@
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plating,
 /area/station/engineering/equipmentstorage)
-"csy" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/transit_tube/curved{
-	dir = 8
-	},
-/turf/space,
-/area/space/nearstation)
 "csz" = (
 /obj/structure/closet/crate{
 	name = "solar pack crate"
@@ -30967,19 +30957,6 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/carpet,
 /area/station/service/library)
-"ctI" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
 "ctJ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/curved{
@@ -41955,9 +41932,7 @@
 /area/station/medical/cryo)
 "drZ" = (
 /obj/structure/table/reinforced,
-/obj/item/camera{
-	pixel_y = 2
-	},
+/obj/item/camera,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -49614,7 +49589,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "esw" = (
 /obj/machinery/access_button{
 	autolink_id = "enginen_btn_ext";
@@ -50614,7 +50589,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "eJJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -50630,7 +50605,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "eJO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -50911,7 +50886,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "eNt" = (
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
@@ -52803,7 +52778,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ftD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -53593,8 +53568,14 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "fGU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -55964,7 +55945,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "gtR" = (
-/obj/item/seeds/coffee,
+/obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -57620,7 +57601,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "gVw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -58257,14 +58238,11 @@
 /obj/structure/transit_tube/station{
 	dir = 1
 	},
-/obj/structure/transit_tube_pod{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "hgs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60855,7 +60833,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "hVT" = (
 /obj/effect/turf_decal/stripes/white/line{
 	color = "lightblue"
@@ -65327,7 +65305,7 @@
 "jof" = (
 /obj/structure/transit_tube/horizontal,
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "jog" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -69433,14 +69411,8 @@
 	},
 /area/station/security/permabrig)
 "kFr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "kFG" = (
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "HoS"
@@ -70069,11 +70041,7 @@
 /area/station/maintenance/fore2)
 "kOr" = (
 /obj/structure/table,
-/obj/item/camera{
-	name = "Autopsy Camera";
-	pixel_x = 4;
-	pixel_y = 8
-	},
+/obj/item/camera/autopsy,
 /obj/item/autopsy_scanner{
 	pixel_x = -2;
 	pixel_y = 4
@@ -75272,7 +75240,7 @@
 	},
 /area/station/hallway/primary/fore)
 "myi" = (
-/obj/item/vending_refill/cola,
+/obj/machinery/economy/vending/cola,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
@@ -83523,15 +83491,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/magistrate)
-"pbJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
 "pbQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -84829,8 +84788,14 @@
 	name = "exterior access button";
 	req_access_txt = "10;13"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "ptU" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86134,7 +86099,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "pQa" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "HoS"
@@ -88024,7 +87989,7 @@
 /area/station/legal/courtroom)
 "qwS" = (
 /turf/simulated/wall/r_wall,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "qxd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -92000,7 +91965,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "rJi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -92167,7 +92132,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "rMi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -92341,7 +92306,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "rPk" = (
 /obj/machinery/door/airlock{
 	name = "Toilet";
@@ -94248,17 +94213,22 @@
 	req_access_txt = "10;13";
 	vent_link_id = "stationai_vent"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "stationai_vent";
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "suE" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/light/directional/south,
@@ -94330,13 +94300,14 @@
 /area/station/hallway/primary/central/sw)
 "swm" = (
 /obj/machinery/computer/card/minor/qm,
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Requests Console";
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/requests_console{
+	department = "Quartermaster's Desk";
+	departmentType = 5;
+	name = "Quartermaster Requests Console";
+	pixel_y = 30;
+	announcementConsole = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -95095,7 +95066,7 @@
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "sEI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95671,7 +95642,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "sPz" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/vacuum{
@@ -95706,14 +95677,14 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
 "sPW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "sQa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -96205,10 +96176,7 @@
 /area/station/public/locker)
 "sYQ" = (
 /obj/structure/closet/secure_closet/detective,
-/obj/item/camera{
-	desc = "A one use - polaroid camera. 30 photos left.";
-	name = "detectives camera"
-	},
+/obj/item/camera/detective,
 /obj/item/restraints/handcuffs,
 /obj/item/storage/lockbox/spy_kit,
 /obj/item/storage/box/bodybags,
@@ -100171,7 +100139,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "unT" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/delivery/hollow,
@@ -100903,15 +100871,19 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "uBg" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/effect/decal/cleanable/dirt,
@@ -101917,8 +101889,14 @@
 	name = "interior access button";
 	req_access_txt = "10;13"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "uQP" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -103189,11 +103167,15 @@
 /obj/structure/sign/vacuum{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	autolink_id = "stationai_vent"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "vkw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -105928,7 +105910,7 @@
 /area/space/nearstation)
 "wdu" = (
 /turf/simulated/wall,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "wdz" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -107040,14 +107022,8 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/dark,
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "wxg" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/delivery/hollow,
@@ -108550,7 +108526,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "wWY" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "Interrogation"
@@ -112562,7 +112538,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/aitransit)
+/area/station/engineering/ai_transit_tube)
 "yiO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -123104,7 +123080,7 @@ bUJ
 aaa
 bku
 bmq
-bTS
+bPV
 bpq
 brr
 aaa
@@ -123875,7 +123851,7 @@ bUJ
 aaa
 bPU
 bms
-bZw
+oMO
 bms
 bXR
 aaa
@@ -124130,11 +124106,11 @@ aaa
 aaa
 bUJ
 abj
-bPV
+csr
 abj
-chw
 abj
-bPV
+abj
+csr
 aaa
 aaa
 aaa
@@ -124389,7 +124365,7 @@ bUJ
 aaa
 bPW
 wXe
-chw
+abj
 wXe
 bXS
 aaa
@@ -124646,7 +124622,7 @@ bUJ
 aaa
 abj
 bRQ
-chw
+abj
 bWb
 abj
 aaa
@@ -130810,7 +130786,7 @@ bge
 bGu
 bwN
 abj
-bUJ
+chw
 abj
 abj
 abj
@@ -131071,7 +131047,7 @@ ptq
 qwS
 qwS
 abj
-csy
+bPW
 abj
 bXU
 bZl
@@ -131328,7 +131304,7 @@ suC
 vkv
 qwS
 bZf
-ctI
+bZf
 ctJ
 bXU
 bZm
@@ -131842,7 +131818,7 @@ fGI
 eNr
 pPZ
 rJg
-pbJ
+kFr
 jof
 bXU
 bXU

--- a/modular_ss220/maps220/code/Areas/station.dm
+++ b/modular_ss220/maps220/code/Areas/station.dm
@@ -15,10 +15,6 @@
 /area/station/bridge/checkpoint/south
 	name = "\improper South Command Checkpoint"
 
-/area/station/engineering/aitransit
-	name = "\improper AI Satellite Transfer Point"
-	icon_state = "engi"
-
 /area/station/engineering/hallway
 	name = "\improper Engineering Hallway"
 	icon_state = "engine_hallway"

--- a/modular_ss220/maps220/code/spawners.dm
+++ b/modular_ss220/maps220/code/spawners.dm
@@ -97,11 +97,11 @@
 /obj/effect/spawner/random_spawners/syndicate/loot/stetchkin
 	icon_state = "stetchkin"
 
-/obj/item/reagent_containers/food/pill/random_drugs
+/obj/item/reagent_containers/pill/random_drugs
 	icon = 'modular_ss220/maps220/icons/spawner_icons.dmi'
 	icon_state = "pills"
 
-/obj/item/reagent_containers/food/pill/random_drugs/Initialize(mapload)
+/obj/item/reagent_containers/pill/random_drugs/Initialize(mapload)
 	icon = 'icons/obj/chemical.dmi'
 	. = ..()
 

--- a/modular_ss220/silicons/code/items/gripper.dm
+++ b/modular_ss220/silicons/code/items/gripper.dm
@@ -53,7 +53,7 @@
 					/obj/item/robot_parts,
 					/obj/item/stack/sheet/mineral/plasma, // for repair plasmamans
 					/obj/item/mmi,
-					/obj/item/reagent_containers/food/pill,
+					/obj/item/reagent_containers/pill,
 					/obj/item/reagent_containers/food/drinks,
 					/obj/item/reagent_containers/glass,
 					/obj/item/reagent_containers/syringe,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Актуализация карт, вырезал лишнюю модульную зону, некоторые фиксы. Подробнее в чейнджлоге.

## Почему это хорошо для игры
Меньше багов, больше удобств

## Изображения изменений
Мапдифф

## Тестирование
-

## Changelog

:cl:
tweak: Все карты: Теперь КМ имеет корректную реквест консоль, которая имеет доступ к объявлениям
tweak: Мета: Теперь транзит-комната к спутнику ИИ имеет собственную зону
tweak: Дельта: Переложены трубы от транзит-комнаты к спутнику ИИ, дабы инженерам было проще с ними работать
tweak: Задана актуализированная зона для транзит-комнаты к спутнику ИИ
tweak: Заменены var-эдитные камеры на их аналог в коде
fix: Пофикшен спавнер таблетниц с рандомными наркотиками
fix: Медицинский гриппер снова может держать таблетки
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
