### PR TITLE
Fix: Black Mesa and Space Hotel

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -71,9 +71,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "aK" = (
 /obj/machinery/door/morgue{
 	name = "Private Study"
@@ -211,9 +209,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "bz" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/spawner/random_spawners/dirt_often,
@@ -393,18 +389,14 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "db" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "dc" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/internals,
@@ -582,9 +574,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "er" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -762,9 +752,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "fG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1233,9 +1221,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "jj" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -1276,9 +1262,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "jA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1493,9 +1477,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "la" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/ruin/space/spacehotelv1/guestroom6)
@@ -1738,9 +1720,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "mw" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/beach/water{
@@ -2045,9 +2025,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "ov" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2312,9 +2290,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "qt" = (
 /obj/structure/AIcore,
 /turf/simulated/floor/greengrid/airless{
@@ -2421,9 +2397,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/economy/vending/shoedispenser,
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "rj" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/wood,
@@ -2605,9 +2579,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "sV" = (
 /obj/structure/railing{
 	dir = 8
@@ -2630,9 +2602,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "te" = (
 /mob/living/simple_animal/hostile/alien/maid,
 /turf/simulated/floor/carpet/royalblack,
@@ -2706,9 +2676,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "tB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2723,9 +2691,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "tC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2925,9 +2891,7 @@
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/siding/wood/end,
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "uP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3084,9 +3048,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "wc" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -3543,9 +3505,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "yP" = (
 /obj/structure/computerframe{
 	dir = 1
@@ -3631,9 +3591,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/economy/vending/suitdispenser,
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "zt" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/door/window/reinforced/normal{
@@ -3706,9 +3664,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "zJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3766,9 +3722,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Ad" = (
 /turf/simulated/floor/carpet,
 /area/ruin/space/spacehotelv1/restoraunt1)
@@ -3995,9 +3949,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "BN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
@@ -4147,9 +4099,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Dh" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
@@ -4245,9 +4195,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "DK" = (
 /obj/structure/rack,
 /turf/simulated/floor/beach/sand{
@@ -4549,9 +4497,7 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "FP" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/off_station/east,
@@ -4782,17 +4728,13 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Hj" = (
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Ho" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4806,9 +4748,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Hx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4867,9 +4807,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "HY" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/oak,
@@ -4883,9 +4821,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass/no_creep,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Ig" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -5143,9 +5079,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Kb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -5167,9 +5101,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Ko" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5205,9 +5137,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "KD" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/window/reinforced{
@@ -5277,9 +5207,7 @@
 	id = "restoom2_tint"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "KZ" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -5304,9 +5232,7 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Lg" = (
 /obj/machinery/power/solar,
 /obj/structure/cable{
@@ -5472,9 +5398,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Mo" = (
 /obj/structure/table/holotable/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
@@ -5490,9 +5414,7 @@
 /area/ruin/space/spacehotelv1/guestroom5)
 "Ms" = (
 /turf/simulated/wall,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Mv" = (
 /obj/structure/chair/sofa/right,
 /turf/simulated/floor/carpet/cyan,
@@ -5623,9 +5545,7 @@
 "No" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Nr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5661,9 +5581,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "NF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5696,9 +5614,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "NU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood/end{
@@ -6158,9 +6074,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Rc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6280,9 +6194,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Sx" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/siding/wood{
@@ -6854,9 +6766,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Wu" = (
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plasteel{
@@ -6955,9 +6865,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "Xy" = (
 /obj/structure/toilet{
 	dir = 8
@@ -7266,9 +7174,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway{
-	name = "Hotel Entry Hallway"
-	})
+/area/ruin/space/spacehotelv1/entryhallway)
 "ZS" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /obj/effect/spawner/random_spawners/dirt_often,

--- a/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -71,7 +71,9 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "aK" = (
 /obj/machinery/door/morgue{
 	name = "Private Study"
@@ -209,7 +211,9 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "bz" = (
 /obj/machinery/light/small/directional/west,
 /obj/effect/spawner/random_spawners/dirt_often,
@@ -389,14 +393,18 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "db" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "dc" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/internals,
@@ -574,7 +582,9 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "er" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -752,7 +762,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "fG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1221,7 +1233,9 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "jj" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -1262,7 +1276,9 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "jA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1477,7 +1493,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "la" = (
 /turf/simulated/floor/carpet/royalblack,
 /area/ruin/space/spacehotelv1/guestroom6)
@@ -1720,7 +1738,9 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "mw" = (
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/beach/water{
@@ -2025,7 +2045,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "ov" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2290,7 +2312,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "qt" = (
 /obj/structure/AIcore,
 /turf/simulated/floor/greengrid/airless{
@@ -2397,7 +2421,9 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/economy/vending/shoedispenser,
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "rj" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/wood,
@@ -2579,7 +2605,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "sV" = (
 /obj/structure/railing{
 	dir = 8
@@ -2602,7 +2630,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "te" = (
 /mob/living/simple_animal/hostile/alien/maid,
 /turf/simulated/floor/carpet/royalblack,
@@ -2676,7 +2706,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "tB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2691,7 +2723,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "tC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2891,7 +2925,9 @@
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/siding/wood/end,
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "uP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3048,7 +3084,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "wc" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -3505,7 +3543,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "yP" = (
 /obj/structure/computerframe{
 	dir = 1
@@ -3591,7 +3631,9 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/economy/vending/suitdispenser,
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "zt" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/door/window/reinforced/normal{
@@ -3664,7 +3706,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "zJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3722,7 +3766,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Ad" = (
 /turf/simulated/floor/carpet,
 /area/ruin/space/spacehotelv1/restoraunt1)
@@ -3949,7 +3995,9 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "BN" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
@@ -4099,7 +4147,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Dh" = (
 /obj/machinery/door/airlock,
 /obj/machinery/door/firedoor,
@@ -4195,7 +4245,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "DK" = (
 /obj/structure/rack,
 /turf/simulated/floor/beach/sand{
@@ -4497,7 +4549,9 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "FP" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/off_station/east,
@@ -4728,13 +4782,17 @@
 	icon_state = "darkblue";
 	dir = 1
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Hj" = (
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Ho" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4748,7 +4806,9 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Hx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4807,7 +4867,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "HY" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/oak,
@@ -4821,7 +4883,9 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass/no_creep,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Ig" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -5079,7 +5143,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Kb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -5101,7 +5167,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Ko" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5137,7 +5205,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "KD" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/window/reinforced{
@@ -5207,7 +5277,9 @@
 	id = "restoom2_tint"
 	},
 /turf/simulated/floor/plating,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "KZ" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -5232,7 +5304,9 @@
 /turf/simulated/floor/plasteel/airless{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Lg" = (
 /obj/machinery/power/solar,
 /obj/structure/cable{
@@ -5398,7 +5472,9 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Mo" = (
 /obj/structure/table/holotable/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_robust{
@@ -5414,7 +5490,9 @@
 /area/ruin/space/spacehotelv1/guestroom5)
 "Ms" = (
 /turf/simulated/wall,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Mv" = (
 /obj/structure/chair/sofa/right,
 /turf/simulated/floor/carpet/cyan,
@@ -5545,7 +5623,9 @@
 "No" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Nr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5581,7 +5661,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "NF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5614,7 +5696,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "NU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood/end{
@@ -6074,7 +6158,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Rc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6194,7 +6280,9 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Sx" = (
 /obj/item/kirbyplants,
 /obj/effect/turf_decal/siding/wood{
@@ -6766,7 +6854,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Wu" = (
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plasteel{
@@ -6865,7 +6955,9 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "Xy" = (
 /obj/structure/toilet{
 	dir = 8
@@ -7174,7 +7266,9 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/ruin/space/spacehotelv1/entryhallway)
+/area/ruin/space/spacehotelv1/entryhallway{
+	name = "Hotel Entry Hallway"
+	})
 "ZS" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /obj/effect/spawner/random_spawners/dirt_often,

--- a/_maps/map_files220/RandomZLevels/blackmesa.dmm
+++ b/_maps/map_files220/RandomZLevels/blackmesa.dmm
@@ -3619,6 +3619,11 @@
 /mob/living/simple_animal/hostile/blackmesa/xen/headcrab/fast,
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/black_mesa/entrance)
+"etS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/dark,
+/area/awaymission/black_mesa/xen/acid_lake_building)
 "etZ" = (
 /obj/effect/bump_teleporter{
 	id = "lambda2";
@@ -7868,6 +7873,14 @@
 	icon_state = "alienvault"
 	},
 /area/awaymission/black_mesa/xen/nihilanth_arena)
+"jLi" = (
+/obj/structure/inflatable{
+	opacity = 1;
+	color = "#556B2F"
+	},
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/awaymission/black_mesa/xen/acid_lake_building)
 "jLu" = (
 /obj/structure/sign/chemistry{
 	pixel_y = -32
@@ -8337,6 +8350,10 @@
 /obj/machinery/light/directional/west,
 /turf/simulated/floor/plasteel/smooth,
 /area/awaymission/black_mesa/black_ops_armory)
+"koI" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/smooth,
+/area/awaymission/black_mesa/cryo_room)
 "kpg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -15260,6 +15277,10 @@
 /obj/structure/alien/xenoweeds,
 /turf/simulated/floor/plasteel,
 /area/awaymission/black_mesa/science_decon_room)
+"sCM" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/wood/fancy/cherry,
+/area/awaymission/black_mesa/xen/vortigaunt_village_nihilanth)
 "sCN" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -17454,6 +17475,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/awaymission/black_mesa/security_outpost)
+"vug" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plating,
+/area/awaymission/black_mesa/xen/acid_lake_building)
 "vuI" = (
 /obj/structure/flora/biolumini/mine/weaklight,
 /turf/simulated/floor/plating/xen,
@@ -32459,7 +32484,7 @@ qeH
 rvt
 pTC
 uzo
-uzo
+etS
 pzr
 uzo
 lUJ
@@ -32571,7 +32596,7 @@ qQx
 lQm
 lQm
 nmA
-aHI
+sCM
 aHI
 aHI
 nmA
@@ -32974,9 +32999,9 @@ pzr
 aNx
 pzr
 pzr
-pzr
+jLi
 uzo
-xlP
+vug
 pzr
 jSI
 uCx
@@ -65687,7 +65712,7 @@ ptr
 ptr
 uDt
 pOl
-pOl
+koI
 xZT
 xGZ
 xzz

--- a/_maps/map_files220/RandomZLevels/blackmesa.dmm
+++ b/_maps/map_files220/RandomZLevels/blackmesa.dmm
@@ -2343,7 +2343,7 @@
 "cTV" = (
 /obj/structure/alien/xenoweeds,
 /obj/effect/bump_teleporter{
-	id = "lambda_xen";
+	id = "lambda_lab_gate";
 	density = 0
 	},
 /turf/simulated/floor/engine,
@@ -3697,6 +3697,10 @@
 /obj/machinery/door/airlock/public,
 /turf/simulated/floor/plasteel,
 /area/awaymission/black_mesa/black_ops_science_room)
+"exS" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/smooth,
+/area/awaymission/black_mesa/deep_sci_storage)
 "eyf" = (
 /obj/structure/flora/biolumini/mine,
 /turf/simulated/floor/beach/away/coastline/xen{
@@ -10322,8 +10326,8 @@
 /area/awaymission/black_mesa/science_labs)
 "mMa" = (
 /obj/effect/bump_teleporter/lambda{
-	id = "lambda_xen2";
-	id_target = "lambda2";
+	id = "lambda_xen3";
+	id_target = "lambda_lab_gate";
 	color = "lime"
 	},
 /turf/simulated/floor/vault{
@@ -19251,6 +19255,10 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/awaymission/black_mesa/tram_room)
+"xGZ" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel/smooth,
+/area/awaymission/black_mesa/cryo_storage)
 "xHI" = (
 /obj/effect/landmark/awaymissions/black_mesa/random_mob_placer/xen,
 /turf/simulated/floor/plasteel,
@@ -57660,7 +57668,7 @@ cBU
 cBU
 cBU
 dgN
-sHE
+exS
 mIc
 wBx
 mIc
@@ -65681,7 +65689,7 @@ uDt
 pOl
 pOl
 xZT
-bBe
+xGZ
 xzz
 bBe
 bBe

--- a/modular_ss220/maps220/code/Areas/away.dm
+++ b/modular_ss220/maps220/code/Areas/away.dm
@@ -50,7 +50,7 @@
 	icon_state = "awaycontent9"
 
 /area/ruin/space/spacehotelv1/entryhallway
-	name = "awaycontent17"
+	name = "Hotel Entry Hallway"
 	icon_state = "awaycontent10"
 
 /area/ruin/space/spacehotelv1/restoraunt3


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Пофиксил телепорт в мезе. Теперь из Зена можно выбраться прямо к гейту.
Пофиксил зону в космическом отеле. На GPS теперь все отображается корректно.

## Почему это хорошо для игры

Подбираю за собой.

## Изображения изменений
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Локалка, работает

## Changelog

:cl:
fix: В гейте Black Mesa теперь корректно работает телепорт из Зена. Косморуина Space Hotel теперь корректно отображается на GPS.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
