### PR TITLE
[FIX] Headslugs cannot be taken in hands

### DIFF
--- a/modular_ss220/mobs/code/simple_animal/mobs.dm
+++ b/modular_ss220/mobs/code/simple_animal/mobs.dm
@@ -7,7 +7,7 @@
 
 /mob/living/simple_animal/hostile/headslug
 	attacktext = "грызёт"
-//	holder_type = /obj/item/holder/headslug
+// holder_type = /obj/item/holder/headslug (Пупс попросил закомментить)
 
 /mob/living/simple_animal/hostile/retaliate/clown/goblin
 	holder_type = /obj/item/holder/clowngoblin

--- a/modular_ss220/mobs/code/simple_animal/mobs.dm
+++ b/modular_ss220/mobs/code/simple_animal/mobs.dm
@@ -7,7 +7,7 @@
 
 /mob/living/simple_animal/hostile/headslug
 	attacktext = "грызёт"
-	holder_type = /obj/item/holder/headslug
+//	holder_type = /obj/item/holder/headslug
 
 /mob/living/simple_animal/hostile/retaliate/clown/goblin
 	holder_type = /obj/item/holder/clowngoblin


### PR DESCRIPTION
## Что этот PR делает
Более нельзя взять в руки живого хедслага. 

## Почему это хорошо для игры

Теперь невозможна ситуация, когда живой хедслаг находится в руках или инвентаре и его не видно из-за отсутствующего спрайта

## Changelog

:cl:
fix: Более нельзя взять в руки живого хедслага. 
/:cl: