### PR TITLE
[TM] Bring animal devouring back

### DIFF
--- a/modular_ss220/mobs/_mobs.dme
+++ b/modular_ss220/mobs/_mobs.dme
@@ -13,6 +13,7 @@
 #include "code/simple_animal/friendly/snail.dm"
 #include "code/simple_animal/hostile/alien.dm"
 #include "code/simple_animal/hostile/bear.dm"
+#include "code/simple_animal/hostile/bee.dm"
 #include "code/simple_animal/hostile/headcrab.dm"
 #include "code/simple_animal/hostile/lizard.dm"
 #include "code/simple_animal/hostile/snake.dm"

--- a/modular_ss220/mobs/_mobs.dme
+++ b/modular_ss220/mobs/_mobs.dme
@@ -1,5 +1,6 @@
 #include "_mobs.dm"
 
+#include "code/simple_animal/friendly/butterfly.dm"
 #include "code/simple_animal/friendly/crab.dm"
 #include "code/simple_animal/friendly/farm_animals.dm"
 #include "code/simple_animal/friendly/frog.dm"

--- a/modular_ss220/mobs/code/mob_holder.dm
+++ b/modular_ss220/mobs/code/mob_holder.dm
@@ -27,7 +27,7 @@
 	else
 		visible_message(span_danger("[user] пытается съесть [animal]!"))
 
-	if(!do_after(user, SECONDS(3), target = devourer))
+	if(!do_after(user, 3 SECONDS, target = devourer))
 		return
 
 	visible_message(span_danger("[devourer] съедает [animal]!"))

--- a/modular_ss220/mobs/code/mob_holder.dm
+++ b/modular_ss220/mobs/code/mob_holder.dm
@@ -7,6 +7,7 @@
 	slot_flags = SLOT_FLAG_HEAD
 
 /obj/item/holder/attack(mob/living/target, mob/living/user, def_zone)
+	ASSERT(length(contents) > 0)
 	var/mob/living/simple_animal/animal = contents[1]
 	var/mob/living/carbon/devourer = target
 	if(!istype(animal) || !istype(devourer))
@@ -19,7 +20,7 @@
 		if(user != devourer)
 			user.visible_message(span_notice("Вряд ли это понравится [devourer]..."))
 		else if(ishuman(devourer))
-			user.visible_message(span_notice("Интересно, как на вкус [animal]? Но проверять не будем."))
+			user.visible_message(span_notice("Интересно, каков на вкус [animal]? Но проверять не будем."))
 		return
 
 	if(!user.canUnEquip(src, FALSE))

--- a/modular_ss220/mobs/code/mob_holder.dm
+++ b/modular_ss220/mobs/code/mob_holder.dm
@@ -33,6 +33,19 @@
 	visible_message(span_danger("[devourer] съедает [animal]!"))
 	if(animal.mind)
 		add_attack_logs(devourer, animal, "Devoured")
+
+	if(istype(animal, /mob/living/simple_animal/hostile/poison/bees)) // Eating a bee will end up damaging you
+		var/obj/item/organ/external/mouth = devourer.get_organ(BODY_ZONE_PRECISE_MOUTH)
+		var/mob/living/simple_animal/hostile/poison/bees/bee = animal
+		mouth.receive_damage(1)
+		if(bee.beegent)
+			bee.beegent.reaction_mob(devourer, REAGENT_INGEST)
+			devourer.reagents.add_reagent(bee.beegent.id, rand(1, 5))
+		else
+			devourer.reagents.add_reagent("spidertoxin", 5)
+		visible_message(span_warning("Рот [devourer] опух."))
+		devourer.visible_message(span_danger("Ваш рот ужален, он теперь опухает!"))
+
 	animal.forceMove(devourer)
 	LAZYADD(devourer.stomach_contents, animal)
 	icon = null // workaround to hide cringy holder lying on the floor for 1 sec
@@ -92,6 +105,14 @@
 	origin_tech = "materials=3;programming=4;engineering=4"
 	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 
