### PR TITLE
[TM] Softcrit return

### DIFF
--- a/modular_ss220/crit_rework/code/crit_rework_component.dm
+++ b/modular_ss220/crit_rework/code/crit_rework_component.dm
@@ -1,10 +1,9 @@
-#define OLD_CRIT_TRAIT "old-crit"
+#define OLD_CRIT_TRAIT "softcrit"
 
 /datum/component/softcrit
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 
 /datum/component/softcrit/Initialize(...)
-	. = ..()
 	if(!ishuman(parent))
 		return COMPONENT_INCOMPATIBLE
 	softcrit_entered()
@@ -20,7 +19,6 @@
 	UnregisterSignal(parent, COMSIG_LIVING_HANDLE_MESSAGE_MODE)
 
 /datum/component/softcrit/proc/softcrit_entered()
-	SIGNAL_HANDLER
 	ADD_TRAIT(parent, TRAIT_FLOORED, OLD_CRIT_TRAIT)
 	ADD_TRAIT(parent, TRAIT_HANDS_BLOCKED, OLD_CRIT_TRAIT)
 
@@ -29,13 +27,12 @@
 	REMOVE_TRAIT(parent, TRAIT_FLOORED, OLD_CRIT_TRAIT)
 	REMOVE_TRAIT(parent, TRAIT_HANDS_BLOCKED, OLD_CRIT_TRAIT)
 	qdel(src)
-	return
 
 /datum/component/softcrit/proc/on_examine(atom/A, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 	var/mob/living/carbon/human/owner = parent
-	if(owner.stat == CONSCIOUS)
-		examine_list += span_warning("<B>[owner] с трудом держится в сознании.\n</B>")
+	if(owner.stat != DEAD)
+		examine_list += span_warning("<B>[owner] на грани потери сознания!\n</B>")
 
 /datum/component/softcrit/proc/check_health()
 	SIGNAL_HANDLER

--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -49,6 +49,7 @@
 #include "crawl_speed/_crawl_speed.dme"
 #include "credits/_credits.dme"
 #include "cyrillic_fixes/_cyrillic_fixes.dme"
+#include "crit_rework/_crit_rework.dme"
 #include "debug/_debug.dme"
 #include "detective_rework/detective_rework.dme"
 #include "discord_link/_discord_link.dme"
@@ -101,5 +102,3 @@
 	он всегда напоминает о своём существовании. Небольшая библиотека,
 	если так вообще можно выразиться.
  ---------------------------------------------------------------------*/
-
-// #include "crit_rework/_crit_rework.dme"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Не изменяет текущий "прогрессивный крит", а лишь дополняет его.

Теперь при достижении крита, вы:
* Можете только шептать
* Не можете использовать руки
* Можете только ползать

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Более смертные куклы

## Changelog

:cl:
tweak: Возвращен софткрит, делая куклы более смертными. При достижении 100 урона (крит), кукла переходит в состояние софт-крита, в котором она может только ползать и шептать.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
