### PR TITLE
fix: make choosing voice by borg possible again

### DIFF
--- a/modular_ss220/text_to_speech/code/tts_seed.dm
+++ b/modular_ss220/text_to_speech/code/tts_seed.dm
@@ -10,38 +10,49 @@
 	new_dna.tts_seed_dna = tts_seed_dna
 	return new_dna
 
-/atom/proc/select_voice(mob/user, silent_target = FALSE, override = FALSE)
-	if(!ismob(src) && !user)
-		return null
+/atom/proc/select_voice(mob/user, silent_target = FALSE, override = FALSE, fancy_voice_input_tgui = FALSE)
+	if(!user)
+		if(!ismob(src))
+			return null
+		else
+			user = src
+
 	var/static/tts_test_str = "Так звучит мой голос."
 
 	var/tts_seeds
 	var/tts_gender = get_converted_tts_seed_gender(user.gender)
-	var/list/list_genders = SStts220.tts_list_names_gender[tts_gender]
+	var/list/tts_seeds_by_gender = SStts220.tts_seeds_by_gender[tts_gender]
 	if(user && (check_rights(R_ADMIN, FALSE, user) || override))
-		tts_seeds = list_genders
+		tts_seeds = tts_seeds_by_gender
 	else
-		var/list/not_available_tts_seeds = list_genders - SStts220.get_available_seeds(src)
-		tts_seeds = list_genders - not_available_tts_seeds
+		tts_seeds = tts_seeds_by_gender && SStts220.get_available_seeds(src) // && for lists means intersection
 
-	var/datum/character_save/active_character = user?.client?.prefs.active_character
+	var/datum/character_save/active_character = user.client?.prefs.active_character
 	var/new_tts_seed
-	if(active_character.tts_seed && (user.gender == active_character.gender))
+	if(active_character?.tts_seed && (user.gender == active_character.gender))
 		if(alert(user || src, "Оставляем голос вашего персонажа [active_character.real_name]?", "Выбор голоса", "Нет", "Да") ==  "Да")
 			new_tts_seed = active_character.tts_seed
+
 	if(!new_tts_seed)
-		new_tts_seed = input(user, "Выберите голос вашего персонажа", "Преобразуем голос") as null|anything in tts_seeds
+		if(fancy_voice_input_tgui)
+			new_tts_seed = tgui_input_list(user, "Выберите голос вашего персонажа", "Преобразуем голос", tts_seeds)
+		else
+			new_tts_seed = input(user, "Выберите голос вашего персонажа", "Преобразуем голос") as null|anything in tts_seeds
+
 		if(!new_tts_seed)
 			return null
-	if(!silent_target && ismob(src) && src != user)
+
+	if(!silent_target && src != user && ismob(src))
 		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(tts_cast), null, src, tts_test_str, new_tts_seed, FALSE)
+
 	if(user)
 		INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(tts_cast), null, user, tts_test_str, new_tts_seed, FALSE)
+
 	return new_tts_seed
 
-/atom/proc/change_voice(mob/user, override = FALSE)
+/atom/proc/change_voice(mob/user, override = FALSE, fancy_voice_input_tgui = FALSE)
 	set waitfor = FALSE
-	var/new_tts_seed = select_voice(user, override = override)
+	var/new_tts_seed = select_voice(user = user, override = override, fancy_voice_input_tgui = fancy_voice_input_tgui)
 	if(!new_tts_seed)
 		return null
 	return update_tts_seed(new_tts_seed)
@@ -63,10 +74,10 @@
 	set name = "Смена голоса"
 	set desc = "Express yourself!"
 	set category = "Подсистемы"
-	change_voice()
+	change_voice(fancy_voice_input_tgui = TRUE)
 
-/atom/proc/get_converted_tts_seed_gender()
-	switch(gender)
+/atom/proc/get_converted_tts_seed_gender(gender_to_convert = gender)
+	switch(gender_to_convert)
 		if(MALE)
 			return TTS_GENDER_MALE
 		if(FEMALE)
@@ -76,7 +87,7 @@
 
 /atom/proc/pick_tts_seed_gender()
 	var/tts_gender = get_converted_tts_seed_gender()
-	return pick(SStts220.tts_list_names_gender[tts_gender])
+	return pick(SStts220.tts_seeds_by_gender[tts_gender])
 
 /atom/proc/get_random_tts_seed_gender()
 	var/tts_choice = pick_tts_seed_gender(gender)

--- a/modular_ss220/text_to_speech/code/tts_subsystem.dm
+++ b/modular_ss220/text_to_speech/code/tts_subsystem.dm
@@ -34,7 +34,7 @@ SUBSYSTEM_DEF(tts220)
 	var/list/tts_seeds_names_by_donator_levels = list()
 	var/list/datum/tts_provider/tts_providers = list()
 
-	var/list/tts_list_names_gender = list(TTS_GENDER_ANY = list(), TTS_GENDER_MALE = list(), TTS_GENDER_FEMALE = list())
+	var/list/tts_seeds_by_gender = list(TTS_GENDER_ANY = list(), TTS_GENDER_MALE = list(), TTS_GENDER_FEMALE = list())
 
 	var/list/tts_local_channels_by_owner = list()
 
@@ -184,7 +184,7 @@ SUBSYSTEM_DEF(tts220)
 		tts_seeds[seed.name] = seed
 		tts_seeds_names += seed.name
 		tts_seeds_names_by_donator_levels["[seed.required_donator_level]"] += list(seed.name)
-		tts_list_names_gender[seed.gender] += seed.name
+		tts_seeds_by_gender[seed.gender] += seed.name
 	tts_seeds_names = sortTim(tts_seeds_names, /proc/cmp_text_asc)
 
 /datum/controller/subsystem/tts220/Initialize(start_timeofday)


### PR DESCRIPTION
## Что этот PR делает

closes #961 

Исправляет баг с невозможностью за борга выбрать голос.
Добавляет боргам `tgui_input_list` для выбора голосов.

## Почему это хорошо для игры

Борги снова могут выбрать голос, так еще и с ТГУИ

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/44334376/365691cf-0141-4304-97bd-82f3d35ded6b)


## Тестирование
Запустил игру, попробовал сменить голос. Всё корректно работает, рантаймов нет.

## Changelog

:cl:
tweak: Добавляет боргам удобный список с поиском для выбора голосов
fix: Исправляет баг с невозможностью за борга выбрать голос
/:cl:
