### PR TITLE
Fix: Очепятка перевода

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -16,7 +16,7 @@
 		announcement = "Массовая миграция неизвестных биологических объектов была зафиксирована вблизи станции [station_name()], будьте наготове."
 	else
 		announcement = "Неизвестные биологические объекты были зафиксированы вблизи станции [station_name()], будьте наготове."
-	GLOB.minor_announcement.Announce(announcement, "ВНИМАНИЕ: Неопозанные формы жизни.")
+	GLOB.minor_announcement.Announce(announcement, "ВНИМАНИЕ: Неопознанные формы жизни.")
 
 /datum/event/carp_migration/start()
 


### PR DESCRIPTION

## Что этот PR делает
Добавил недостающую букову

## Changelog

:cl:
spellcheck: Исправлена очепятка в анонсе. Неопозанные -> Неопознанные
/:cl:


