### PR TITLE
Fix: spacebattle minor fixes

### DIFF
--- a/_maps/map_files220/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files220/RandomZLevels/spacebattle.dmm
@@ -119,17 +119,11 @@
 	},
 /area/awaymission/space_battle/hallway6)
 "av" = (
-/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory{
-	armour_penetration_flat = 20;
-	armour_penetration_percentage = 80;
-	loot = list(/obj/effect/decal/cleanable/ash,/obj/item/documents/syndicate/blue);
-	speed = 2;
-	health = 600;
-	maxHealth = 450;
-	name = "Syndicate Commander"
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/awaymission/space_battle/bridge)
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/awaymission/space_battle/syndicate/syndicate5)
 "aw" = (
 /obj/structure/window/plasmareinforced{
 	color = "red";
@@ -1475,6 +1469,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/awaymission/space_battle/cruiser)
+"eN" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib/spacebattle,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/awaymission/space_battle/syndicate/syndicate5)
 "eO" = (
 /obj/machinery/door/airlock/titanium,
 /obj/effect/landmark/damageturf,
@@ -4233,6 +4231,19 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "blue"
 	},
+/area/awaymission/space_battle/bridge)
+"nb" = (
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/syndicate/melee/autogib/depot/armory{
+	armour_penetration_flat = 20;
+	armour_penetration_percentage = 80;
+	loot = list(/obj/effect/decal/cleanable/ash,/obj/item/documents/syndicate/blue);
+	speed = 2;
+	health = 600;
+	maxHealth = 450;
+	name = "Syndicate Commander"
+	},
+/turf/simulated/floor/plasteel,
 /area/awaymission/space_battle/bridge)
 "nc" = (
 /obj/machinery/atmospherics/portable/canister/air,
@@ -9990,7 +10001,7 @@
 /obj/structure/chair/comfy/shuttle/dark{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/syndicate/ranged/autogib/spacebattle,
+/mob/living/simple_animal/hostile/syndicate/ranged/space/autogib/spacebattle,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/space_battle/syndicate/syndicate5)
 "Fd" = (
@@ -13765,6 +13776,10 @@
 	dir = 8
 	},
 /area/awaymission/space_battle/hallway4)
+"QF" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/awaymission/space_battle/syndicate/syndicate5)
 "QG" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral";
@@ -14591,10 +14606,7 @@
 /area/awaymission/space_battle/syndicate/syndicate6)
 "Tq" = (
 /obj/effect/spawner/window/plastitanium,
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	layer = 2.9
-	},
+/obj/machinery/door/poddoor,
 /turf/simulated/floor/plating,
 /area/awaymission/space_battle/syndicate/syndicate5)
 "Tr" = (
@@ -16007,7 +16019,7 @@
 /area/awaymission/space_battle/cruiser)
 "XH" = (
 /obj/mecha/combat/marauder/mauler{
-	max_integrity = 400
+	max_integrity = 250
 	},
 /obj/machinery/light/directional/west,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -50849,10 +50861,10 @@ jt
 by
 ek
 JE
-by
+nb
 JE
-av
 JE
+mb
 JE
 na
 VC
@@ -67067,7 +67079,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -68847,7 +68859,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -69645,7 +69657,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -71658,7 +71670,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -73693,6 +73705,7 @@ yG
 yG
 yG
 yG
+ol
 yG
 yG
 yG
@@ -73756,8 +73769,7 @@ yG
 yG
 yG
 yG
-yG
-yG
+ol
 yG
 yG
 yG
@@ -75509,7 +75521,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -76041,13 +76053,13 @@ yG
 yG
 ps
 Nu
-RU
+QF
 ks
 ks
 dj
 ks
 ks
-Jt
+av
 Nu
 ps
 yG
@@ -76555,13 +76567,13 @@ yG
 yG
 Nu
 Nu
-ks
+eN
 ks
 UJ
 XH
 IT
 ks
-ks
+eN
 Nu
 Nu
 yG
@@ -77099,7 +77111,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -77298,7 +77310,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -77863,7 +77875,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG
@@ -80132,7 +80144,7 @@ yG
 yG
 yG
 yG
-yG
+ol
 yG
 yG
 yG

--- a/_maps/map_files220/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files220/RandomZLevels/spacebattle.dmm
@@ -16477,6 +16477,11 @@
 /obj/structure/rack/gunrack,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/awaymission/space_battle/syndicate/syndicate2)
