### PR TITLE
Longer pointer animation

### DIFF
--- a/code/modules/point/point.dm
+++ b/code/modules/point/point.dm
@@ -22,7 +22,7 @@
 	var/turf/our_tile = get_turf(src)
 	var/obj/visual = new /obj/effect/temp_visual/point(our_tile, invisibility)
 
-	animate(visual, pixel_x = (tile.x - our_tile.x) * world.icon_size + pointed_atom.pixel_x, pixel_y = (tile.y - our_tile.y) * world.icon_size + pointed_atom.pixel_y, time = 1.7, easing = EASE_OUT)
+	animate(visual, pixel_x = (tile.x - our_tile.x) * world.icon_size + pointed_atom.pixel_x, pixel_y = (tile.y - our_tile.y) * world.icon_size + pointed_atom.pixel_y, time = 3, easing = EASE_OUT) // SS220 EDIT - "time = 3"
 
 /// Create a bubble pointing at a particular icon and icon state.
 /// See args for create_point_bubble_from_atom.


### PR DESCRIPTION
## Что этот PR делает
Слегка увеличил анимацию Point to (Почти в 2 раза)

## Почему это хорошо для игры
Легче увидеть куда показывают

## Изображения изменений
https://github.com/ss220club/Paradise-SS220/assets/69762909/451e2f07-589e-4d42-b7d7-d079e7cd6f73

## Changelog

:cl:
tweak: Анимация стрелочки при указании (СКМ) теперь немного дольше
/:cl:
