### PR TITLE
[TM] Revert adjust_yield() changes

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -179,7 +179,7 @@
 /// Setter procs ///
 /obj/item/seeds/proc/adjust_yield(adjustamt)
 	if(yield != -1) // Unharvestable shouldn't suddenly turn harvestable
-		yield = clamp(yield + adjustamt, 0, 5)
+		yield = clamp(yield + adjustamt, 0, 10)
 
 		if(yield <= 0 && get_gene(/datum/plant_gene/trait/plant_type/fungal_metabolism))
 			yield = 1 // Mushrooms always have a minimum yield of 1.


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Ограничили зачем-то изменение yield через мутацию и удобрения, а стандартные значения у растений не поменяли, из-за этого зияет дыра в логике, когда с помощью удобрений растение может деградировать с 10 до 5 yield. Ждем судьбу ParadiseSS13/Paradise#24342, а пока тестмерге.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Дыра в логике будет отсутствовать.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Я не верю в тестирование.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Вообще-то это сообщение не должно было здесь появиться.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
