### PR TITLE
Fix: centcomm teleporter fix

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -28695,7 +28695,9 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "qIF" = (
-/obj/machinery/teleport/hub/upgraded,
+/obj/machinery/teleport/hub/upgraded{
+	admin_usage = 1
+	},
 /obj/effect/turf_decal/stripes,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Телепорт в зоне ОБР снова работает (вроде бы)

## Почему это хорошо для игры

Работает = хорошо.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Локалка, у меня работает.

## Changelog

:cl:
fix: Починен телепортер в зоне ОБР - доставка отряда с ЦК без посредников и прямиком на мостик.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
