### PR TITLE
Actualize stations & Lavaland

### DIFF
--- a/_maps/map_files220/generic/Lavaland.dmm
+++ b/_maps/map_files220/generic/Lavaland.dmm
@@ -102,7 +102,8 @@
 /area/mine/outpost/custodial)
 "at" = (
 /obj/machinery/shower{
-	dir = 8
+	dir = 8;
+	pixel_x = -6
 	},
 /obj/structure/curtain/open/shower,
 /obj/effect/decal/cleanable/dirt,
@@ -140,10 +141,11 @@
 "ay" = (
 /obj/item/bikehorn/rubberducky,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -6
+	},
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
 "az" = (
@@ -201,11 +203,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
+	dir = 5;
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
@@ -737,9 +736,9 @@
 /area/mine/outpost/cafeteria)
 "bO" = (
 /obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
+	id_tag = "s_docking_airlock";
+	name = "Labor Shuttle Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/docking_port/mobile/labour,
 /obj/structure/fans/tiny,
 /obj/docking_port/stationary{
@@ -862,6 +861,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/bed/roller,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -3417,11 +3417,16 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "hj" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/mineral/titanium,
+/obj/effect/turf_decal{
+	dir = 10
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "hl" = (
 /obj/structure/stone_tile/block{
@@ -3463,8 +3468,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "hx" = (
@@ -3574,8 +3578,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "id" = (
@@ -3729,6 +3732,9 @@
 	},
 /area/mine/outpost/lockers)
 "iB" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
 /obj/machinery/mineral/labor_prisoner_shuttle_console{
 	pixel_y = 32
 	},
@@ -3920,8 +3926,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "jq" = (
@@ -5382,6 +5387,12 @@
 /obj/structure/table/reinforced/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"pn" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/siberia)
 "pq" = (
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
@@ -5504,6 +5515,10 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"qJ" = (
+/obj/effect/decal/cleanable/fungus,
+/turf/simulated/wall/r_wall,
+/area/mine/laborcamp)
 "qK" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -5545,7 +5560,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredyellowfull"
+	},
 /area/mine/laborcamp)
 "rm" = (
 /obj/machinery/conveyor{
@@ -5776,10 +5793,8 @@
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/legion)
 "sO" = (
+/obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/storage/firstaid/ancient,
-/obj/item/stack/medical/bruise_pack/advanced,
 /turf/simulated/floor/plasteel{
 	icon_state = "barber"
 	},
@@ -6261,9 +6276,10 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "vk" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/machinery/door/airlock/titanium{
+	name = "Labor Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "vm" = (
@@ -6308,8 +6324,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "vy" = (
@@ -6351,14 +6366,19 @@
 	dir = 8
 	},
 /area/mine/outpost/hallway/east)
+"vG" = (
+/obj/structure/shuttle/engine/propulsion/burst{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium/interior,
+/area/lavaland/surface/outdoors)
 "vI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/item/trash/syndi_cakes,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "vK" = (
@@ -6442,7 +6462,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredyellowfull"
+	},
 /area/mine/laborcamp)
 "wn" = (
 /obj/structure/stone_tile/block/cracked{
@@ -6742,8 +6764,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "yo" = (
@@ -6908,8 +6929,7 @@
 /obj/structure/table,
 /obj/item/kitchen/utensil/fork,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "zs" = (
@@ -7367,6 +7387,12 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/random/volcanic,
 /area/lavaland/surface/outdoors)
+"BC" = (
+/obj/structure/closet/crate/freezer/iv_storage,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/mine/laborcamp)
 "BD" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
@@ -7428,8 +7454,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "Cb" = (
@@ -7569,8 +7594,18 @@
 	},
 /area/mine/laborcamp/security)
 "CK" = (
-/obj/structure/closet/crate,
-/turf/simulated/floor/mineral/titanium,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Labor Camp Shuttle";
+	network = list("Labor Camp");
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "CL" = (
 /obj/structure/girder,
@@ -7604,6 +7639,15 @@
 /obj/item/wirecutters/brass,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"CW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/stack/medical/splint,
+/obj/item/stack/medical/bruise_pack/advanced,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/mine/laborcamp)
 "CX" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/item/radio/intercom/directional/west,
@@ -7679,6 +7723,14 @@
 "Dq" = (
 /turf/simulated/wall,
 /area/mine/outpost/hallway/east)
+"Dt" = (
+/obj/item/stack/ore/iron,
+/turf/simulated/floor/plating{
+	nitrogen = 14;
+	oxygen = 8;
+	temperature = 500
+	},
+/area/lavaland/surface/outdoors)
 "Dy" = (
 /obj/item/toy/figure/crew/miner,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -7984,7 +8036,7 @@
 /obj/item/bedsheet/orange,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/damageturf,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/oak,
 /area/mine/laborcamp)
 "Fs" = (
 /obj/structure/stone_tile/block/burnt{
@@ -8067,11 +8119,11 @@
 /area/lavaland/surface/outdoors)
 "FW" = (
 /obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
+	id_tag = "s_docking_airlock";
+	name = "Labor Shuttle Airlock"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/structure/fans/tiny,
-/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "FX" = (
@@ -8106,6 +8158,18 @@
 /obj/effect/spawner/random_spawners/oil_maybe,
 /turf/simulated/floor/plasteel,
 /area/mine/outpost/mechbay)
+"Gm" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/ancient,
+/obj/machinery/camera{
+	c_tag = "Labor Camp Infirmary";
+	network = list("Labor Camp");
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/mine/laborcamp)
 "Gn" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -8116,7 +8180,7 @@
 "Gp" = (
 /obj/structure/sign/poster/contraband/clown,
 /obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/mine/laborcamp)
 "Gt" = (
 /obj/structure/stone_tile/cracked{
@@ -8251,6 +8315,9 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/legion)
+"Hs" = (
+/turf/simulated/wall/r_wall,
+/area/mine/laborcamp)
 "Hu" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -8300,6 +8367,12 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"HE" = (
+/obj/structure/closet/walllocker/emerglocker/north,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight/flare,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/lavaland/surface/outdoors)
 "HF" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -8451,7 +8524,9 @@
 	dir = 4
 	},
 /obj/item/trash/sosjerky,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredyellowfull"
+	},
 /area/mine/laborcamp)
 "Iv" = (
 /obj/effect/turf_decal/delivery,
@@ -8670,6 +8745,10 @@
 /obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"JJ" = (
+/obj/structure/door_assembly/door_assembly_silver,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/lavaland/surface/outdoors)
 "JK" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -8687,7 +8766,7 @@
 	network = list("Labor Camp")
 	},
 /obj/effect/landmark/damageturf,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood/oak,
 /area/mine/laborcamp)
 "JQ" = (
 /obj/machinery/light/small/directional/east,
@@ -8701,7 +8780,9 @@
 "JV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredyellowfull"
+	},
 /area/mine/laborcamp)
 "JX" = (
 /obj/structure/table,
@@ -8756,8 +8837,7 @@
 /obj/structure/table,
 /obj/item/trash/plate,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "Ko" = (
@@ -8892,7 +8972,13 @@
 	id = "gulagshuttleflasher";
 	pixel_x = 25
 	},
-/turf/simulated/floor/mineral/titanium,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal{
+	dir = 9
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "KS" = (
 /turf/simulated/wall/boss,
@@ -8946,6 +9032,10 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Ll" = (
+/obj/structure/flora/ash/tall_shroom,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Lr" = (
@@ -9307,6 +9397,9 @@
 /obj/structure/railing,
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/outpost/catwalk)
+"Nl" = (
+/turf/simulated/wall/mineral/titanium,
+/area/lavaland/surface/outdoors)
 "Nn" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
@@ -9654,7 +9747,7 @@
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "PX" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/mine/laborcamp/security)
 "Qb" = (
 /obj/structure/stone_tile/cracked{
@@ -9815,6 +9908,18 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/mining)
+"Rb" = (
+/obj/structure/grille/broken,
+/obj/structure/grille/broken,
+/obj/effect/mob_spawn/human/corpse/skeleton,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/turf/simulated/floor/plating{
+	nitrogen = 14;
+	oxygen = 8;
+	temperature = 500
+	},
+/area/lavaland/surface/outdoors)
 "Rd" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -9968,6 +10073,14 @@
 /obj/structure/stone_tile/cracked,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"RY" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating{
+	nitrogen = 14;
+	oxygen = 8;
+	temperature = 500
+	},
+/area/lavaland/surface/outdoors)
 "Sa" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/marker_beacon/dock_marker,
@@ -10217,6 +10330,14 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
+"TV" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating{
+	nitrogen = 14;
+	oxygen = 8;
+	temperature = 500
+	},
+/area/lavaland/surface/outdoors)
 "Uc" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -10326,7 +10447,10 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/simulated/floor/mineral/titanium,
+/obj/effect/turf_decal{
+	dir = 5
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "UA" = (
 /obj/structure/stone_tile/block,
@@ -10472,6 +10596,13 @@
 	},
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"Vr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/iv_drip,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/mine/laborcamp)
 "Vt" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Central";
@@ -10537,7 +10668,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkredyellowfull"
+	},
 /area/mine/laborcamp)
 "VD" = (
 /obj/machinery/door/airlock/glass,
@@ -10553,21 +10686,12 @@
 	},
 /area/mine/outpost/cafeteria)
 "VI" = (
-/obj/effect/baseturf_helper/lava_land,
+/obj/effect/baseturf_helper/asteroid/basalt,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
 "VJ" = (
-/obj/structure/table,
-/obj/item/stack/medical/bruise_pack/advanced,
-/obj/item/storage/firstaid/ancient,
-/obj/machinery/camera{
-	c_tag = "Labor Camp Infirmary";
-	network = list("Labor Camp");
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "barber"
-	},
+/obj/effect/spawner/random_spawners/wall_rusted_always,
+/turf/simulated/wall/r_wall,
 /area/mine/laborcamp)
 "VK" = (
 /obj/structure/flora/ash/stem_shroom,
@@ -10731,7 +10855,14 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/restraints/handcuffs,
-/obj/machinery/light/directional/east,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/flasher_button{
+	id = "gulagshuttleflasher";
+	name = "Flash Control";
+	req_access_txt = "1"
+	},
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "WC" = (
@@ -10818,6 +10949,10 @@
 	icon_state = "tranquillite"
 	},
 /area/mine/outpost/cafeteria)
+"Xb" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -11005,7 +11140,7 @@
 /area/mine/outpost/hallway/east)
 "Yb" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/mine/laborcamp/security)
 "Yc" = (
 /obj/machinery/light/small/directional/east,
@@ -11217,8 +11352,7 @@
 "Zv" = (
 /obj/machinery/economy/vending/sustenance,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
 "Zy" = (
@@ -11312,9 +11446,16 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"ZY" = (
+/obj/item/mounted/frame/intercom,
+/obj/item/stack/cable_coil{
+	amount = 1
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/lavaland/surface/outdoors)
 "ZZ" = (
 /obj/effect/decal/cleanable/fungus,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/mine/laborcamp/security)
 
 (1,1,1) = {"
@@ -13224,9 +13365,9 @@ an
 an
 an
 an
-an
-an
-an
+Xb
+aj
+aj
 an
 an
 an
@@ -13325,17 +13466,17 @@ aj
 aj
 aj
 aj
+ab
+dT
 aj
 aj
 aj
+ab
+Xu
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
+ab
 aj
 aj
 aj
@@ -13481,9 +13622,9 @@ an
 an
 an
 an
-an
-an
-an
+ab
+ab
+ab
 an
 an
 an
@@ -13580,17 +13721,17 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
+ab
+Ll
+ab
+ab
+ab
+dT
+ab
+ab
+ab
+ab
 aj
 aj
 aj
@@ -13738,9 +13879,9 @@ an
 an
 an
 an
-an
-an
-an
+vG
+JJ
+vG
 an
 an
 an
@@ -13836,8 +13977,8 @@ aj
 aj
 aj
 aj
-aj
-aj
+ab
+ab
 kI
 kI
 NW
@@ -13847,7 +13988,7 @@ NW
 kI
 kI
 kI
-aj
+ab
 aj
 aj
 aj
@@ -13995,9 +14136,9 @@ an
 an
 an
 an
-an
-an
-an
+Nl
+HE
+TV
 an
 an
 an
@@ -14093,19 +14234,19 @@ aj
 aj
 aj
 ab
-aj
-aj
+ab
+ab
 NW
 aw
 Bg
 vk
-pq
+pn
 Uy
 CK
 wP
 wt
-aj
-aj
+ab
+ab
 aj
 aj
 aj
@@ -14252,9 +14393,9 @@ an
 an
 an
 an
-an
-an
-an
+Dt
+ZY
+Nl
 an
 an
 an
@@ -14350,8 +14491,8 @@ aj
 aj
 aj
 aj
-aj
 ab
+ai
 NW
 BP
 Bg
@@ -14361,9 +14502,9 @@ VI
 pq
 wP
 wt
-aj
-aj
-aj
+ab
+ai
+ai
 aj
 aj
 aj
@@ -14509,8 +14650,8 @@ an
 an
 an
 an
-an
-an
+RY
+Rb
 an
 an
 an
@@ -14608,7 +14749,7 @@ aD
 aj
 aj
 aj
-aj
+ai
 NW
 Wx
 hf
@@ -14618,9 +14759,9 @@ hj
 pq
 wP
 wt
-aj
-aj
 ab
+ai
+aj
 aj
 aj
 aj
@@ -14865,7 +15006,7 @@ wY
 aj
 aj
 aj
-aj
+ab
 kI
 kI
 FW
@@ -14875,8 +15016,8 @@ kI
 bO
 kI
 kI
-aj
-aj
+ab
+VK
 aj
 aj
 aj
@@ -15127,12 +15268,12 @@ PX
 PX
 Hc
 PX
-aq
-aq
+Hs
+Hs
 TU
-aq
-aj
-aj
+VJ
+ai
+ab
 aj
 aj
 aj
@@ -15387,7 +15528,7 @@ PX
 DT
 zY
 JZ
-aq
+VJ
 aj
 aj
 aj
@@ -15629,12 +15770,12 @@ aj
 aj
 aj
 aD
-qT
+VJ
 ap
 ap
 ap
-qT
-qT
+VJ
+VJ
 Yb
 Ov
 OE
@@ -15644,7 +15785,7 @@ PX
 rd
 Xr
 yw
-aq
+Hs
 oj
 aj
 aj
@@ -15886,7 +16027,7 @@ aj
 aj
 aj
 aD
-aq
+Hs
 vw
 zo
 Kl
@@ -15901,10 +16042,10 @@ PX
 PK
 JZ
 hQ
-aq
+Hs
 Lz
-aj
-aj
+ab
+ab
 aj
 aj
 aj
@@ -16158,11 +16299,11 @@ HN
 JZ
 YI
 aJ
-aq
+Hs
 Ni
-aq
-aq
-aj
+VJ
+VJ
+VJ
 aj
 aj
 aj
@@ -16400,7 +16541,7 @@ an
 aj
 aj
 aj
-tZ
+qJ
 vI
 ic
 ym
@@ -16415,11 +16556,11 @@ PX
 op
 sv
 jn
-aq
+Hs
 bZ
 sO
-ap
-aj
+Vr
+Hs
 aj
 aj
 aj
@@ -16655,9 +16796,9 @@ an
 an
 an
 aj
-qT
-qT
-aq
+VJ
+VJ
+Hs
 qT
 qT
 qT
@@ -16669,14 +16810,14 @@ ZZ
 PX
 ba
 PX
-aq
-aq
+Hs
+Hs
 Cy
-aq
+Hs
 ca
 YV
+cd
 ap
-aj
 aj
 aj
 aj
@@ -16912,7 +17053,7 @@ an
 an
 an
 ab
-qT
+VJ
 NZ
 sF
 KE
@@ -16932,8 +17073,8 @@ tJ
 aq
 cb
 bh
+bh
 ap
-aj
 aj
 aj
 aj
@@ -17169,7 +17310,7 @@ an
 an
 an
 ab
-qT
+VJ
 qT
 GD
 YY
@@ -17189,9 +17330,9 @@ by
 bL
 cc
 ci
+CW
 ap
-aj
-aj
+ab
 aj
 aj
 aj
@@ -17426,7 +17567,7 @@ an
 an
 an
 an
-qT
+VJ
 Dd
 sF
 KE
@@ -17444,11 +17585,11 @@ bn
 Oh
 rS
 qT
-cd
+BC
+bh
+Gm
 VJ
-ap
-aj
-aj
+ab
 aj
 aj
 aj
@@ -17683,8 +17824,8 @@ an
 an
 an
 an
-qT
-qT
+VJ
+VJ
 aq
 aq
 aq
@@ -17700,13 +17841,13 @@ Vv
 bl
 aq
 bA
-qT
-aq
-aq
-aq
-aj
-aj
-aj
+VJ
+Hs
+Hs
+Hs
+VJ
+ab
+ab
 aj
 aj
 aj
@@ -17941,7 +18082,7 @@ an
 an
 an
 an
-aq
+Hs
 au
 au
 au
@@ -17957,12 +18098,12 @@ Vv
 jf
 aq
 bz
-qT
+VJ
 ce
 cz
-aq
-aj
-aj
+Hs
+ai
+ab
 aj
 aj
 aj
@@ -18198,7 +18339,7 @@ an
 an
 an
 an
-qT
+VJ
 lO
 HA
 av
@@ -18217,9 +18358,9 @@ bB
 bM
 cA
 sM
-tZ
-aj
-aj
+qJ
+ai
+ab
 aj
 aj
 aj
@@ -18455,7 +18596,7 @@ an
 an
 an
 an
-qT
+VJ
 tT
 WJ
 qw
@@ -18471,12 +18612,12 @@ Vv
 qT
 aq
 qT
-qT
+VJ
 cg
 sM
-tZ
-aj
-aj
+qJ
+dT
+ab
 aj
 aj
 aj
@@ -18712,7 +18853,7 @@ an
 an
 an
 an
-aq
+Hs
 oA
 Ts
 JQ
@@ -18728,11 +18869,11 @@ Ia
 zt
 rr
 JP
-qT
+VJ
 cB
 cC
-aq
-aj
+VJ
+ab
 aj
 aj
 aj
@@ -18969,12 +19110,12 @@ an
 an
 an
 an
-aq
-qT
-qT
-aq
-qT
-qT
+Hs
+VJ
+VJ
+Hs
+VJ
+VJ
 xx
 DX
 aq
@@ -18985,10 +19126,10 @@ Hi
 aq
 De
 Fp
-qT
-qT
-qT
-qT
+VJ
+VJ
+VJ
+VJ
 aj
 aj
 aj
@@ -19231,18 +19372,18 @@ an
 an
 an
 an
-aq
+Hs
 tC
 JZ
-aq
-qT
-qT
-qT
-tZ
-qT
-qT
-aq
-aq
+Hs
+VJ
+VJ
+VJ
+qJ
+VJ
+VJ
+Hs
+Hs
 aj
 aj
 aj
@@ -19488,10 +19629,10 @@ an
 an
 an
 an
-aq
+Hs
 ap
 gF
-aq
+Hs
 aT
 aX
 aX

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -39189,8 +39189,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
 "wIt" = (
-/obj/machinery/barsign,
-/turf/simulated/wall/indestructible/riveted,
+/obj/machinery/barsign{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
 /area/ghost_bar)
 "wIu" = (
 /obj/structure/rack,
@@ -95449,8 +95451,8 @@ tpP
 rRR
 tpP
 jmo
+fyL
 wIt
-que
 que
 que
 que

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -694,7 +694,7 @@
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "aev" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -791,16 +791,8 @@
 /area/station/maintenance/apmaint)
 "aeF" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "aeG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -813,7 +805,7 @@
 	dir = 5;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "aeI" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -822,7 +814,7 @@
 	dir = 4;
 	icon_state = "redcorner"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "aeJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -909,8 +901,13 @@
 	},
 /area/station/command/office/hos)
 "afa" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "afe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -964,11 +961,16 @@
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
 /obj/machinery/light/directional/east,
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "afs" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plasteel{
@@ -1033,13 +1035,15 @@
 /area/station/engineering/control)
 "afV" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "afX" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
@@ -1067,8 +1071,12 @@
 /area/station/security/main)
 "agk" = (
 /obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "ago" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -1170,10 +1178,20 @@
 /obj/machinery/door/airlock/multi_tile/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "ahf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2380,7 +2398,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
 "alS" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2454,7 +2472,7 @@
 	},
 /area/station/security/armory/secure)
 "ama" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -2463,7 +2481,7 @@
 	},
 /area/station/security/evidence)
 "amb" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -2927,7 +2945,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "ann" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -3412,7 +3430,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
 "apd" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/machinery/alarm/directional/west,
 /obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plasteel{
@@ -4643,13 +4661,13 @@
 /obj/machinery/computer/prisoner{
 	dir = 4;
 	req_access = null;
-	req_one_access_txt = "2"
+	req_access_txt = "2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "atO" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -4690,13 +4708,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "atY" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/sunglasses,
 /obj/machinery/light_switch/west,
+/obj/structure/rack,
+/obj/machinery/syndicatebomb/training,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
 "aua" = (
@@ -4822,20 +4836,15 @@
 /obj/item/clothing/shoes/orange,
 /obj/item/restraints/handcuffs,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "auD" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -4876,7 +4885,7 @@
 	},
 /area/station/security/lobby)
 "auI" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5043,7 +5052,7 @@
 	dir = 4;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "auW" = (
 /obj/machinery/power/apc/directional/east,
 /obj/structure/cable,
@@ -5410,6 +5419,14 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/processing)
+"awk" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prisonershuttle)
 "awl" = (
 /turf/simulated/wall,
 /area/station/maintenance/fore)
@@ -5992,7 +6009,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "ayp" = (
 /obj/structure/chair{
 	dir = 4
@@ -6665,6 +6682,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -6672,7 +6694,7 @@
 	dir = 1;
 	icon_state = "redcorner"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "azW" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 5";
@@ -7132,9 +7154,11 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "aBA" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "aBB" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/kitchen_machine/grill{
@@ -14802,7 +14826,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "bcM" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18009,6 +18033,9 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"bqi" = (
+/turf/simulated/wall/r_wall,
+/area/station/security/prisonershuttle)
 "bqj" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -23349,6 +23376,30 @@
 /obj/structure/sign/chemistry,
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
+"bOV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/paper/nuclear_guide_spacing{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/paper/nuclear_guide_defusing{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/paper/nuclear_guide_operating{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/disk/nuclear/training{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/disk/nuclear/training{
+	pixel_x = -5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/range)
 "bPd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47104,16 +47155,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "ekB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "ekQ" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
@@ -50242,7 +50285,7 @@
 	dir = 4;
 	icon_state = "redcorner"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "fvT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -50964,6 +51007,17 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/science/server/coldroom)
+"fId" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "fIB" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -56162,11 +56216,6 @@
 /area/station/medical/psych)
 "hyO" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -56174,6 +56223,14 @@
 	dir = 1
 	},
 /obj/item/paper/firingrange,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 4
+	},
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
 "hyQ" = (
@@ -57425,18 +57482,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/smes)
 "hUX" = (
-/obj/structure/toilet{
-	pixel_y = 8
-	},
+/obj/machinery/recharge_station,
 /obj/machinery/light/small/directional/west,
 /obj/item/radio/intercom/locked/prison{
 	name = "Prison Intercom (General)";
 	pixel_y = 24
-	},
-/mob/living/simple_animal/frog/scream{
-	real_name = "лягушка-нонконформист";
-	name = "лягушка-нонконформист";
-	desc = "Кто-нибудь, заткните её пожалуйста!"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -60400,11 +60450,9 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "jeS" = (
 /obj/item/radio/intercom/department/security{
 	pixel_y = 22
@@ -63393,6 +63441,23 @@
 	icon_state = "purplecorner"
 	},
 /area/station/science/robotics)
+"knX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/multitool{
+	pixel_y = -5;
+	pixel_x = 5
+	},
+/obj/item/clothing/head/welding{
+	pixel_y = -2;
+	pixel_x = -6
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/plasteel,
+/area/station/security/range)
 "knY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -64502,6 +64567,12 @@
 	icon_state = "dark"
 	},
 /area/station/security/detective)
+"kIR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "kIT" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -64921,7 +64992,7 @@
 	dir = 10;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "kQn" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
@@ -68286,6 +68357,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"mao" = (
+/obj/machinery/alarm/directional/south,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/prisonershuttle)
 "maF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69621,19 +69699,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint2)
 "myQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "mze" = (
 /obj/structure/table/reinforced,
 /obj/item/food/snacks/breadslice,
@@ -72003,7 +72075,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "nsu" = (
 /obj/structure/closet/wardrobe/pjs,
 /obj/effect/decal/cleanable/dirt,
@@ -72179,15 +72251,24 @@
 	},
 /area/station/science/hallway)
 "nvy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "nvN" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/ai_transit_tube)
@@ -72253,11 +72334,8 @@
 /area/station/maintenance/asmaint)
 "nwO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "nwR" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -73975,9 +74053,8 @@
 	},
 /area/station/public/sleep)
 "ofw" = (
-/obj/machinery/barsign,
 /turf/simulated/wall,
-/area/station/service/bar/atrium)
+/area/station/security/prisonershuttle)
 "ofy" = (
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
@@ -76369,8 +76446,8 @@
 /area/station/command/bridge)
 "oVr" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/syndicatebomb/training,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/nuclearbomb/training,
 /turf/simulated/floor/plasteel,
 /area/station/security/range)
 "oVs" = (
@@ -81770,11 +81847,9 @@
 /turf/simulated/floor/plating,
 /area/station/command/teleporter)
 "qOj" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "qOs" = (
 /obj/machinery/airlock_controller/access_controller{
 	ext_button_link_id = "xeno_btn_ext";
@@ -82377,6 +82452,12 @@
 	icon_state = "blue"
 	},
 /area/station/maintenance/aft)
+"ras" = (
+/obj/machinery/barsign{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/west)
 "raG" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -83594,7 +83675,7 @@
 	dir = 8;
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "rDI" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -84001,6 +84082,11 @@
 /obj/structure/sink/directional/west,
 /obj/structure/mirror{
 	pixel_x = 28
+	},
+/mob/living/simple_animal/frog/scream{
+	real_name = "лягушка-нонконформист";
+	name = "лягушка-нонконформист";
+	desc = "Кто-нибудь, заткните её пожалуйста!"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -94152,7 +94238,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
-/area/station/security/brig)
+/area/station/security/prisonershuttle)
 "vts" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
@@ -124837,8 +124923,8 @@ aaa
 aaa
 aaa
 aaa
-aqI
-aqI
+bqi
+bqi
 abN
 abN
 abN
@@ -125094,12 +125180,12 @@ aaa
 aaa
 aaa
 aaa
-aqI
+bqi
 ayo
 atN
 rCT
 kQb
-auc
+ofw
 qNk
 wLF
 pzZ
@@ -125352,11 +125438,11 @@ aaa
 aaa
 hoB
 nsq
-aBA
+nwO
 jeQ
-afa
+aBA
 vtj
-auc
+ofw
 hiO
 uGA
 dFG
@@ -125611,9 +125697,9 @@ aaa
 bcL
 fvy
 nwO