+"YZ" = (
+/obj/item/stack/ore/glass,
+/obj/effect/landmark/burnturf,
+/turf/simulated/floor/plating/asteroid/airless,
+/area/awaymission)
 "Za" = (
 /obj/item/shard{
 	icon_state = "medium";
@@ -19697,7 +19702,7 @@ cv
 cv
 cv
 cv
-TX
+YB
 yG
 yG
 cv
@@ -19954,8 +19959,8 @@ cv
 cv
 cv
 cv
-TX
-TX
+YB
+YB
 yG
 YB
 cv
@@ -20213,7 +20218,7 @@ cv
 cv
 YB
 YB
-TX
+YB
 YB
 cv
 cv
@@ -21498,9 +21503,9 @@ cv
 cv
 cv
 YB
-TX
-TX
-TX
+YB
+YB
+YB
 cv
 cv
 cv
@@ -21755,9 +21760,9 @@ cv
 cv
 cv
 cv
-TX
+YB
 yG
-TX
+YB
 cv
 cv
 cv
@@ -22012,7 +22017,7 @@ cv
 cv
 cv
 cv
-TX
+YB
 yG
 yG
 cv
@@ -58412,7 +58417,7 @@ yG
 yG
 yG
 yG
-Hc
+YO
 cv
 cv
 cv
@@ -58664,12 +58669,12 @@ yG
 yG
 yG
 yG
-yG
 yV
 yG
 yG
 yG
-cw
+yG
+YZ
 jQ
 cv
 cv
@@ -58920,10 +58925,10 @@ yG
 KW
 yG
 yG
-yG
 KW
 KW
 Hc
+yG
 yG
 cv
 cv
@@ -59178,8 +59183,8 @@ yG
 yG
 yG
 yG
-yG
 KW
+yG
 yG
 cv
 cv

--- a/_maps/map_files220/RandomZLevels/spacebattle.dmm
+++ b/_maps/map_files220/RandomZLevels/spacebattle.dmm
@@ -124,7 +124,7 @@
 	armour_penetration_percentage = 80;
 	loot = list(/obj/effect/decal/cleanable/ash,/obj/item/documents/syndicate/blue);
 	speed = 2;
-	health = 450;
+	health = 600;
 	maxHealth = 450;
 	name = "Syndicate Commander"
 	},
@@ -795,7 +795,7 @@
 /turf/simulated/floor/mineral/titanium,
 /area/awaymission/space_battle/storage)
 "cv" = (
-/turf/simulated/mineral/random,
+/turf/simulated/mineral,
 /area/awaymission)
 "cw" = (
 /obj/item/stack/ore/glass,
@@ -1188,7 +1188,9 @@
 /obj/machinery/field/containment{
 	layer = 1
 	},
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /turf/simulated/floor/fakespace,
 /area/awaymission/space_battle/sec_storage)
 "dL" = (
@@ -1765,7 +1767,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "LeftTurret"
@@ -2058,7 +2061,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "RightTurret"
@@ -4998,7 +5002,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "LeftTurret"
@@ -5331,9 +5336,17 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/space_battle/sec_storage)
 "qH" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating/airless,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/off_station/empty_charge/north,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel/airless{
+	icon_state = "yellow";
+	dir = 1
+	},
+/area/awaymission/space_battle/engineering)
 "qI" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 1
@@ -6032,7 +6045,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "RightTurret"
@@ -6114,7 +6128,9 @@
 /turf/simulated/floor/plating/airless,
 /area/awaymission/space_battle/hallway11)
 "tn" = (
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /obj/item/kirbyplants,
 /turf/space,
 /area/space)
@@ -6170,7 +6186,9 @@
 /turf/space,
 /area/awaymission/space_battle/prhallway2)
 "tu" = (
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /turf/space,
 /area/awaymission/space_battle/engineering)
 "tv" = (
@@ -7354,7 +7372,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "RightTurret"
@@ -7533,7 +7552,9 @@
 /obj/machinery/field/containment{
 	layer = 1
 	},
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /turf/simulated/floor/fakespace,
 /area/awaymission/space_battle/sec_storage)
 "xM" = (
@@ -9591,7 +9612,9 @@
 	},
 /area/awaymission/space_battle/hallway2)
 "Ea" = (
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /obj/effect/landmark/awaymissions/spacebattle/mob_spawn/ranged_space{
 	id = "hangar"
 	},
@@ -9832,7 +9855,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "RightTurret"
@@ -9929,7 +9953,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "LeftTurret"
@@ -9939,7 +9964,7 @@
 /area/awaymission/space_battle/turret6)
 "EY" = (
 /obj/effect/landmark/damageturf,
-/turf/simulated/mineral/random,
+/turf/simulated/mineral,
 /area/awaymission)
 "EZ" = (
 /obj/structure/closet/crate/can,
@@ -10084,7 +10109,9 @@
 	},
 /area/awaymission/space_battle/server)
 "Fx" = (
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /obj/item/stack/cable_coil,
 /turf/space,
 /area/space)
