### PR TITLE
Make Exploreverse elligible to use in Space Ruins levels

### DIFF
--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -18,7 +18,7 @@
 
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
 	. = ..()
-	if(is_away_level(new_z) || (!is_station_level(new_z) && is_level_reachable(new_z)))
+	if(is_away_level(new_z) || (!is_station_level(new_z) && check_level_trait(new_z, REACHABLE_SPACE_ONLY)))
 		if(ismob(loc))
 			to_chat(loc, span_notice("Ваш [src] активируется, начиная аккумулировать энергию из материи сущего."))
 		selfcharge = TRUE

--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -17,18 +17,17 @@
 	onTransitZ(new_z = loc.z)
 
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
-
-	if(is_away_level(new_z))
+	. = ..()
+	if(is_away_level(new_z) || (!is_station_level(new_z) && is_level_reachable(new_z)))
 		if(ismob(loc))
 			to_chat(loc, span_notice("Ваш [src] активируется, начиная аккумулировать энергию из материи сущего."))
 		selfcharge = TRUE
-	else
-		if(selfcharge)
-			if(ismob(loc))
-				to_chat(loc, span_danger("Ваш [src] деактивируется, так как он подавляется системами станции.</span>"))
-			cell.charge = 0
-			selfcharge = FALSE
-			update_icon()
+		return
+	if(ismob(loc) && selfcharge)
+		to_chat(loc, span_danger("Ваш [src] деактивируется, так как он подавляется системами станции.</span>"))
+	cell.charge = 0
+	selfcharge = FALSE
+	update_icon()
 
 /obj/item/gun/energy/laser/awaymission_aeg/proc/update_mob()
 	if(ismob(loc))


### PR DESCRIPTION
## Что этот PR делает
Гейт ган можно использовать не только в гейте, но и в космосе, вне станционного уровня

## Почему это хорошо для игры
Эксплореры могут защититься в космосе

## Тестирование
Да

## Changelog

:cl:
tweak: Exploreverse (Гейт-ган) можно теперь использовать в секторах с космическими руинами.
/:cl:
