### PR TITLE
Tesla containment area safety

### DIFF
--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -54961,6 +54961,12 @@
 /obj/item/radio/intercom,
 /turf/simulated/wall,
 /area/station/engineering/atmos)
+"hcy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "hcz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/atmospherics/meter,
@@ -60436,6 +60442,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/processing)
+"jft" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "jfx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66728,6 +66744,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/engine,
 /area/station/science/explab/chamber)
+"lBS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "lCk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -121204,17 +121226,17 @@ qsQ
 qsQ
 qsQ
 cSU
-clS
-pqE
-clS
-cSU
-cKr
-cKr
-cKr
+jft
+jft
+jft
 cSU
 clS
 pqE
 clS
+cSU
+jft
+jft
+jft
 cSU
 cKr
 cKr
@@ -121715,7 +121737,7 @@ aab
 cSU
 iIG
 dpO
-cPn
+lBS
 aaa
 cTn
 cVB
@@ -121731,7 +121753,7 @@ cVB
 cVB
 rDS
 aaa
-qJO
+hcy
 afT
 cSU
 cSU
@@ -123257,7 +123279,7 @@ aab
 cSU
 cSU
 cRz
-cRA
+cLC
 aab
 dei
 cWf
@@ -123273,7 +123295,7 @@ aaa
 cRk
 mha
 aab
-cRA
+cLC
 dfA
 cSU
 cSU

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -28769,6 +28769,15 @@
 /mob/living/simple_animal/pet/cat/Floppa,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/blueshield)
+"clS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "clU" = (
 /obj/machinery/door/airlock/medical/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -77526,6 +77535,18 @@
 /obj/effect/spawner/random_spawners/blood_maybe,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"pqE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "pqG" = (
 /obj/structure/table,
 /obj/machinery/door/window/classic/normal{
@@ -121183,17 +121204,17 @@ qsQ
 qsQ
 qsQ
 cSU
-cKr
-cKr
-cKr
+clS
+pqE
+clS
 cSU
 cKr
 cKr
 cKr
 cSU
-cKr
-cKr
-cKr
+clS
+pqE
+clS
 cSU
 cKr
 cKr

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -49194,6 +49194,12 @@
 "eoX" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/permabrig)
+"epo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "epE" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -57204,6 +57210,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
+"gSE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "gSH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/pew/right{
@@ -129600,17 +129616,17 @@ cba
 cba
 cba
 bXU
-sAx
-uIz
-sAx
-bXU
-cie
-cie
-cie
+gSE
+gSE
+gSE
 bXU
 sAx
 uIz
 sAx
+bXU
+gSE
+gSE
+gSE
 bXU
 cie
 cie
@@ -130111,7 +130127,7 @@ aaa
 bXU
 bZj
 cbb
-cdc
+epo
 aaa
 ctY
 cJe
@@ -130127,7 +130143,7 @@ cJe
 cJe
 cOm
 aaa
-cda
+cbb
 cbb
 cDx
 bXU
@@ -131653,7 +131669,7 @@ jof
 bXU
 bXU
 bZl
-cbb
+cda
 abj
 cBU
 cjJ
@@ -131669,7 +131685,7 @@ aaa
 dUE
 cPK
 abj
-cbb
+cda
 cDv
 bXU
 cEA

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -94522,6 +94522,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/aft)
+"sAx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "sAG" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -101088,6 +101097,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/service/hydroponics)
+"uIz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "uIK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -129579,17 +129600,17 @@ cba
 cba
 cba
 bXU
-cie
-cie
-cie
+sAx
+uIz
+sAx
 bXU
 cie
 cie
 cie
 bXU
-cie
-cie
-cie
+sAx
+uIz
+sAx
 bXU
 cie
 cie


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Переставляет громоотводы в зоне содержания теслы, чтобы за ее пределами никого не било током.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Better gameplay.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
mapdiff
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Ни один робот бобот не пострадал

![image](https://github.com/ss220club/Paradise-SS220/assets/39908528/89461aeb-d4c8-4017-a3e6-4ffd035aea95)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Кибериада/Керберос: громоотводы в зоне содержания теслы были переставлены и теперь обеспечивают безопасность перемещения кого-либо за ее пределами.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