-afa
+kIR
 ank
-auc
+ofw
 akm
 lJf
 anu
@@ -125865,12 +125951,12 @@ aaa
 aaa
 aaa
 aaa
-aqI
+bqi
 auy
 aeF
-afa
-auc
-auc
+mao
+ofw
+ofw
 gWZ
 qkA
 uFa
@@ -126125,8 +126211,8 @@ aaa
 bcL
 azV
 ekB
-afa
-agk
+kIR
+awk
 aoh
 tXE
 hgU
@@ -126636,10 +126722,10 @@ aaa
 aaa
 aaa
 aaa
-aqI
+bqi
 aeI
 qOj
-afa
+fId
 afV
 wyJ
 iwJ
@@ -126893,7 +126979,7 @@ aaa
 aaa
 aaa
 aaa
-aqI
+bqi
 aeH
 auV
 afo
@@ -133568,7 +133654,7 @@ aqd
 act
 aqd
 hyO
-aqd
+bOV
 adi
 akW
 acP
@@ -134082,7 +134168,7 @@ alB
 acu
 aqd
 hyO
-alB
+knX
 yhS
 akW
 gkC
@@ -136713,8 +136799,8 @@ buC
 tly
 tMP
 dJg
-ofw
-bAk
+aVu
+ras
 bzq
 bAk
 ogI

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -34881,21 +34881,11 @@
 /area/station/medical/medbay)
 "cKZ" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/paper/firingrange,
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32
 	},
 /obj/item/storage/box/flashbangs{
-	pixel_x = 5;
-	pixel_y = 5
+	pixel_y = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
@@ -49271,6 +49261,14 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/paper/firingrange{
+	pixel_y = 4
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 4
+	},
+/obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -51428,6 +51426,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/effect/landmark/start/prisoner,
+/obj/item/food/snacks/grown/pineapple{
+	name = "Старый ананас";
+	desc = "Довольно старый ананас. Интересно как он тут оказался и почему он так странно пахнет..."
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
 	},
@@ -52047,7 +52049,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/storage)
 "fkB" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkred"
@@ -54052,7 +54054,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
 "fRf" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -54160,22 +54162,7 @@
 	},
 /area/station/medical/medbay2)
 "fSZ" = (
-/obj/structure/rack,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target/alien{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/target/alien{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/item/target/alien{
-	pixel_x = 7;
-	pixel_y = 2
-	},
+/obj/machinery/nuclearbomb/training,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
 "fTi" = (
@@ -58524,10 +58511,17 @@
 /area/station/maintenance/starboardsolar)
 "hpo" = (
 /obj/structure/table/reinforced,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/item/clothing/head/welding{
+	pixel_x = 9;
+	pixel_y = 10
+	},
+/obj/item/multitool{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -2;
+	pixel_x = -3
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
@@ -59533,7 +59527,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "hEX" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -61472,7 +61466,7 @@
 	},
 /area/station/service/bar/atrium)
 "iiH" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/item/id_skin/donut,
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/plasteel{
@@ -66653,7 +66647,7 @@
 /turf/simulated/wall,
 /area/station/medical/patients_rooms)
 "jNz" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkred"
@@ -77675,14 +77669,8 @@
 	},
 /area/station/security/brig)
 "noL" = (
-/obj/structure/toilet{
-	dir = 4
-	},
+/obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/food/snacks/grown/pineapple{
-	name = "Старый ананас";
-	desc = "Довольно старый ананас. Интересно как он тут оказался и почему он так странно пахнет..."
-	},
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "hydrofloor"
@@ -80330,6 +80318,30 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/engineering/mechanic)
+"oai" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/nuclear_guide_spacing{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/paper/nuclear_guide_defusing{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/paper/nuclear_guide_operating{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/item/disk/nuclear/training{
+	pixel_x = -5
+	},
+/obj/item/disk/nuclear/training{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/range)
 "oan" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line,
@@ -90837,7 +90849,7 @@
 	},
 /area/station/security/brig)
 "rpF" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -91267,6 +91279,14 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/paper/firingrange{
+	pixel_y = 4
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 4
+	},
+/obj/item/clothing/ears/earmuffs,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkred"
@@ -97725,23 +97745,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "tuQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/structure/table/reinforced,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -5;
-	pixel_y = 6
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_y = 6
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
 	},
-/obj/item/paper/firingrange,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 32
-	},
-/obj/item/storage/box/flashbangs{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
 "tuT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -100186,7 +100202,7 @@
 	},
 /area/station/maintenance/old_kitchen)
 "ulQ" = (
-/obj/structure/closet,
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -109673,6 +109689,22 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target/alien{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/target/alien{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/target/alien{
+	pixel_x = 7;
+	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -164105,9 +164137,9 @@ off
 iVy
 eqH
 imZ
-imZ
+tuQ
 xnE
-imZ
+tuQ
 imZ
 rvJ
 muX
@@ -164876,10 +164908,10 @@ off
 iVy
 cvz
 cKZ
-hpo
+oai
 fSZ
 hpo
-tuQ
+cKZ
 wuX
 muX
 bed

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -339,6 +339,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -1519,9 +1520,7 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/brig)
 "amI" = (
-/obj/structure/closet{
-	name = "Evidence Closet 3"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/structure/cable/yellow{
 	d2 = 4;
 	icon_state = "0-4"
@@ -2405,9 +2404,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aqQ" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4926,6 +4923,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -5527,6 +5525,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -6285,9 +6284,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "aHe" = (
-/obj/machinery/barsign,
-/turf/simulated/wall,
-/area/station/service/bar)
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/barsign{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/starboard)
 "aHg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8723,8 +8728,8 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -36743,9 +36748,7 @@
 	},
 /area/station/engineering/gravitygenerator)
 "cAJ" = (
-/obj/structure/closet{
-	name = "Evidence Closet 2"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -46729,6 +46732,33 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"erL" = (
+/obj/item/disk/nuclear/training{
+	pixel_y = -2;
+	pixel_x = -7
+	},
+/obj/item/paper/nuclear_guide_spacing{
+	pixel_x = 10;
+	pixel_y = 7
+	},
+/obj/item/paper/nuclear_guide_defusing{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/disk/nuclear/training{
+	pixel_x = -5
+	},
+/obj/item/paper/nuclear_guide_operating{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Defusal Workshop"
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/security/defusal)
 "erM" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Mass Driver";
@@ -47013,13 +47043,25 @@
 /turf/simulated/floor/grass/no_creep,
 /area/station/medical/virology)
 "exm" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/door/airlock/security/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/security/main)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "redfull"
+	},
+/area/station/security/defusal)
 "exI" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler,
@@ -49786,6 +49828,17 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/medbay)
+"fLm" = (
+/obj/machinery/syndicatebomb/training,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/security/defusal)
 "fLw" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/portable/canister/nitrogen,
@@ -58141,6 +58194,22 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"jIN" = (
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/book/manual/wiki/hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/security/defusal)
 "jIR" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -62555,6 +62624,20 @@
 	icon_state = "cautioncorner"
 	},
 /area/station/hallway/primary/starboard)
+"lDG" = (
+/obj/structure/table,
+/obj/item/clothing/head/welding{
+	pixel_x = -4;
+	pixel_y = 19
+	},
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/alarm/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/security/defusal)
 "lEb" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/plasteel{
@@ -71926,6 +72009,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "red"
@@ -71943,8 +72032,8 @@
 	},
 /area/station/security/main)
 "qaA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -71958,6 +72047,9 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -73293,9 +73385,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "qIB" = (
-/obj/structure/toilet{
-	dir = 8
-	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -77741,9 +77831,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
 "sNG" = (
-/obj/structure/closet{
-	name = "Evidence Closet 4"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -78945,6 +79033,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"tnT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/security/defusal)
 "toD" = (
 /obj/structure/sign/poster/official/random/west,
 /obj/effect/turf_decal/stripes/line{
@@ -79783,9 +79888,8 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "tNe" = (
-/obj/effect/spawner/random_spawners/wall_rusted_probably,
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/fore)
+/area/station/security/defusal)
 "tNh" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -83677,9 +83781,7 @@
 	},
 /area/station/science/rnd)
 "vJo" = (
-/obj/structure/closet{
-	name = "Evidence Closet 5"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -88509,9 +88611,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "yev" = (
-/obj/structure/closet{
-	name = "Evidence Closet 6"
-	},
+/obj/structure/closet/secure_closet/evidence,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -88566,6 +88666,15 @@
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
+"yfj" = (
+/obj/machinery/nuclearbomb/training,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/radio/intercom/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/security/defusal)
 "yfv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -120008,11 +120117,11 @@ aaa
 laH
 abq
 apO
-apO
-apO
+tNe
+tNe
 exm
-apO
-apO
+tNe
+tNe
 xyP
 apO
 apO
@@ -120265,10 +120374,10 @@ aaa
 aaa
 aaa
 laH
-aaa
-aaa
-aaa
-aaa
+tNe
+yfj
+tnT
+fLm
 tNe
 oQV
 ajg
@@ -120522,11 +120631,11 @@ aaa
 aaa
 aaa
 laH
-aaa
-aaa
-aaa
-aaa
-ahH
+tNe
+erL
+jIN
+lDG
+tNe
 alW
 akR
 aDY
@@ -120779,11 +120888,11 @@ aaa
 aaa
 aaa
 laH
-aaa
-aaa
-aaa
-aaa
-ahH
+tNe
+tNe
+tNe
+tNe
+tNe
 aDY
 wLB
 cnV
@@ -121863,8 +121972,8 @@ bjp
 bez
 bnr
 boY
-bqA
 aHe
+bsp
 ded
 bEv
 bEv


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Актуализация с картами оффов
https://github.com/ParadiseSS13/Paradise/pull/24037
https://github.com/ParadiseSS13/Paradise/pull/23981
https://github.com/ParadiseSS13/Paradise/pull/24605
https://github.com/ParadiseSS13/Paradise/pull/25352
https://github.com/ParadiseSS13/Paradise/pull/24548

## Changelog

:cl:
tweak: Небольшие изменения шаттла Гулага, а также зоны посадки на Лаваленде.
tweak: Лаваленд: Наружные стены Гулага теперь укрепленные, а также небольшие изменения визуальной составляющей.
tweak: Лаваленд: На вершине скалы Гулага разбилась старая спасательная капсула. В ней находится ящик с инструментами, что делает возможным побег из "Чазмаленда" (Дырявый Лаваленд xdd).
tweak: Кибериада: изменена область вокруг шаттла Гулага, чтобы он перестал открываться во время события "Greytide".
tweak: Все карты: Шкафчики для улик в Бриге теперь заперты за общим доступом Брига.
add: Все карты: В Пермабриг добавлены зарядники киборгов, благодаря чему КПБ смогут заряжать себя сами.
add: Все карты: Добавлена учебная ядерная бомба и инструменты для её деактивации в стрельбище Брига.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
