### PR TITLE
Fix: whiteship dock sizes

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -82,7 +82,10 @@
 /obj/docking_port/stationary/whiteship{
 	dir = 8;
 	id = "whiteship_cyberiad";
-	name = "North of Cyberiad"
+	name = "North of Cyberiad";
+	dwidth = 8;
+	height = 31;
+	width = 21
 	},
 /turf/space,
 /area/space)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -80,12 +80,9 @@
 /area/station/aisat/atmos)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
-	dir = 8;
 	id = "whiteship_cyberiad";
 	name = "North of Cyberiad";
-	dwidth = 8;
-	height = 31;
-	width = 21
+	dir = 8
 	},
 /turf/space,
 /area/space)

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -80,9 +80,9 @@
 /area/station/aisat/atmos)
 "aaQ" = (
 /obj/docking_port/stationary/whiteship{
+	dir = 8;
 	id = "whiteship_cyberiad";
-	name = "North of Cyberiad";
-	dir = 8
+	name = "North of Cyberiad"
 	},
 /turf/space,
 /area/space)

--- a/_maps/map_files220/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/whiteship.dmm
@@ -2595,7 +2595,7 @@ Ia
 Kt
 Ts
 Ts
-Ts
+aA
 vk
 Kr
 dr
@@ -2671,7 +2671,7 @@ Rf
 aA
 Ts
 Ts
-Ts
+aA
 lO
 RT
 nQ

--- a/_maps/map_files220/cyberiad/cyberiad.dmm
+++ b/_maps/map_files220/cyberiad/cyberiad.dmm
@@ -90,7 +90,8 @@
 	id = "whiteship_cyberiad";
 	name = "North of Cyberiad";
 	dwidth = 8;
-	height = 31
+	height = 31;
+	width = 21
 	},
 /turf/space,
 /area/space)

--- a/_maps/map_files220/delta/delta.dmm
+++ b/_maps/map_files220/delta/delta.dmm
@@ -154688,10 +154688,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 hDZ
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Поменял размеры порта для медицинского шаттла НТ на Кибериаде. 
Опустил порт на Керберосе на три тайла вниз, что бы не было проблем с телепортацией с границы сектора на шаттл.
Небольшая правка стен шаттла.

## Почему это хорошо для игры

Медицинский шаттл НТ снова работает на Кибериаде. Нет проблем с телепортацией с границы сектора прямо на шаттл.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Локалка.

## Changelog

:cl:
fix: Медицинский шаттл НТ снова работает на Кибериаде (надеюсь). Нет проблем с телепортацией с границы сектора прямо на шаттл на Керберосе.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
