### PR TITLE
[Fix] Metastation Fixes

### DIFF
--- a/_maps/map_files220/MetaStation/MetaStation.dmm
+++ b/_maps/map_files220/MetaStation/MetaStation.dmm
@@ -29706,7 +29706,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/obj/machinery/alarm/directional/north,
+/obj/machinery/alarm/server{
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/station/science/server/coldroom)
 "cbi" = (
@@ -56230,6 +56232,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -67601,6 +67604,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)


### PR DESCRIPTION
## Что этот PR делает
Фиксит 3 вещи на метастейшене:
- У коридора в медбее теперь есть воздушная сигнализация
- К офису священника теперь проложен провод
- Воздушная сигнализация в серверной РнД больше не будет давать тревогу от того, что в серверной холодно

## Почему это хорошо для игры
Меньше багов

## Тестирование
Я верю в свои силы

## Changelog

:cl:
fix: Цереброн: Коридор медбея имеет воздушную сигнализацию
fix: Цереброн: К офису священника проложен провод
fix: Цереброн: Воздушная сигнализация серверной РнД заменена на серверную
/:cl: