### PR TITLE
fix: Invisible items into SOL trader box

### DIFF
--- a/modular_ss220/jobs/code/objects/job_objects.dm
+++ b/modular_ss220/jobs/code/objects/job_objects.dm
@@ -123,6 +123,7 @@
 /obj/item/storage/box/legal_loot/populate_contents()
 	// "увеличиваем" шансы на выпадение коллекционного хлама
 	possible_type_loot |= subtypesof(/obj/item/toy) + subtypesof(/obj/item/clothing/head/collectable) + subtypesof(/obj/item/poster) + subtypesof(/obj/item/storage/fancy/cigarettes) + subtypesof(/obj/item/lighter/zippo) + subtypesof(/obj/item/id_skin)
+	possible_type_loot -= list(/obj/item/lighter/zippo/fluff, /obj/item/toy/plushie, /obj/item/toy/character, /obj/item/toy/desk, /obj/item/toy/plushie/fluff, /obj/item/toy/random)
 	for(var/i in 1 to loot_amount)
 		var/loot_type = pick(possible_type_loot)
 		new loot_type(src)


### PR DESCRIPTION
## Что этот PR делает
Убрал из списка невидимые предметы, они же подтипы в подтипах

## Почему это хорошо для игры
Нет невидимых игрушек

## Тестирование
![image](https://github.com/ss220club/Paradise-SS220/assets/69762909/c97eacf1-23df-4878-8349-c9033bf13597)

## Changelog

:cl:
fix: В коробке торговца больше не должно быть невидимых вещей
/:cl:
