### PR TITLE
Add parry for electrostaff

### DIFF
--- a/modular_ss220/objects/code/electrostaff.dm
+++ b/modular_ss220/objects/code/electrostaff.dm
@@ -161,6 +161,7 @@
 	reqs = list(/obj/item/melee/baton = 2,
 				/obj/item/stock_parts/cell/high = 1,
 				/obj/item/stack/cable_coil = 5,
+				/obj/item/assembly/signaler/anomaly/flux = 1,
 				/obj/item/weaponcrafting/gunkit/electrostaff = 1)
 	time = 10 SECONDS
 	category = CAT_WEAPONRY

--- a/modular_ss220/objects/code/electrostaff.dm
+++ b/modular_ss220/objects/code/electrostaff.dm
@@ -34,6 +34,7 @@
 
 /obj/item/melee/baton/electrostaff/Initialize(mapload)
 	current_skin = "_orange"
+	AddComponent(/datum/component/parry, _stamina_constant = 2, _stamina_coefficient = 0.5, _parryable_attack_types = NON_PROJECTILE_ATTACKS)
 	AddComponent(/datum/component/two_handed, force_unwielded = force / 2, force_wielded = force, wield_callback = CALLBACK(src, PROC_REF(on_wield)), unwield_callback = CALLBACK(src, PROC_REF(on_unwield)))
 	options["Оранжевое свечение"] = "_orange"
 	options["Красное свечение"] = "_red"

--- a/modular_ss220/objects/code/electrostaff.dm
+++ b/modular_ss220/objects/code/electrostaff.dm
@@ -75,6 +75,11 @@
 	if(signal_ret & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 
+/obj/item/melee/baton/electrostaff/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(!HAS_TRAIT(src, TRAIT_WIELDED))
+		return FALSE
+	. = ..()
+
 /obj/item/melee/baton/electrostaff/proc/on_wield(obj/item/source, mob/living/carbon/user)
 	after_turn(TRUE, user)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавляет возможность парирования электропосохом атак в ближнем бою. Работает только если включен двуручный режим.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Потому что парирование - это круто. И одобрено.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
На локалке с товарищем и на мобах.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: Добавлено парирование для электропосоха атак ближнего боя, если он в двух руках.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