@@ -10562,6 +10589,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/off_station/empty_charge/south,
 /turf/simulated/floor/plating,
 /area/awaymission/space_battle/turret7)
 "GR" = (
@@ -11850,10 +11878,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "KW" = (
-/turf/simulated/mineral/random,
+/turf/simulated/mineral,
 /area/space)
 "KX" = (
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /turf/space,
 /area/space)
 "KY" = (
@@ -11880,15 +11910,16 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/space_battle/turret5)
 "La" = (
-/obj/item/powersink{
-	mode = 1;
-	in_use = 1;
-	anchored = 1;
-	origin_tech = "powerstorage=5;syndicate=1"
-	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure{
+	icon = 'icons/goonstation/objects/powersink.dmi';
+	icon_state = "powersink0";
+	name = "power sink";
+	desc = "A nulling power sink which drains energy from electrical systems.";
+	anchored = 1
 	},
 /turf/simulated/floor/plating/airless,
 /area/awaymission/space_battle/engineering)
@@ -13180,7 +13211,9 @@
 	layer = 1;
 	dir = 4
 	},
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /turf/simulated/floor/fakespace,
 /area/awaymission/space_battle/sec_storage)
 "OX" = (
@@ -16055,7 +16088,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "LeftTurret"
@@ -16183,7 +16217,8 @@
 /obj/machinery/porta_turret{
 	lethal = 1;
 	name = "ship defense turret";
-	attacked = 1
+	attacked = 1;
+	faction = "hostile"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "LeftTurret"
@@ -16270,7 +16305,9 @@
 /area/awaymission/space_battle/engine)
 "Yz" = (
 /obj/machinery/gateway,
-/obj/effect/decal/fakelattice,
+/obj/effect/decal/fakelattice{
+	density = 0
+	},
 /turf/simulated/floor/fakespace,
 /area/awaymission/space_battle/sec_storage)
 "YA" = (
@@ -35633,7 +35670,7 @@ yG
 Mn
 ex
 VC
-il
+qH
 Lw
 BL
 Lw
@@ -54404,9 +54441,9 @@ VC
 Mn
 jN
 Mn
-VC
+cf
 VE
-VC
+cf
 Mn
 bH
 Mn
@@ -59285,7 +59322,7 @@ cf
 Oj
 kH
 po
-qH
+Mn
 yG
 Dg
 yG
@@ -59542,7 +59579,7 @@ VF
 Lu
 or
 po
-qH
+Mn
 yG
 Dg
 yG
@@ -59799,7 +59836,7 @@ cf
 IZ
 kH
 po
-qH
+Mn
 yG
 Dg
 yG

--- a/modular_ss220/maps220/code/Areas/gateway.dm
+++ b/modular_ss220/maps220/code/Areas/gateway.dm
@@ -641,7 +641,7 @@
 	icon_state = "awaycontent1"
 	requires_power = TRUE
 	report_alerts = FALSE
-	dynamic_lighting = DYNAMIC_LIGHTING_ENABLED
+	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 
 /area/awaymission/space_battle/cruiser
 	name = "\improper Nanotrasen Cruiser"

--- a/modular_ss220/maps220/code/mobs.dm
+++ b/modular_ss220/maps220/code/mobs.dm
@@ -1386,8 +1386,8 @@
 	. = ..()
 
 /mob/living/simple_animal/hostile/syndicate/Initialize()
-	switch(rand(1,33))
-		// 3%
+	switch(rand(1,100))
+		// 1%
 		if(1)
 			SynSpace = /obj/item/clothing/suit/space/hardsuit/syndi
 		else
@@ -1428,9 +1428,11 @@
 	. = ..()
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/spacebattle
-	damage_coeff = list("brute" = 0.8, "fire" = 0.8, "tox" = 1, "clone" = 2, "stamina" = 0, "oxy" = 0.5)
+	damage_coeff = list("brute" = 1, "fire" = 0.6, "tox" = 1, "clone" = 2, "stamina" = 0, "oxy" = 0.5)
 	melee_damage_type = BURN
 	attack_sound = 'sound/weapons/saberon.ogg'
+	maxHealth = 160
+	health = 160
 
 /mob/living/simple_animal/hostile/syndicate/melee/autogib/spacebattle/Initialize()
 	. = ..()
@@ -1438,11 +1440,11 @@
 	return .
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/autogib/spacebattle
-	damage_coeff = list("brute" = 0.8, "fire" = 0.8, "tox" = 1, "clone" = 2, "stamina" = 0, "oxy" = 0)
+	damage_coeff = list("brute" = 1, "fire" = 0.8, "tox" = 1, "clone" = 2, "stamina" = 0, "oxy" = 0)
 	melee_damage_type = BURN
 	attack_sound = 'sound/weapons/saberon.ogg'
-	maxHealth = 130
-	health = 130
+	maxHealth = 200
+	health = 200
 
 /mob/living/simple_animal/hostile/syndicate/melee/space/autogib/spacebattle/Initialize()
 	. = ..()
@@ -1450,7 +1452,9 @@
 	return .
 
 /mob/living/simple_animal/hostile/syndicate/ranged/autogib/spacebattle
-	damage_coeff = list("brute" = 1, "fire" = 1, "tox" = 1, "clone" = 2, "stamina" = 0, "oxy" = 0.5)
+	damage_coeff = list("brute" = 1, "fire" = 0.6, "tox" = 1, "clone" = 2, "stamina" = 0, "oxy" = 0.5)
+	maxHealth = 150
+	health = 150
 
 /mob/living/simple_animal/hostile/syndicate/ranged/autogib/spacebattle/Initialize()
 	. = ..()
@@ -1458,8 +1462,8 @@
 	return .
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/autogib/spacebattle
-	maxHealth = 130
-	health = 130
+	maxHealth = 180
+	health = 180
 
 /mob/living/simple_animal/hostile/syndicate/ranged/space/autogib/spacebattle/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Заменил весь камень на /turf/simulated/mineral, что бы избежать генерации лаваленда.
Поставил недостоющие зоны, апц.
Заменил паверсинк на структуру.
Поднял ХП главгаду.
Скинул процент дропа синди хардсьюта до 1, скинул хп маулеру до 250, поднял хп мобам.

## Почему это хорошо для игры

Чуть прибрал за собой.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

В раунде.

## Changelog

:cl:
fix: Технические изменения гейта spacebattle.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
