### PR TITLE
Better changelog validation

### DIFF
--- a/tools/changelog/tags.yml
+++ b/tools/changelog/tags.yml
@@ -1,25 +1,49 @@
 tags:
-    add: add
-    del: del
-    tweak: tweak
-    fix: fix
-    wip: wip
-    soundadd: soundadd
-    sounddel: sounddel
-    imageadd: imageadd
-    imagedel: imagedel
-    spellcheck: spellcheck
-    experiment: experiment
+  fix: 'fix'
+  fixes: 'fix'
+  bugfix: 'fix'
+  wip: 'wip'
+  tweak: 'tweak'
+  tweaks: 'tweak'
+  rsctweak: 'tweak'
+  soundadd: 'soundadd'
+  sounddel: 'sounddel'
+  imageadd: 'imageadd'
+  imagedel: 'imagedel'
+  add: 'codeadd'
+  adds: 'codeadd'
+  rscadd: 'codeadd'
+  codeadd: 'codeadd'
+  del: 'codedel'
+  dels: 'codedel'
+  rscdel: 'codedel'
+  codedel: 'codedel'
+  typo: 'spellcheck'
+  spellcheck: 'spellcheck'
+  experimental: 'experiment'
+  experiment: 'experiment'
 
 defaults:
-    add: Что-то добавил
-    del: Что-то удалил
-    tweak: Поменял что-то по мелочи
-    fix: Что-то починил
-    wip: Какие-либо наработки в процессе
-    soundadd: Добавил новый звук
-    sounddel: Удалил старый звук
-    imageadd: Добавил новую картинку
-    imagedel: Удалил старую картинку
-    spellcheck: Исправил опечатку
-    experiment: Добавил эксперементальную функцию
+  fix: 'Что-то починил'
+  fixes: 'Что-то починил'
+  bugfix: 'Что-то починил'
+  wip: 'Какие-либо наработки в процессе'
+  tweak: 'Поменял что-то по мелочи'
+  tweaks: 'Поменял что-то по мелочи'
+  rsctweak: 'Поменял что-то по мелочи'
+  soundadd: 'Добавил новый звук'
+  sounddel: 'Удалил старый звук'
+  imageadd: 'Добавил новую картинку'
+  imagedel: 'Удалил старую картинку'
+  add: 'Что-то добавил'
+  adds: 'Что-то добавил'
+  rscadd: 'Что-то добавил'
+  codeadd: 'Что-то добавил'
+  del: 'Что-то удалил'
+  dels: 'Что-то удалил'
+  rscdel: 'Что-то удалил'
+  codedel: 'Что-то удалил'
+  typo: 'Исправил опечатку'
+  spellcheck: 'Исправил опечатку'
+  experimental: 'Добавил экспериментальную функцию'
+  experiment: 'Добавил экспериментальную функцию'


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
- [x] Рефакторит валидацию чейнджлога.
- [x] Разрешает синонимичные теги.
- [x] Запрещает использование чейнджлога из шаблона ПРа.
- [x] Ставит на валидации крестик, если она провалена.
- [x] Ограничивает длину эмодзифицированного чейнджлога в 4096 символов согласно [документации](https://discord.com/developers/docs/resources/channel#embed-object-embed-limits).
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Чейнджлог чаще попадает в базу/дис.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Я (тестировщик), произвожу тесты воркфлоу на форке 😎 

![image](https://github.com/ss220club/Paradise-SS220/assets/39908528/205f90d9-a4a7-4c59-821f-cfea27afed95)

Но нормально работает вроде.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

