### PR TITLE
Floor Painter Tweaks

### DIFF
--- a/code/game/objects/items/devices/painter/floor_painter.dm
+++ b/code/game/objects/items/devices/painter/floor_painter.dm
@@ -33,7 +33,7 @@
 				lookup_cache[style] = list()
 
 			for(var/dir in GLOB.alldirs)
-				var/icon/floor_icon = icon('icons/turf/floors.dmi', style, dir)
+				var/icon/floor_icon = icon('modular_ss220/aesthetics/floors/icons/floors.dmi', style, dir) // SS220 EDIT
 				// These indexes have to be strings otherwise it treats it as a list index not a map lookup index
 				lookup_cache[style] += "[dir]"
 				lookup_cache[style]["[dir]"] = icon2base64(floor_icon)

--- a/modular_ss220/aesthetics/floors/code/floors.dm
+++ b/modular_ss220/aesthetics/floors/code/floors.dm
@@ -1,3 +1,12 @@
+/// Floor icon_states for floor painter
+/datum/painter/floor/New()
+	allowed_states |= list("darkneutralcorner", "darkneutral", "darkneutralfull", "navybluecorners", "navyblue", "navybluefull",
+		"navybluealt", "navybluealtstrip", "navybluecornersalt", "darkbluealt", "darkbluealtstrip", "darkbluecornersalt",
+		"darkredalt", "darkredaltstrip", "darkredcornersalt", "darkyellowalt", "darkyellowaltstrip", "darkyellowcornersalt",
+		"whitebrowncorner", "whitebrown"
+		)
+	. = ..()
+
 /turf/simulated/floor
 	icon = 'modular_ss220/aesthetics/floors/icons/floors.dmi'
 


### PR DESCRIPTION
## Что этот PR делает
Покрасчик полов теперь имеет спрайты наших полов, плюс несколько новых


## Почему это хорошо для игры
Красить люблю пиздец

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/69762909/b145ef59-cd7a-4995-b9b7-b021042e1cd0)

## Тестирование
Ага

## Changelog

:cl:
fix: Painter в режиме покраски полов, теперь имеет спрайты наших полов.
tweak: Также добавлено несколько новых расцветок полов туда же.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