+/obj/item/holder/bee
+	name = "bee"
+	desc = "Buzzy buzzy bee, stingy sti- Ouch!"
+	icon = 'icons/mob/bees.dmi'
+	icon_state = "queen_item"
+	origin_tech = "biotech=5"
+	slot_flags = null
+
 /obj/item/holder/bunny
 	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 
@@ -100,6 +121,7 @@
 	desc = "A colorful butterfly, how'd it get up here?"
 	icon = 'icons/mob/animal.dmi'
 	icon_state = "butterfly"
+	origin_tech = "biotech=4"
 	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 
 /obj/item/holder/mouse

--- a/modular_ss220/mobs/code/mob_holder.dm
+++ b/modular_ss220/mobs/code/mob_holder.dm
@@ -22,6 +22,10 @@
 			user.visible_message(span_notice("Интересно, как на вкус [animal]? Но проверять не будем."))
 		return
 
+	if(!user.canUnEquip(src, FALSE))
+		user.visible_message(span_notice("[src] никак не отлипает от руки!"))
+		return
+
 	if(user != devourer)
 		visible_message(span_danger("[user] пытается скормить [devourer] [animal]!"))
 	else

--- a/modular_ss220/mobs/code/mob_holder.dm
+++ b/modular_ss220/mobs/code/mob_holder.dm
@@ -83,25 +83,31 @@
 	desc = "It's a tiny plant critter."
 	icon_state = "nymph"
 	origin_tech = "biotech=5"
-	slot_flags = SLOT_FLAG_HEAD|SLOT_FLAG_EARS
-	icon = 'icons/mob/animal.dmi'
+	icon = 'icons/mob/monkey.dmi' // why...
 
 /obj/item/holder/pai
 	name = "pAI"
 	desc = "It's a little robot."
 	icon_state = "pai"
 	origin_tech = "materials=3;programming=4;engineering=4"
-	slot_flags = SLOT_FLAG_HEAD|SLOT_FLAG_EARS
+	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 
 /obj/item/holder/bunny
-	slot_flags = SLOT_FLAG_HEAD|SLOT_FLAG_EARS
+	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
+
+/obj/item/holder/butterfly
+	name = "butterfly"
+	desc = "A colorful butterfly, how'd it get up here?"
+	icon = 'icons/mob/animal.dmi'
+	icon_state = "butterfly"
+	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 
 /obj/item/holder/mouse
 	name = "mouse"
 	desc = "It's a small, disease-ridden rodent."
 	icon = 'modular_ss220/mobs/icons/mob/animal.dmi'
 	icon_state = "mouse_gray"
-	slot_flags = SLOT_FLAG_HEAD|SLOT_FLAG_EARS
+	slot_flags = SLOT_FLAG_HEAD | SLOT_FLAG_EARS
 
 /obj/item/holder/drone
 	name = "maintenance drone"
@@ -294,13 +300,13 @@
 /obj/item/holder/lizard
 	name = "pet"
 	desc = "It's a pet"
-	icon = 'modular_ss220/mobs/icons/mob/animal.dmi'
+	icon = 'icons/mob/animal.dmi'
 	icon_state = "lizard"
 
 /obj/item/holder/chick
 	name = "pet"
 	desc = "It's a small chicken"
-	icon = 'modular_ss220/mobs/icons/mob/animal.dmi'
+	icon = 'icons/mob/animal.dmi'
 	icon_state = "chick"
 
 /obj/item/holder/chicken

--- a/modular_ss220/mobs/code/mob_holder.dm
+++ b/modular_ss220/mobs/code/mob_holder.dm
@@ -18,13 +18,13 @@
 	
 	if(!is_type_in_list(animal,  devourer.dna.species.allowed_consumed_mobs))
 		if(user != devourer)
-			user.visible_message(span_notice("Вряд ли это понравится [devourer]..."))
+			to_chat(user, span_notice("Вряд ли это понравится [devourer]..."))
 		else if(ishuman(devourer))
