### PR TITLE
CereStation for shitspawn

### DIFF
--- a/code/modules/admin/verbs/mapping_verbs.dm
+++ b/code/modules/admin/verbs/mapping_verbs.dm
@@ -190,7 +190,7 @@ GLOBAL_VAR_INIT(intercom_range_display_status, 0)
 	var/list/map_datums = list()
 	for(var/x in subtypesof(/datum/map))
 		var/datum/map/M = x
-		if(initial(M.voteable))
+		if(initial(M.voteable) || initial(M.admin_only)) // SS220 EDIT - ADD FARRAGUS FOR ADMINS
 			map_datums["[initial(M.fluff_name)] ([initial(M.technical_name)])"] = M // Put our map in
 
 	var/target_map_name = input(usr, "Select target map", "Next map", null) as null|anything in map_datums

--- a/modular_ss220/maps220/code/Station/cerestation.dm
+++ b/modular_ss220/maps220/code/Station/cerestation.dm
@@ -1,2 +1,6 @@
+/datum/map
+	var/admin_only = FALSE
+
 /datum/map/cerestation
 	voteable = FALSE
+	admin_only = TRUE


### PR DESCRIPTION
## Что этот PR делает
Это не первоапрельская шутка.
Добавлена возможность щитспавна Фаррагуса, это остаётся на совести администрации.

## Почему это хорошо для игры
Некоторым нравится Фаррагус

## Тестирование
Да

## Changelog

:cl:
add: Админам добавлена возможность поставить CereStation (Фаррагус) принудительно, читай - щитспавн. Все действия остаются на совести администрации! Мы лишь добавили возможность, карта нами не поддерживается! Гейт и наши предметы отсутствуют! Также возможны проблемы с шаттлами торговцев, нюки и ЦК.
/:cl:
