### PR TITLE
[Fix] Cyberiad Fix

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -26467,7 +26467,6 @@
 	},
 /area/station/science/robotics)
 "cck" = (
-/obj/structure/table,
 /obj/structure/table/glass,
 /obj/item/storage/box/donkpockets,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{


### PR DESCRIPTION
## Что этот PR делает
Убирает обычный стол под стеклянным в кабинете вирусолога

## Почему это хорошо для игры
Я не думаю, что двойной стол - модно

## Тестирование
Я верю в свои силы

## Changelog

:cl:
fix: Кибериада: У вирусолога больше не стоит обычный стол под стеклянным
/:cl: