### PR TITLE
Allow robotics to use the R&D scientists console

### DIFF
--- a/modular_ss220/balance/code/access/access.dm
+++ b/modular_ss220/balance/code/access/access.dm
@@ -29,3 +29,7 @@
 /datum/job/engineer/New()
 	. = ..()
 	access += list(ACCESS_ATMOSPHERICS)
+
+/datum/job/roboticist/New()
+	. = ..()
+	access += list(ACCESS_TOX)

--- a/modular_ss220/jobs/_jobs.dme
+++ b/modular_ss220/jobs/_jobs.dme
@@ -1,6 +1,5 @@
 #include "_jobs.dm"
 
-#include "code/access.dm"
 #include "code/card_computer.dm"
 #include "code/card_id.dm"
 #include "code/departaments.dm"

--- a/modular_ss220/jobs/code/access.dm
+++ b/modular_ss220/jobs/code/access.dm
@@ -1,3 +1,0 @@
-/datum/job/scientist/New()
-	. = ..()
-	access |= ACCESS_MAINT_TUNNELS


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Даем робототехнику трогать РНД консоль ученых, ладно. Ну и лишний файлик убираю, и так сейчас все сотрудники отделов могут в техах шастать.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Я не знаю.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Побегал по текущим картам - консоль трогать можно, в техах бегать можно.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Maxiemar
tweak: Робототехники снова могут пользоваться консолью ученых в РНД.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
