### PR TITLE
Add: Missed disaster counters

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -12189,6 +12189,7 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser,
+/obj/machinery/status_display/directional/north,
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "aTT" = (
@@ -21421,7 +21422,7 @@
 /obj/item/eftpos{
 	pixel_x = 9
 	},
-/obj/structure/sign/poster/official/science{
+/obj/structure/disaster_counter/chemistry{
 	pixel_x = -32
 	},
 /turf/simulated/floor/plasteel{
@@ -23415,7 +23416,6 @@
 	dir = 9
 	},
 /obj/machinery/chem_heater,
-/obj/machinery/status_display/directional/west,
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "bPf" = (
@@ -24473,6 +24473,9 @@
 	pixel_x = 5
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/sign/poster/official/science{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteyellow"
@@ -97703,6 +97706,7 @@
 	dir = 8
 	},
 /obj/machinery/chem_dispenser,
+/obj/machinery/status_display/directional/west,
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "wGj" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -7154,10 +7154,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
-"aFg" = (
-/obj/structure/sign/fire,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/engine/supermatter)
 "aFi" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/cable/yellow{
@@ -34834,6 +34830,9 @@
 /obj/machinery/chem_dispenser,
 /obj/structure/reagent_dispensers/fueltank/chem/east,
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/structure/disaster_counter/chemistry{
+	pixel_y = 32
+	},
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "cKY" = (
@@ -77449,6 +77448,9 @@
 "nmA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
+/obj/structure/disaster_counter/scichem{
+	pixel_y = 32
+	},
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
 "nmK" = (
@@ -97225,6 +97227,9 @@
 "tnN" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/disaster_counter/toxins{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "tnO" = (
@@ -107348,6 +107353,9 @@
 	},
 /obj/machinery/atmospherics/meter{
 	autolink_id = "sm_sen_hot"
+	},
+/obj/structure/disaster_counter/supermatter{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
@@ -136054,7 +136062,7 @@ aik
 sqD
 ksd
 ayM
-aFg
+ayM
 wBz
 aHh
 aIF


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавлены недостающие disaster counter'ы на карты... Даже оффы забыли добавить некоторые на свои же карты, лол........

## Changelog

:cl:
add: На карты добавлены недостающие disaster counter'ы (монитор кол-ва смен прошедших без происшествий в определенных отделах)
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
