### PR TITLE
refactor: make voice selection with TGUI input list for all cases, except ERT, define gender by atom's gender, not users

### DIFF
--- a/modular_ss220/text_to_speech/code/base_seeds/objs/objs.dm
+++ b/modular_ss220/text_to_speech/code/base_seeds/objs/objs.dm
@@ -22,4 +22,4 @@
 
 /obj/structure/mirror/magic/proc/tts_choose(choice, mob/living/carbon/human/human_to_update)
 	if(choice == "Voice TTS")
-		human_to_update.change_voice(human_to_update, TRUE)
+		human_to_update.change_voice(human_to_update, TRUE, TRUE)

--- a/modular_ss220/text_to_speech/code/tts_seed.dm
+++ b/modular_ss220/text_to_speech/code/tts_seed.dm
@@ -20,7 +20,7 @@
 	var/static/tts_test_str = "Так звучит мой голос."
 
 	var/tts_seeds
-	var/tts_gender = get_converted_tts_seed_gender(user.gender)
+	var/tts_gender = get_converted_tts_seed_gender(gender)
 	var/list/tts_seeds_by_gender = SStts220.tts_seeds_by_gender[tts_gender]
 	if(user && (check_rights(R_ADMIN, FALSE, user) || override))
 		tts_seeds = tts_seeds_by_gender
@@ -131,7 +131,7 @@
 	..()
 
 /datum/surgery_step/tune_vocal_cords/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	target.change_voice(user, TRUE)
+	target.change_voice(user, TRUE, TRUE)
 	user.visible_message("[user] tunes [target]'s vocals completely!", span_notice("You tune [target]'s vocals completely."))
 	return TRUE
 


### PR DESCRIPTION
## Что этот PR делает

Для всех выборов голоса, кроме ЕРТ использует ТГУИ список.
Пул доступных голосов определяется гендером обьекта, которому меняют голос, а не гендером того кто меняет.

## Почему это хорошо для игры

Исправлен баг.
Красивые списки с поиском хорошо.

## Изображения изменений
В игре посмотрите:)

## Тестирование
Скомпилировал, проверил.

## Changelog

:cl:
tweak: Для всех случаев смены голоса используются `tgui_input_list` (красивые списки с поиском), кроме ЕРТ
fix: Пул доступных для куклы голосов, определяется гендером куклы
/:cl:

