### PR TITLE
Cyberiad: Separate cryo canisters

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -26319,6 +26319,9 @@
 	dir = 1;
 	name = "Cryo Tank Storage"
 	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/medical/general{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -24924,9 +24924,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "cloning"
 	},
@@ -25073,8 +25070,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "bWC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -25300,6 +25297,9 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
 	dir = 1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -26305,8 +26305,9 @@
 	},
 /area/station/medical/virology)
 "cbE" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on{
+	dir = 1;
+	name = "Temperature control unit"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -26314,13 +26315,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/portable/canister/oxygen,
 /obj/machinery/door/window/classic/normal{
 	dir = 1;
 	name = "Cryo Tank Storage"
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/all/medical/general{
-	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -26490,7 +26487,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -28427,7 +28426,7 @@
 /area/station/medical/medbay2)
 "ckC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29610,8 +29609,9 @@
 /area/station/medical/surgery/primary)
 "cpa" = (
 /obj/structure/table/glass,
-/obj/item/storage/toolbox/emergency,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 4
+	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -45179,9 +45179,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
@@ -45975,9 +45972,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -55482,10 +55476,6 @@
 /area/station/security/permabrig)
 "hlq" = (
 /obj/machinery/alarm/directional/south,
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on{
-	dir = 1;
-	name = "Temperature control unit"
-	},
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -57097,13 +57087,8 @@
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/item/crowbar,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light_switch/west,
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 10;
-	pixel_y = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -82604,7 +82589,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "rcZ" = (
-/obj/machinery/alarm/directional/north,
+/obj/machinery/atmospherics/portable/canister/oxygen,
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/classic/normal{
+	name = "Cryo Tank Storage"
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/all/medical/general,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -84607,6 +84603,7 @@
 /area/station/legal/courtroom)
 "rWA" = (
 /obj/machinery/clonepod/biomass,
+/obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},


### PR DESCRIPTION
## Что этот PR делает
Читай название

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
![image](https://github.com/ss220club/Paradise-SS220/assets/69762909/79ffdc0c-8ba4-4b55-8ae3-813c7ae7dc31)


## Тестирование
Нахуй надо

## Changelog

:cl:
tweak: Кибериада: Крио в клонёрке и просто крио теперь независимы. Однако я спиздил один клинер и бикер криоксадона :ratge:
/:cl:

