### PR TITLE
[Fix] Delta Fixes

### DIFF
--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -30517,7 +30517,6 @@
 "csf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/directional/south,
-/obj/effect/landmark/damageturf,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
 	icon_state = "black"
@@ -33942,6 +33941,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -50020,6 +50024,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/theatre,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "eBE" = (
@@ -83692,6 +83701,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;


### PR DESCRIPTION
## Что этот PR делает
Видимо, моя трилогия фиксов карт...

Фиксит три проблемы на дельте:
- Обрезанный провод от допросной до "просматриваемой допросной"
- Обрезанный провод с техов до комнат клоуна и мима
- ЛКП в техах над голопадом теперь изначально подключён к общей сети (почему-то лэндмарк повреждённого пола "ломает" соединение провода и терминала ЛКП)

## Почему это хорошо для игры
Меньше инженерных тревог из-за ошибок ~~мапперов~~ инженеров НТ, полагаю

## Тестирование
Играл на локалке 9 часов

## Changelog

:cl:
fix: Дельта: Обрезанный провод в допросной
fix: Дельта: Обрезанный провод под дверью с техов до комнат клоуна и мима
fix: Дельта: ЛКП в техах над голопадом теперь изначально подключён к сети
/:cl: