### PR TITLE
Fix: lavaland_air plasteel floor temperature and air parameters

### DIFF
--- a/modular_ss220/maps220/code/floors.dm
+++ b/modular_ss220/maps220/code/floors.dm
@@ -78,9 +78,9 @@
 /* Lavaland */
 /turf/simulated/floor/plasteel/lavaland_air
 	name = "floor"
-	temperature = 300
-	oxygen = 14
-	nitrogen = 23
+	temperature = 500
+	oxygen = 8
+	nitrogen = 14
 
 /* Indestructible */
 /turf/simulated/floor/indestructible/grass


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Продолжаю работать банщиком. Приводим параметры пола lavaland_air к оффовским значениям. Меньше нагрузки из-за разности в газовом давлении.

## Почему это хорошо для игры

Меньше нагрузки.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Локалка.

## Changelog

:cl:

fix: Приводим параметры пола lavaland_air к оффовским значениям.

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