-			user.visible_message(span_notice("Интересно, каков на вкус [animal]? Но проверять не будем."))
+			to_chat(user, span_notice("Интересно, каков на вкус [animal]? Но проверять не будем."))
 		return
 
 	if(!user.canUnEquip(src, FALSE))
-		user.visible_message(span_notice("[src] никак не отлипает от руки!"))
+		to_chat(user, span_notice("[src] никак не отлипает от руки!"))
 		return
 
 	if(user != devourer)
@@ -48,8 +48,7 @@
 			devourer.reagents.add_reagent(bee.beegent.id, rand(1, 5))
 		else
 			devourer.reagents.add_reagent("spidertoxin", 5)
-		visible_message(span_warning("Рот [devourer] опух."))
-		devourer.visible_message(span_danger("Ваш рот ужален, он теперь опухает!"))
+		devourer.visible_message(span_warning("Рот [devourer] опух."), span_danger("Ваш рот ужален, он теперь опухает!"))
 
 	animal.forceMove(devourer)
 	LAZYADD(devourer.stomach_contents, animal)

--- a/modular_ss220/mobs/code/simple_animal/friendly/butterfly.dm
+++ b/modular_ss220/mobs/code/simple_animal/friendly/butterfly.dm
@@ -1,3 +1,2 @@
 /mob/living/simple_animal/butterfly
-	tts_seed = "Ladyvashj"
 	holder_type = /obj/item/holder/butterfly

--- a/modular_ss220/mobs/code/simple_animal/friendly/butterfly.dm
+++ b/modular_ss220/mobs/code/simple_animal/friendly/butterfly.dm
@@ -1,0 +1,3 @@
+/mob/living/simple_animal/butterfly
+	tts_seed = "Ladyvashj"
+	holder_type = /obj/item/holder/butterfly

--- a/modular_ss220/mobs/code/simple_animal/friendly/lizard.dm
+++ b/modular_ss220/mobs/code/simple_animal/friendly/lizard.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_animal/lizard
 	tts_seed = "Ladyvashj"
 	death_sound = 'modular_ss220/mobs/sound/creatures/lizard_death.ogg'
+	holder_type = /obj/item/holder/lizard
 
 /mob/living/simple_animal/lizard/axolotl
 	name = "Аксолотль"

--- a/modular_ss220/mobs/code/simple_animal/hostile/bee.dm
+++ b/modular_ss220/mobs/code/simple_animal/hostile/bee.dm
@@ -1,0 +1,3 @@
+/mob/living/simple_animal/hostile/poison/bees
+	tts_seed = "Ladyvashj"
+	holder_type = /obj/item/holder/bee

--- a/modular_ss220/mobs/code/simple_animal/hostile/bee.dm
+++ b/modular_ss220/mobs/code/simple_animal/hostile/bee.dm
@@ -1,3 +1,2 @@
 /mob/living/simple_animal/hostile/poison/bees
-	tts_seed = "Ladyvashj"
 	holder_type = /obj/item/holder/bee


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Теперь животных в руке можно будет в `harm` интенте съесть, как обычную еду. При этом учитываются предпочтения из `species`. Также будет возможность скормить животное другой кукле аналогичным образом.

- [x] Иконка холдера цыпленка
- [x] Иконка холдера нимфы дионы
- [x] Добавить холдер лизарда
- [x] Добавить холдер бабочки
- [x] Добавить холдер пчолы
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Ксеносы истребят всех мышей на станции, слава ксеносам.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

https://github.com/ss220club/Paradise-SS220/assets/39908528/8beb2833-4029-42c7-98ad-3c462ccc8133
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: Таяры, вульпканины, унатхи и киданы теперь могут съесть некоторых мелких животных.
fix: Исправлены проблемы с невозможностью взять некоторых мелких животных в руку.
fix: Исправлены некоторые проблемы с отображением мелких животных в руке.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
