### PR TITLE
Fix roundstart observers and actualize wizard home

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -274,16 +274,12 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
 "aiZ" = (
-/obj/effect/turf_decal/woodsiding{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/candle/eternal/wizard{
+	pixel_y = 5;
+	pixel_x = -7
 	},
-/obj/effect/turf_decal/woodsiding{
-	dir = 4
-	},
-/obj/structure/mineral_door/wood{
-	name = "Changing chamber"
-	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/carpet/black,
 /area/wizard_station)
 "ajc" = (
 /obj/structure/chair/comfy/brown{
@@ -440,7 +436,6 @@
 /area/syndicate_mothership/cargo)
 "aoX" = (
 /obj/structure/light_fake/small{
-	dir = 2;
 	light_range = 6;
 	light_color = "red"
 	},
@@ -565,12 +560,10 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
 "arZ" = (
-/obj/structure/rack,
-/obj/item/kitchen/knife/ritual,
-/obj/structure/window/reinforced/clockwork{
-	dir = 4
+/obj/machinery/economy/vending/cola/free{
+	name = "\improper Wizbust Softdrinks"
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "ase" = (
 /obj/machinery/door/airlock/centcom{
@@ -1148,11 +1141,9 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
 "aIZ" = (
-/obj/machinery/computer/library{
-	pixel_y = 8
-	},
+/obj/machinery/recharger,
 /obj/structure/table/wood,
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "aJf" = (
 /obj/structure/table/wood/fancy/black,
@@ -1217,8 +1208,8 @@
 /turf/simulated/floor/wood,
 /area/ghost_bar)
 "aKO" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/flora/junglebush,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "aKS" = (
 /obj/machinery/computer/drone_control{
@@ -1472,6 +1463,18 @@
 	water_overlay_image = null
 	},
 /area/syndicate_mothership/outside)
+"aRM" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/candle/eternal/wizard{
+	pixel_y = 5;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/drinks/mugwort{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/wizard_station)
 "aRU" = (
 /obj/docking_port/stationary/transit{
 	dir = 8;
@@ -3675,8 +3678,14 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate_sit)
 "caA" = (
-/obj/structure/showcase,
-/turf/simulated/floor/wood/oak,
+/obj/structure/table/wood,
+/obj/item/razor{
+	pixel_x = 10
+	},
+/obj/item/candle/eternal/wizard{
+	pixel_y = 11
+	},
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "caG" = (
 /obj/structure/sign/poster/official/nanotrasen_logo{
@@ -4584,11 +4593,11 @@
 /area/syndicate_mothership)
 "cFS" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/trash/semki,
+/obj/item/storage/fancy/matches,
 /obj/effect/turf_decal/woodsiding{
-	dir = 9
+	dir = 1
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "cFW" = (
 /obj/machinery/door/airlock/centcom{
@@ -4628,16 +4637,8 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership)
 "cHw" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/candle/eternal/wizard{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/drinks/mugwort{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/turf/simulated/floor/carpet/purple,
+/mob/living/carbon/human/monkey/magic,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "cHz" = (
 /obj/structure/light_fake/spot{
@@ -5003,7 +5004,6 @@
 "cTi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/centcom/ss220/supply)
@@ -5694,6 +5694,14 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
+"dou" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet{
+	name = "our demands";
+	info = "Deliver five cream pies to the agreed place or your apprentice gets honked again"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/wizard_station)
 "dow" = (
 /obj/item/kirbyplants,
 /turf/simulated/floor/plasteel{
@@ -6940,7 +6948,6 @@
 /area/shuttle/syndicate)
 "dVH" = (
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/centcom/ss220/supply)
@@ -7209,10 +7216,8 @@
 	},
 /area/centcom/ss220/admin1)
 "edZ" = (
-/obj/machinery/economy/vending/artvend{
-	name = "\improper WizArtVend"
-	},
-/turf/simulated/floor/wood/oak,
+/obj/item/kirbyplants,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "eed" = (
 /obj/structure/chair/stool/bar{
@@ -7663,7 +7668,6 @@
 /area/syndicate_mothership)
 "esG" = (
 /turf/simulated/floor/plasteel/dark{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/centcom/ss220/supply)
@@ -8664,9 +8668,8 @@
 /area/centcom/ss220/evac)
 "eTP" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/dice,
 /obj/effect/turf_decal/woodsiding,
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "eTS" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
@@ -10692,7 +10695,6 @@
 	desc = "Слава Нанотрейзен!"
 	},
 /obj/structure/light_fake/small{
-	dir = 2;
 	light_range = 6;
 	light_color = "red"
 	},
@@ -10818,8 +10820,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "giy" = (
-/obj/item/flag/wiz,
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "giO" = (
 /obj/structure/light_fake/small{
@@ -10835,8 +10836,12 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "giY" = (
-/obj/structure/kitchenspike,
-/turf/simulated/floor/wood/oak,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/item/kirbyplants,
+/obj/structure/window/reinforced/clockwork{
+	dir = 4
+	},
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "gjQ" = (
 /obj/structure/sign/poster/official/random/north,
@@ -11036,10 +11041,12 @@
 	},
 /area/ghost_bar)
 "gqe" = (
-/obj/structure/chair/sofa{
+/obj/structure/chair/sofa/corner{
+	dir = 6;
 	color = "#63009c"
 	},
-/turf/simulated/floor/wood/oak,
+/obj/effect/landmark/spawner/roundstart_observer,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "gqH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -11926,12 +11933,11 @@
 /turf/simulated/floor/carpet/arcade,
 /area/syndicate_mothership/infteam)
 "gSz" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/paper/crumpled/bloody/ruins/lavaland/clown_planet{
-	info = "Deliver five cream pies to the agreed place or your apprentice gets honked again";
-	name = "our demands"
+/mob/living/simple_animal/hostile/creature{
+	name = "Experiment 35b"
 	},
-/turf/simulated/floor/carpet/purple,
+/obj/item/candle/eternal/wizard,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "gSF" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -12108,12 +12114,11 @@
 	},
 /area/syndicate_mothership)
 "gXA" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/drinks/mug/novelty,
-/obj/item/candle/eternal/wizard{
-	pixel_y = 11
+/obj/structure/chair/sofa/right{
+	color = "#63009c"
 	},
-/turf/simulated/floor/wood/oak,
+/obj/effect/landmark/spawner/roundstart_observer,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "gXS" = (
 /obj/structure/fans/tiny/invisible,
@@ -12696,7 +12701,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/specops)
 "hnP" = (
-/turf/simulated/floor/lava/lava_land_surface,
+/turf/simulated/floor/lava/mapping_lava,
 /area/wizard_station)
 "hnT" = (
 /obj/machinery/economy/vending/wallmed/syndicate{
@@ -13955,11 +13960,17 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "hUk" = (
-/turf/simulated/floor/plasteel{
-	dir = 2;
-	icon_state = "whiteblue"
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
 	},
-/area/centcom/ss220/medbay)
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
+	},
+/obj/structure/mineral_door/wood{
+	name = "Changing chamber"
+	},
+/turf/simulated/floor/wood/fancy/cherry,
+/area/wizard_station)
 "hUn" = (
 /obj/machinery/icemachine{
 	dir = 1
@@ -15123,6 +15134,11 @@
 /obj/item/deck/cards/black,
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/bar)
+"ixW" = (
+/obj/effect/decal/cleanable/molten_object/large,
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/grass/jungle,
+/area/wizard_station)
 "iyK" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/simulated/floor/indestructible/grass,
@@ -15547,6 +15563,16 @@
 	icon_state = "dark_small"
 	},
 /area/centcom/ss220/admin2)
+"iQF" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/gavelblock{
+	desc = "Smack it with a gavel hammer when the wizard council gets rowdy."
+	},
+/obj/item/gavelhammer{
+	desc = "Order, order! No bombs in my council chamber."
+	},
+/turf/simulated/floor/wood,
+/area/wizard_station)
 "iQW" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/glass/bottle/morphine,
@@ -15568,7 +15594,6 @@
 "iRB" = (
 /obj/effect/turf_decal/delivery/blue/hollow,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/medbay)
@@ -16339,6 +16364,7 @@
 /obj/structure/chair/comfy/purp{
 	name = "wizard council throne"
 	},
+/obj/effect/landmark/spawner/roundstart_observer,
 /turf/simulated/floor/carpet/red,
 /area/wizard_station)
 "jss" = (
@@ -16420,7 +16446,8 @@
 	},
 /area/centcom/ss220/admin3)
 "juJ" = (
-/turf/simulated/floor/wood/oak,
+/obj/effect/baseturf_helper/asteroid/basalt,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "jvf" = (
 /obj/machinery/computer/account_database{
@@ -18854,7 +18881,7 @@
 /obj/structure/mineral_door/wood{
 	name = "Main chamber"
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "kOF" = (
 /obj/structure/table/holotable/wood{
@@ -19052,10 +19079,10 @@
 /turf/simulated/floor/carpet/cyan,
 /area/centcom/ss220/supply)
 "kTs" = (
-/obj/machinery/economy/vending/cola/free{
-	name = "\improper Wizbust Softdrinks"
+/obj/machinery/economy/vending/snack/free{
+	name = "\improper Wizmore Chocolate Corp"
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "kUd" = (
 /obj/structure/table/reinforced,
@@ -19439,11 +19466,11 @@
 /area/centcom/ss220/command)
 "leH" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/storage/fancy/matches,
+/obj/item/stack/spacecash,
 /obj/effect/turf_decal/woodsiding{
 	dir = 1
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "leS" = (
 /obj/structure/table/glass,
@@ -19717,8 +19744,12 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
 "lmc" = (
-/obj/item/kirbyplants,
-/turf/simulated/floor/wood/oak,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/stack/ore/uranium,
+/obj/effect/turf_decal/woodsiding{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "lmy" = (
 /obj/item/storage/bible,
@@ -19882,7 +19913,6 @@
 /area/centcom/ss220/supply)
 "lsx" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	layer = 2.9;
 	name = "LMG M249 SAW";
 	req_access_txt = "114"
 	},
@@ -20022,9 +20052,9 @@
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "luW" = (
-/obj/structure/chair/comfy/purp{
-	dir = 1;
-	name = "wizard council throne"
+/obj/item/radio/intercom/syndicate{
+	pixel_x = 24;
+	dir = 8
 	},
 /turf/simulated/floor/carpet/red,
 /area/wizard_station)
@@ -20167,7 +20197,6 @@
 	base_icon_state = "sleeper_s-open"
 	},
 /turf/simulated/floor/plasteel/dark{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/centcom/ss220/admin3)
@@ -20372,8 +20401,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/polarized{
-	id = "cc_syrg_2";
-	dir = 2
+	id = "cc_syrg_2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -20937,10 +20965,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/general)
 "lSO" = (
-/obj/structure/chair/sofa/right{
+/obj/structure/chair/sofa{
 	color = "#63009c"
 	},
-/turf/simulated/floor/wood/oak,
+/obj/effect/landmark/spawner/roundstart_observer,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "lTh" = (
 /obj/structure/closet/cabinet{
@@ -22066,8 +22095,11 @@
 /area/centcom/ss220/general)
 "mGK" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/effect/turf_decal/woodsiding,
-/turf/simulated/floor/wood/oak,
+/obj/structure/pondering_orb,
+/obj/effect/turf_decal/woodsiding{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "mGP" = (
 /obj/structure/chair/sofa/corner{
@@ -23043,8 +23075,8 @@
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/gamma/space)
 "nlm" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/flora/junglebush/large,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "nls" = (
 /obj/structure/window/reinforced{
@@ -24872,7 +24904,8 @@
 	},
 /area/syndicate_mothership/cargo)
 "ouy" = (
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/flora/grass/jungle,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "ouD" = (
 /obj/structure/rack/gunrack,
@@ -25450,8 +25483,8 @@
 /turf/simulated/floor/carpet/green,
 /area/ghost_bar)
 "oJS" = (
-/obj/structure/flora/junglebush,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "oKb" = (
 /obj/structure/table,
@@ -26067,12 +26100,12 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
 "pai" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/candle/eternal/wizard,
-/obj/effect/turf_decal/woodsiding{
-	dir = 8
+/obj/structure/table/wood,
+/obj/item/reagent_containers/drinks/mug/novelty,
+/obj/item/candle/eternal/wizard{
+	pixel_y = 11
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "pas" = (
 /obj/structure/statue/cyberiad/north,
@@ -26607,12 +26640,7 @@
 	},
 /area/shuttle/syndicate)
 "pvL" = (
-/obj/structure/table/wood,
-/obj/item/candle/eternal/wizard{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "pvN" = (
 /obj/structure/chair/sofa/corp/right{
@@ -26775,8 +26803,7 @@
 /area/syndicate_mothership/infteam)
 "pAR" = (
 /obj/structure/window/reinforced/polarized{
-	id = "cc_syrg_2";
-	dir = 2
+	id = "cc_syrg_2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
@@ -27133,9 +27160,8 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
 "pMU" = (
-/obj/effect/decal/cleanable/molten_object/large,
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/flora/tree/jungle/small,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "pNe" = (
 /obj/structure/window/reinforced{
@@ -27991,10 +28017,8 @@
 	},
 /area/centcom/ss220/medbay)
 "qmm" = (
-/obj/machinery/economy/vending/snack/free{
-	name = "\improper Wizmore Chocolate Corp"
-	},
-/turf/simulated/floor/wood/oak,
+/obj/item/flag/wiz,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "qms" = (
 /obj/structure/table,
@@ -28176,11 +28200,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
 "qsi" = (
-/obj/structure/chair/sofa/corner{
-	color = "#63009c";
-	dir = 6
+/obj/structure/chair/comfy/purp{
+	name = "wizard council throne";
+	dir = 1
 	},
-/turf/simulated/floor/wood/oak,
+/obj/effect/landmark/spawner/roundstart_observer,
+/turf/simulated/floor/carpet/red,
 /area/wizard_station)
 "qsk" = (
 /obj/effect/turf_decal/delivery,
@@ -28202,9 +28227,10 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/general)
 "qsK" = (
-/obj/machinery/recharger,
-/obj/structure/table/wood,
-/turf/simulated/floor/wood/oak,
+/obj/machinery/economy/vending/artvend{
+	name = "\improper WizArtVend"
+	},
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "qtv" = (
 /obj/machinery/cryopod/robot/offstation,
@@ -28734,7 +28760,6 @@
 /area/centcom/ss220/park)
 "qKs" = (
 /obj/structure/closet/secure_closet/guncabinet{
-	layer = 2.9;
 	name = "Automatic Shotgun";
 	req_access_txt = "114"
 	},
@@ -29130,14 +29155,8 @@
 	},
 /area/centcom/ss220/admin2)
 "qXy" = (
-/obj/structure/table/wood,
-/obj/item/razor{
-	pixel_x = 10
-	},
-/obj/item/candle/eternal/wizard{
-	pixel_y = 11
-	},
-/turf/simulated/floor/wood/oak,
+/obj/structure/kitchenspike,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "qXJ" = (
 /obj/machinery/door_control/no_emag/east{
@@ -29262,15 +29281,15 @@
 /area/centcom/ss220/medbay)
 "rae" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/dice/d20,
+/obj/item/trash/semki,
 /obj/effect/turf_decal/woodsiding{
-	dir = 5
+	dir = 9
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "rak" = (
-/obj/structure/flora/rock/jungle,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/effect/decal/remains/human,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "ram" = (
 /obj/structure/mecha_wreckage/durand/old{
@@ -29424,8 +29443,7 @@
 "rfp" = (
 /obj/machinery/bodyscanner,
 /obj/structure/window/reinforced/polarized{
-	id = "cc_syrg_2";
-	dir = 2
+	id = "cc_syrg_2"
 	},
 /obj/structure/window/reinforced/polarized{
 	id = "cc_syrg_2";
@@ -29529,7 +29547,6 @@
 	},
 /obj/structure/rack,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/medbay)
@@ -30443,14 +30460,13 @@
 	},
 /area/centcom/ss220/jail)
 "rCd" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/gavelblock{
-	desc = "Smack it with a gavel hammer when the wizard council gets rowdy."
+/obj/structure/chair/brass{
+	name = "arch wizard's throne"
 	},
-/obj/item/gavelhammer{
-	desc = "Order, order! No bombs in my council chamber."
+/obj/effect/turf_decal/woodsiding{
+	dir = 4
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "rCj" = (
 /obj/structure/platform{
@@ -31404,7 +31420,6 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/medbay)
@@ -31951,11 +31966,8 @@
 /turf/simulated/floor/wood,
 /area/centcom/ss220/court)
 "stQ" = (
-/obj/structure/chair/sofa/left{
-	color = "#63009c";
-	dir = 4
-	},
-/turf/simulated/floor/wood/oak,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "stR" = (
 /obj/machinery/door/airlock/centcom{
@@ -32224,8 +32236,8 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/bar)
 "sEk" = (
-/obj/structure/flora/grass/jungle,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/flora/rock/jungle,
+/turf/simulated/floor/grass/jungle,
 /area/wizard_station)
 "sEq" = (
 /obj/structure/bookcase/random,
@@ -33513,7 +33525,6 @@
 "tqp" = (
 /obj/structure/sink/directional/south,
 /turf/simulated/floor/plasteel{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/centcom/ss220/medbay)
@@ -33750,13 +33761,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "txR" = (
-/obj/structure/chair/brass{
-	name = "arch wizard's throne"
-	},
-/obj/effect/turf_decal/woodsiding{
-	dir = 4
-	},
-/turf/simulated/floor/wood/oak,
+/obj/structure/showcase,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "tyo" = (
 /obj/effect/spawner/window,
@@ -34456,7 +34462,6 @@
 	color = "#6697cc"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 2;
 	color = "red"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -35053,12 +35058,13 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "unm" = (
-/obj/structure/table/wood,
-/obj/item/candle/eternal/wizard{
-	pixel_y = 11
+/obj/structure/rack,
+/obj/item/radio/intercom/syndicate{
+	pixel_x = -24;
+	dir = 4
 	},
-/obj/item/coin/uranium,
-/turf/simulated/floor/wood/oak,
+/obj/item/kitchen/knife/shiv/carrot,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "uns" = (
 /obj/structure/mirror{
@@ -35604,8 +35610,12 @@
 	},
 /area/syndicate_mothership/control)
 "uFa" = (
-/obj/structure/flora/junglebush/large,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/structure/chair/sofa/left{
+	dir = 4;
+	color = "#63009c"
+	},
+/obj/effect/landmark/spawner/roundstart_observer,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "uFW" = (
 /obj/structure/table/reinforced,
@@ -35709,8 +35719,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "uIE" = (
-/obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/wood/oak,
+/obj/structure/rack,
+/obj/item/kitchen/knife/ritual,
+/obj/structure/window/reinforced/clockwork{
+	dir = 4
+	},
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "uJb" = (
 /obj/structure/curtain/open/shower/security{
@@ -36513,11 +36527,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "vkP" = (
-/mob/living/simple_animal/hostile/creature{
-	name = "Experiment 35b"
+/obj/item/radio/intercom/syndicate{
+	pixel_x = 24;
+	dir = 8
 	},
-/obj/item/candle/eternal/wizard,
-/turf/simulated/floor/grass/jungle/no_creep,
+/turf/simulated/floor/carpet/black,
 /area/wizard_station)
 "vkU" = (
 /obj/machinery/door/airlock/centcom{
@@ -38166,9 +38180,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/escape)
 "wgG" = (
-/obj/structure/rack,
-/obj/item/kitchen/knife/shiv/carrot,
-/turf/simulated/floor/wood/oak,
+/obj/structure/bookcase/random,
+/obj/item/book/granter/spell/summon_cheese,
+/turf/simulated/floor/carpet/red,
 /area/wizard_station)
 "wgM" = (
 /obj/structure/curtain/black{
@@ -38452,9 +38466,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -38579,12 +38591,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "wtd" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/structure/pondering_orb,
-/obj/effect/turf_decal/woodsiding{
-	dir = 6
+/obj/structure/table/wood,
+/obj/item/candle/eternal/wizard{
+	pixel_y = 11
 	},
-/turf/simulated/floor/wood/oak,
+/obj/item/coin/uranium,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "wti" = (
 /obj/machinery/economy/slot_machine,
@@ -38807,11 +38819,9 @@
 /area/centcom/ss220/supply)
 "wxt" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/stack/ore/uranium,
-/obj/effect/turf_decal/woodsiding{
-	dir = 10
-	},
-/turf/simulated/floor/wood/oak,
+/obj/item/dice,
+/obj/effect/turf_decal/woodsiding,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "wxv" = (
 /obj/structure/shuttle/engine/platform{
@@ -40776,8 +40786,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "xzc" = (
-/mob/living/carbon/human/monkey/magic,
-/turf/simulated/floor/wood/oak,
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/candle/eternal/wizard,
+/obj/effect/turf_decal/woodsiding{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "xzF" = (
 /obj/effect/turf_decal/loading_area{
@@ -41189,7 +41203,7 @@
 	},
 /area/centcom/ss220/supply)
 "xLF" = (
-/turf/simulated/wall/indestructible/riveted,
+/turf/simulated/wall/indestructible/boss,
 /area/space/centcomm)
 "xMa" = (
 /obj/structure/chair/office/dark{
@@ -41322,8 +41336,11 @@
 	},
 /area/centcom/ss220/bar)
 "xPy" = (
-/obj/effect/decal/remains/human,
-/turf/simulated/floor/grass/jungle/no_creep,
+/obj/item/radio/intercom/syndicate{
+	pixel_x = 24;
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
 /area/wizard_station)
 "xPO" = (
 /obj/structure/table/reinforced,
@@ -41855,11 +41872,11 @@
 /area/centcom/ss220/admin3)
 "ygr" = (
 /obj/structure/table/wood/fancy/royalblack,
-/obj/item/stack/spacecash,
+/obj/item/dice/d20,
 /obj/effect/turf_decal/woodsiding{
-	dir = 1
+	dir = 5
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/wood,
 /area/wizard_station)
 "ygI" = (
 /obj/machinery/conveyor/south{
@@ -42005,12 +42022,11 @@
 	},
 /area/centcom/ss220/admin1)
 "ylz" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/item/kirbyplants,
-/obj/structure/window/reinforced/clockwork{
-	dir = 4
+/obj/machinery/computer/library{
+	pixel_y = 8
 	},
-/turf/simulated/floor/wood/oak,
+/obj/structure/table/wood,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "ylD" = (
 /obj/machinery/door/airlock/titanium/glass{
@@ -62040,7 +62056,7 @@ ipH
 uMr
 qlN
 qLq
-hUk
+eVA
 uMr
 sZR
 uKR
@@ -62297,7 +62313,7 @@ ttK
 uMr
 fZv
 qLq
-hUk
+eVA
 kdh
 hCE
 vWn
@@ -62811,7 +62827,7 @@ bGa
 uMr
 vTp
 bQB
-hUk
+eVA
 uMr
 kGg
 lLb
@@ -89753,39 +89769,39 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
 adJ
 adJ
 adJ
@@ -90010,39 +90026,39 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+bQD
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bQD
 adJ
 adJ
 adJ
@@ -90268,37 +90284,37 @@ adJ
 adJ
 adJ
 bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
+kKi
+lOn
+lOn
+lOn
+lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+lOn
+lOn
+lOn
+lOn
+kKi
 bQD
 adJ
 adJ
@@ -90526,6 +90542,7 @@ adJ
 adJ
 bQD
 kKi
+lOn
 kKi
 kKi
 kKi
@@ -90543,6 +90560,7 @@ kKi
 kKi
 kKi
 kKi
+kSy
 kKi
 kKi
 kKi
@@ -90552,9 +90570,7 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
-kKi
+lOn
 kKi
 bQD
 adJ
@@ -90784,9 +90800,6 @@ adJ
 bQD
 kKi
 lOn
-lOn
-lOn
-lOn
 kKi
 kKi
 kKi
@@ -90808,9 +90821,12 @@ kKi
 kKi
 kKi
 kKi
-lOn
-lOn
-lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
 lOn
 kKi
 bQD
@@ -91046,19 +91062,19 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
 kSy
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
 kKi
 kKi
 kKi
@@ -91297,7 +91313,6 @@ adJ
 adJ
 bQD
 kKi
-lOn
 kKi
 kKi
 kKi
@@ -91325,7 +91340,8 @@ kKi
 kKi
 kKi
 kKi
-lOn
+kKi
+kKi
 kKi
 bQD
 adJ
@@ -91554,13 +91570,6 @@ adJ
 adJ
 bQD
 kKi
-lOn
-kKi
-kKi
-kKi
-kKi
-kKi
-kSy
 kKi
 kKi
 kKi
@@ -91582,7 +91591,14 @@ kKi
 kKi
 kKi
 kKi
-lOn
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
 kKi
 bQD
 adJ
@@ -92090,7 +92106,7 @@ kKi
 kKi
 kKi
 kKi
-kKi
+kSy
 kKi
 kKi
 kKi
@@ -92604,7 +92620,7 @@ kKi
 kKi
 kKi
 kKi
-kSy
+kKi
 kKi
 kKi
 kKi
@@ -92841,7 +92857,7 @@ bQD
 kKi
 kKi
 kKi
-kKi
+kSy
 kKi
 kKi
 kKi
@@ -93355,31 +93371,31 @@ bQD
 kKi
 kKi
 kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+njf
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
 kSy
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
 kKi
 kKi
 kKi
@@ -93623,9 +93639,9 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
-kKi
+njf
+njf
+njf
 kKi
 kKi
 kKi
@@ -93879,11 +93895,11 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
+hym
+hym
 njf
-kKi
-kKi
+njf
+njf
 kKi
 kKi
 kKi
@@ -94135,8 +94151,10 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
+hym
+hym
+hym
+sps
 njf
 njf
 njf
@@ -94148,9 +94166,7 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
-kKi
+kSy
 kKi
 kKi
 kKi
@@ -94395,8 +94411,8 @@ kKi
 kKi
 hym
 hym
-njf
-njf
+hym
+hym
 njf
 kKi
 kKi
@@ -94649,13 +94665,11 @@ kKi
 kKi
 kKi
 kKi
-hym
-hym
-hym
-sps
+kKi
+kKi
 njf
 njf
-njf
+hym
 kKi
 kKi
 kKi
@@ -94664,7 +94678,9 @@ kKi
 kKi
 kKi
 kKi
-kSy
+kKi
+kKi
+kKi
 kKi
 kKi
 kKi
@@ -94907,10 +94923,8 @@ kKi
 kKi
 kKi
 kKi
-hym
-hym
-hym
-hym
+kKi
+kKi
 njf
 kKi
 kKi
@@ -94921,7 +94935,9 @@ kKi
 kKi
 kKi
 kKi
-kSy
+kKi
+kKi
+kKi
 kKi
 kKi
 kKi
@@ -95165,9 +95181,9 @@ kKi
 kKi
 kKi
 kKi
-njf
-njf
-hym
+kKi
+kKi
+kKi
 kKi
 kKi
 kKi
@@ -95423,7 +95439,6 @@ kKi
 kKi
 kKi
 kKi
-njf
 kKi
 kKi
 kKi
@@ -95436,6 +95451,7 @@ kKi
 kKi
 kKi
 kKi
+kSy
 kKi
 kKi
 kKi
@@ -95666,7 +95682,7 @@ adJ
 adJ
 bQD
 kKi
-kKi
+kSy
 kKi
 kKi
 kKi
@@ -95949,7 +95965,7 @@ kKi
 kKi
 kKi
 kKi
-kSy
+kKi
 kKi
 kKi
 kKi
@@ -96180,7 +96196,7 @@ adJ
 adJ
 bQD
 kKi
-kSy
+kKi
 kKi
 kKi
 kKi
@@ -96698,7 +96714,7 @@ kKi
 kKi
 kKi
 kKi
-kKi
+kSy
 kKi
 kKi
 kKi
@@ -96951,6 +96967,7 @@ adJ
 adJ
 bQD
 kKi
+lOn
 kKi
 kKi
 kKi
@@ -96978,8 +96995,7 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
+lOn
 kKi
 bQD
 adJ
@@ -97208,12 +97224,7 @@ adJ
 adJ
 bQD
 kKi
-kKi
-kKi
-kKi
-kKi
-kSy
-kKi
+lOn
 kKi
 kKi
 kKi
@@ -97237,6 +97248,11 @@ kKi
 kKi
 kKi
 kKi
+kKi
+kKi
+kKi
+kKi
+lOn
 kKi
 bQD
 adJ
@@ -97478,6 +97494,7 @@ kKi
 kKi
 kKi
 kKi
+kSy
 kKi
 kKi
 kKi
@@ -97485,8 +97502,7 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
+kSy
 kKi
 kKi
 kKi
@@ -97723,6 +97739,9 @@ adJ
 bQD
 kKi
 lOn
+lOn
+lOn
+lOn
 kKi
 kKi
 kKi
@@ -97744,12 +97763,9 @@ kKi
 kKi
 kKi
 kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
+lOn
+lOn
+lOn
 lOn
 kKi
 bQD
@@ -97979,7 +97995,6 @@ adJ
 adJ
 bQD
 kKi
-lOn
 kKi
 kKi
 kKi
@@ -97992,7 +98007,6 @@ kKi
 kKi
 kKi
 kKi
-kSy
 kKi
 kKi
 kKi
@@ -98000,14 +98014,16 @@ kKi
 kKi
 kKi
 kKi
-kSy
 kKi
 kKi
 kKi
 kKi
 kKi
 kKi
-lOn
+kKi
+kKi
+kKi
+kKi
 kKi
 bQD
 adJ
@@ -98235,37 +98251,37 @@ adJ
 adJ
 adJ
 bQD
-kKi
-lOn
-lOn
-lOn
-lOn
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-lOn
-lOn
-lOn
-lOn
-kKi
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
+bQD
 bQD
 adJ
 adJ
@@ -98491,39 +98507,39 @@ adJ
 adJ
 adJ
 adJ
-bQD
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-kKi
-bQD
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+adJ
+adJ
+adJ
+adJ
+adJ
 adJ
 adJ
 adJ
@@ -98748,39 +98764,39 @@ adJ
 adJ
 adJ
 adJ
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
-bQD
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+adJ
+xLF
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+xLF
+adJ
+adJ
+adJ
+adJ
+adJ
 adJ
 adJ
 adJ
@@ -99011,27 +99027,27 @@ adJ
 adJ
 adJ
 adJ
+adJ
 xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
 xLF
 adJ
 adJ
@@ -99268,10 +99284,12 @@ adJ
 adJ
 adJ
 adJ
+adJ
 xLF
 hnP
 hnP
 hnP
+qvn
 hnP
 hnP
 hnP
@@ -99279,12 +99297,10 @@ hnP
 hnP
 hnP
 hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
+qvn
+qvn
+qvn
+qvn
 hnP
 hnP
 hnP
@@ -99525,9 +99541,11 @@ adJ
 adJ
 adJ
 adJ
+adJ
 xLF
 hnP
 hnP
+qvn
 hnP
 hnP
 hnP
@@ -99539,10 +99557,8 @@ hnP
 hnP
 hnP
 hnP
-hnP
-hnP
-hnP
-hnP
+qvn
+qvn
 hnP
 hnP
 hnP
@@ -99776,17 +99792,17 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
 xLF
 hnP
 hnP
-hnP
-hnP
+qvn
 hnP
 hnP
 hnP
@@ -100033,12 +100049,6 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
 xLF
 hnP
 hnP
@@ -100059,14 +100069,20 @@ hnP
 hnP
 hnP
 hnP
+qvn
+hnP
+hnP
+hnP
+hnP
+hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+xLF
+xLF
+xLF
+xLF
+xLF
+xLF
 adJ
 adJ
 adJ
@@ -100290,13 +100306,12 @@ adJ
 adJ
 adJ
 adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
 xLF
+hnP
+hnP
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -100311,6 +100326,13 @@ hnP
 hnP
 hnP
 qvn
+qvn
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -100318,14 +100340,8 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+xLF
+xLF
 adJ
 adJ
 tWI
@@ -100548,15 +100564,9 @@ adJ
 adJ
 adJ
 xLF
-xLF
-xLF
-xLF
-xLF
-xLF
-xLF
 hnP
 hnP
-hnP
+qvn
 hnP
 hnP
 hnP
@@ -100572,18 +100582,24 @@ hnP
 hnP
 hnP
 hnP
+qvn
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+xLF
 adJ
 tWI
 eNi
@@ -100807,8 +100823,7 @@ adJ
 xLF
 hnP
 hnP
-hnP
-hnP
+qvn
 hnP
 hnP
 hnP
@@ -100823,7 +100838,17 @@ hnP
 hnP
 hnP
 hnP
-qvn
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -100832,15 +100857,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 eNi
@@ -101073,10 +101089,19 @@ hnP
 hnP
 hnP
 hnP
-qvn
-qvn
 hnP
 hnP
+hnP
+oTA
+oTA
+gGW
+gGW
+oTA
+oTA
+oTA
+oTA
+oTA
+oTA
 hnP
 hnP
 hnP
@@ -101089,15 +101114,6 @@ hnP
 hnP
 hnP
 xLF
-xLF
-xLF
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 eNi
@@ -101334,27 +101350,27 @@ hnP
 hnP
 hnP
 oTA
-oTA
+txR
+giy
+giy
+unm
 gGW
-gGW
-oTA
-oTA
-oTA
-oTA
-oTA
+ouy
+ixW
+sEk
 oTA
 hnP
 hnP
+hnP
+qvn
+hnP
+hnP
+hnP
+hnP
+qvn
 hnP
 hnP
 xLF
-xLF
-xLF
-adJ
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 eNi
@@ -101587,31 +101603,31 @@ hnP
 hnP
 hnP
 hnP
+qvn
+qvn
 hnP
-hnP
-hnP
-oTA
-caA
-juJ
-juJ
-wgG
 gGW
-sEk
+caA
+stQ
+giy
+giy
+gGW
+pvL
 pMU
-rak
+ouy
 oTA
 hnP
 hnP
 hnP
+qvn
+qvn
 hnP
 hnP
+hnP
+qvn
+qvn
 hnP
 xLF
-xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 eNi
@@ -101838,7 +101854,7 @@ hnP
 hnP
 hnP
 hnP
-hnP
+qvn
 hnP
 hnP
 hnP
@@ -101846,16 +101862,16 @@ hnP
 hnP
 qvn
 qvn
-hnP
+qvn
 gGW
 qXy
-uIE
-juJ
-juJ
+cHw
+giy
+stQ
 gGW
 ouy
 aKO
-sEk
+gSz
 oTA
 hnP
 hnP
@@ -101864,11 +101880,11 @@ hnP
 hnP
 hnP
 hnP
+hnP
+hnP
+qvn
+hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 dqH
@@ -102101,19 +102117,23 @@ hnP
 hnP
 hnP
 hnP
-qvn
-qvn
 hnP
-gGW
+hnP
+qvn
+oTA
 giY
-xzc
-juJ
+giy
+giy
 uIE
 gGW
 sEk
 oJS
-vkP
+ouy
 oTA
+qvn
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -102122,10 +102142,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 dqH
@@ -102354,23 +102370,27 @@ hnP
 hnP
 qvn
 hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
+oTA
+oTA
+oTA
+oTA
+oTA
+oTA
+qvn
 oTA
 ylz
-juJ
-juJ
+giy
+giy
 arZ
 gGW
 rak
 nlm
-sEk
+aKO
 oTA
+qvn
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -102379,10 +102399,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 dqH
@@ -102611,23 +102627,27 @@ hnP
 hnP
 qvn
 hnP
+gGW
+aWR
+cJw
+pQt
+rUC
 oTA
 oTA
-oTA
-oTA
-oTA
-oTA
-hnP
 oTA
 aIZ
-juJ
-juJ
+giy
+giy
 kTs
-gGW
-xPy
-uFa
-oJS
 oTA
+oTA
+oTA
+oTA
+oTA
+oTA
+qvn
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -102636,10 +102656,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 eNi
@@ -102861,31 +102877,35 @@ lap
 elh
 adJ
 xLF
-hnP
-hnP
-hnP
-hnP
-hnP
 qvn
 hnP
-gGW
-aWR
-cJw
-pQt
-rUC
+hnP
+hnP
+hnP
+hnP
+hnP
 oTA
-oTA
+xcx
+mLx
+mLx
+mLx
+aiZ
+kpL
 oTA
 qsK
-juJ
-juJ
+giy
+giy
 qmm
 oTA
 oTA
+qNg
+wgG
+ltk
 oTA
+gGW
 oTA
-oTA
-oTA
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -102893,10 +102913,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 eNi
@@ -103118,7 +103134,7 @@ lap
 lap
 adJ
 xLF
-hnP
+qvn
 hnP
 hnP
 hnP
@@ -103126,34 +103142,34 @@ hnP
 hnP
 hnP
 oTA
-xcx
+pJU
 mLx
 mLx
 mLx
-pvL
-kpL
+kqP
+eBq
 oTA
-edZ
-juJ
-juJ
+oTA
+pai
 giy
-oTA
-oTA
-qNg
-ltk
-ltk
-oTA
+giy
+biu
+aph
+aph
+aph
+aph
+aph
+aph
 oTA
 oTA
 hnP
 hnP
+hnP
+hnP
+qvn
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 iav
@@ -103375,42 +103391,42 @@ lap
 lap
 adJ
 xLF
+qvn
 hnP
 hnP
 hnP
 hnP
 hnP
 hnP
-hnP
-oTA
-pJU
+gGW
+leW
 mLx
 mLx
+vkP
 mLx
-kqP
-eBq
+siT
 oTA
 oTA
 gXA
-juJ
-juJ
+giy
+giy
 biu
+jsp
+rae
+xzc
+lmc
+qsi
 aph
-aph
-aph
-aph
-aph
-aph
-oTA
+ltk
 oTA
 hnP
+hnP
+hnP
+hnP
+qvn
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 adJ
@@ -103639,35 +103655,35 @@ hnP
 hnP
 hnP
 hnP
-gGW
-leW
-mLx
-mLx
-mLx
-mLx
-siT
+oTA
+oTA
+oTA
+hUk
+oTA
+oTA
+oTA
 oTA
 oTA
 lSO
 juJ
-juJ
+giy
 biu
 jsp
 cFS
-pai
+kPo
 wxt
-luW
+qsi
 aph
 ltk
 oTA
 hnP
 hnP
 hnP
+hnP
+qvn
+hnP
+hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 adJ
@@ -103897,34 +103913,34 @@ hnP
 hnP
 hnP
 oTA
+rbA
+mXv
+fWC
+tXw
+aRM
 oTA
-oTA
-aiZ
-oTA
-oTA
-oTA
-oTA
-oTA
+wtd
+uFa
 gqe
-juJ
-juJ
+giy
+giy
 biu
 jsp
 leH
-kPo
+iQF
 eTP
-luW
+qsi
 aph
 ltk
 oTA
 hnP
 hnP
 hnP
+hnP
+hnP
+hnP
+hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 tWI
@@ -104154,34 +104170,34 @@ hnP
 hnP
 hnP
 oTA
-rbA
-mXv
+dou
+vOJ
 fWC
-tXw
-cHw
-oTA
-unm
-stQ
-qsi
-juJ
-juJ
+kiC
+fWC
+kOi
+giy
+giy
+giy
+giy
+giy
 biu
 jsp
 ygr
 rCd
 mGK
-luW
+qsi
 aph
 ltk
 oTA
 hnP
 hnP
 hnP
+hnP
+hnP
+hnP
+hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 gPD
@@ -104409,36 +104425,36 @@ hnP
 hnP
 hnP
 hnP
-hnP
+qvn
 oTA
-gSz
-vOJ
+gTg
 fWC
-kiC
+fWC
+fWC
 fWC
 kOi
-juJ
-juJ
-juJ
-juJ
-juJ
+giy
+giy
+giy
+giy
+edZ
 biu
-jsp
-rae
-txR
-wtd
+aph
+aph
+aph
+aph
 luW
 aph
-ltk
 oTA
+oTA
+hnP
+hnP
+qvn
+hnP
 hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 skE
@@ -104664,38 +104680,38 @@ hnP
 hnP
 hnP
 hnP
+qvn
+qvn
+qvn
+oTA
+elf
+aRa
+fWC
+xPy
+gfg
+oTA
+oTA
+gGW
+gGW
+gGW
+oTA
+oTA
+oTA
+ltk
+jNk
+ltk
+oTA
+gGW
+oTA
+hnP
 hnP
 hnP
 qvn
-oTA
-gTg
-fWC
-fWC
-fWC
-fWC
-kOi
-juJ
-juJ
-juJ
-juJ
-lmc
-biu
-aph
-aph
-aph
-aph
-aph
-aph
-oTA
-oTA
+qvn
 hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 tMH
@@ -104921,38 +104937,38 @@ hnP
 hnP
 hnP
 hnP
-qvn
-qvn
-qvn
-oTA
-elf
-aRa
-fWC
-fWC
-gfg
+hnP
+hnP
+hnP
 oTA
 oTA
-gGW
-gGW
+oTA
 gGW
 oTA
 oTA
 oTA
-ltk
-jNk
-ltk
+hnP
+qvn
+qvn
+qvn
+qvn
+hnP
 oTA
 oTA
 oTA
+oTA
+oTA
+qvn
+qvn
+hnP
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 tWI
@@ -105181,24 +105197,28 @@ hnP
 hnP
 hnP
 hnP
-oTA
-oTA
-oTA
-gGW
-oTA
-oTA
-oTA
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
 hnP
 qvn
 qvn
-qvn
-qvn
 hnP
-oTA
-oTA
-oTA
-oTA
-oTA
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -105206,10 +105226,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 vPR
@@ -105454,7 +105470,7 @@ hnP
 hnP
 hnP
 hnP
-hnP
+qvn
 qvn
 hnP
 hnP
@@ -105462,11 +105478,11 @@ hnP
 hnP
 hnP
 hnP
+hnP
+hnP
+hnP
+hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 dgI
@@ -105698,14 +105714,21 @@ hnP
 hnP
 hnP
 hnP
+qvn
+qvn
+qvn
+hnP
+hnP
+hnP
+olA
+qvn
+qvn
 hnP
 hnP
 hnP
 hnP
 hnP
-hnP
-hnP
-hnP
+qvn
 hnP
 hnP
 hnP
@@ -105713,17 +105736,10 @@ hnP
 hnP
 qvn
 qvn
-hnP
-hnP
-hnP
 hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 oTI
@@ -105950,19 +105966,6 @@ hnP
 hnP
 hnP
 hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-qvn
-qvn
-qvn
-hnP
-hnP
-hnP
-olA
-qvn
 qvn
 hnP
 hnP
@@ -105974,13 +105977,26 @@ hnP
 hnP
 hnP
 hnP
+hnP
+hnP
+qvn
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+qvn
+qvn
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 tWI
 tWI
@@ -106204,22 +106220,11 @@ adJ
 xLF
 hnP
 hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
-hnP
 qvn
 hnP
 hnP
-hnP
-hnP
-hnP
-hnP
+qvn
+qvn
 qvn
 hnP
 hnP
@@ -106231,13 +106236,24 @@ hnP
 hnP
 hnP
 hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+hnP
+qvn
+qvn
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 adJ
 adJ
@@ -106461,6 +106477,8 @@ adJ
 xLF
 hnP
 hnP
+qvn
+qvn
 hnP
 hnP
 hnP
@@ -106482,6 +106500,9 @@ hnP
 hnP
 hnP
 hnP
+hnP
+qvn
+qvn
 hnP
 hnP
 hnP
@@ -106490,11 +106511,6 @@ hnP
 hnP
 hnP
 xLF
-xLF
-adJ
-adJ
-adJ
-adJ
 adJ
 adJ
 adJ
@@ -106724,6 +106740,8 @@ hnP
 hnP
 hnP
 hnP
+qvn
+qvn
 hnP
 hnP
 hnP
@@ -106738,6 +106756,9 @@ hnP
 hnP
 hnP
 hnP
+hnP
+qvn
+qvn
 hnP
 hnP
 hnP
@@ -106747,11 +106768,6 @@ hnP
 hnP
 hnP
 xLF
-adJ
-adJ
-adJ
-adJ
-adJ
 adJ
 adJ
 adJ
@@ -106995,6 +107011,12 @@ hnP
 hnP
 hnP
 hnP
+qvn
+qvn
+hnP
+hnP
+hnP
+hnP
 hnP
 hnP
 hnP
@@ -107003,12 +107025,6 @@ hnP
 hnP
 xLF
 xLF
-xLF
-adJ
-adJ
-adJ
-adJ
-adJ
 adJ
 adJ
 adJ
@@ -107258,13 +107274,13 @@ hnP
 hnP
 hnP
 hnP
+hnP
+hnP
+hnP
+hnP
 xLF
-adJ
-adJ
-adJ
-adJ
-adJ
-adJ
+xLF
+xLF
 adJ
 adJ
 adJ
@@ -107516,10 +107532,10 @@ xLF
 xLF
 xLF
 xLF
-adJ
-adJ
-adJ
-adJ
+xLF
+xLF
+xLF
+xLF
 adJ
 adJ
 adJ


### PR DESCRIPTION
## Что этот PR делает
Починил раундстартовых обсёрверов и заодно актуализировал хату мага с оффами

## Почему это хорошо для игры
Свежесть и без багов, наверное

## Изображения изменений
Дифф бот

## Тестирование
Нет

## Changelog

:cl:
fix: Можно снова гоститься до начала раунда
tweak: Хата мага получила интеркомы синдиката, лаву как на лаваленде, пару новых окон и новый пол. А, ещё на одну из книжных полок положена дополнительная книга
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
