### PR TITLE
Remove Jukeboxes from maps

### DIFF
--- a/_maps/map_files220/MetaStation/MetaStation.dmm
+++ b/_maps/map_files220/MetaStation/MetaStation.dmm
@@ -21894,7 +21894,6 @@
 /area/station/service/bar)
 "bAx" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/jukebox/bar,
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "bAy" = (
@@ -67483,7 +67482,6 @@
 	autolink_id = "engine_btn_int";
 	name = "interior access button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -53041,7 +53041,6 @@
 	dir = 5
 	},
 /obj/machinery/economy/atm/north,
-/obj/machinery/jukebox/bar,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/service/bar)
 "gvg" = (
@@ -85248,7 +85247,6 @@
 /obj/machinery/access_button{
 	autolink_id = "fpmaint_btn_ext";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_one_access_txt = "13"
 	},
 /turf/simulated/floor/plating,

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -56837,10 +56837,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
-"gMk" = (
-/obj/machinery/jukebox/bar,
-/turf/simulated/floor/wood/oak,
-/area/station/service/theatre)
 "gMx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -146322,7 +146318,7 @@ aGy
 cnC
 rza
 efP
-gMk
+dBq
 dBq
 dBq
 dBq


### PR DESCRIPTION
## Что этот PR делает
Удаляет жукбоксы с станционных карт

## Почему это хорошо для игры
Возможно общая производительность станет выше

## Changelog

:cl:
del: Со всех станционных карт, были убраны музыкальные автоматы
/:cl:
