### PR TITLE
Tweak: Debuff cash in Cyberiad maints

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -89551,7 +89551,7 @@
 "tLs" = (
 /obj/structure/safe/floor,
 /obj/item/coin/mythril,
-/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c200,
 /obj/item/instrument/violin/golden,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/maintenance/apmaint)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Убирает 1000 кредитов в техах Кибериады

## Почему это хорошо для игры
1. Оффы снизили кол-во кредитов на карте еще давно
2. Столько кэша лежит только в хранилище кэпа
3. Это огромный бафф для того кто это найдет (например карго, или сб)

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/20109643/68869f20-af4e-4cfc-85dd-6df4e9622326)

## Тестирование
Ни за что в жизни

## Changelog

:cl:
tweak: Кибериада: Изменено кол-во кредитов в одной из комнат в техах с 1000 до 200
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
