### PR TITLE
Add: RnD lobby areas

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -11725,7 +11725,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "aRP" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/wood/fancy,
@@ -21607,11 +21607,12 @@
 	},
 /obj/structure/table,
 /obj/item/ashtray/glass,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bGE" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -21657,18 +21658,20 @@
 /area/station/maintenance/asmaint)
 "bGK" = (
 /obj/machinery/economy/vending/coffee,
+/obj/machinery/ai_status_display/north,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bGL" = (
 /obj/structure/chair,
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bGM" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/beach/sand,
@@ -21958,8 +21961,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bIp" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -21986,7 +21994,7 @@
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bIA" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/plasteel{
@@ -22403,7 +22411,7 @@
 	dir = 10;
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bKj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -22412,7 +22420,7 @@
 	dir = 6;
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bKk" = (
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
@@ -22436,7 +22444,7 @@
 	dir = 10;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bKp" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plasteel{
@@ -22795,11 +22803,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bMx" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall,
@@ -23060,10 +23069,15 @@
 /area/station/maintenance/asmaint2)
 "bNC" = (
 /obj/machinery/light/directional/south,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bND" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23498,7 +23512,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bPs" = (
 /obj/structure/table,
 /obj/item/assembly/prox_sensor{
@@ -23557,7 +23571,7 @@
 	dir = 8;
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "bPF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -48209,7 +48223,7 @@
 	dir = 5;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "eES" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -52110,12 +52124,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "geb" = (
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/power/apc/directional/south,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "gei" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -54960,8 +54978,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
-/area/station/science/hallway)
+/area/station/science/lobby)
 "gZW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59015,6 +59038,9 @@
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"iBm" = (
+/turf/simulated/wall,
+/area/station/science/lobby)
 "iBD" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/start/assistant,
@@ -62998,13 +63024,18 @@
 /area/station/maintenance/asmaint)
 "kdx" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/junction/reversed,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "kdD" = (
@@ -66356,6 +66387,16 @@
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
 /area/station/maintenance/asmaint2)
+"lqj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "lql" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -67091,8 +67132,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
-/area/station/science/hallway)
+/area/station/science/lobby)
 "lEA" = (
 /obj/machinery/shower{
 	dir = 4
@@ -67922,7 +67968,7 @@
 "lRy" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/station/science/hallway)
+/area/station/science/lobby)
 "lRS" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on{
 	autolink_id = "o2_out";
@@ -70671,6 +70717,12 @@
 	icon_state = "floorgrime"
 	},
 /area/station/engineering/utility)
+"mQk" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/station/science/lobby)
 "mQz" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plasteel{
@@ -71540,6 +71592,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "nhO" = (
@@ -74711,7 +74768,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "onQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -74789,10 +74846,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "opY" = (
 /obj/machinery/door/airlock/command/qm/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -80168,6 +80230,19 @@
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"qlb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/lobby)
 "qlo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -95253,7 +95328,7 @@
 	dir = 4;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "vGq" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard{
@@ -95652,7 +95727,7 @@
 	dir = 6;
 	icon_state = "whitepurple"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "vOy" = (
 /obj/effect/spawner/random_spawners/blood_maybe,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -96711,6 +96786,9 @@
 /obj/machinery/light/directional/west,
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
+"wkz" = (
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "wkB" = (
 /obj/machinery/door/airlock/maintenance{
 	electrified_until = -1;
@@ -99599,7 +99677,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/station/science/hallway)
+/area/station/science/lobby)
 "xmN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -100513,6 +100591,12 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/hallway)
+"xFY" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "xGy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -149382,10 +149466,10 @@ aYP
 rND
 gZW
 cfy
-rKV
+iBm
 bGK
-bNp
-bNp
+mQk
+mQk
 bKo
 bIa
 bPz
@@ -149639,7 +149723,7 @@ aYQ
 bwv
 uKG
 cfy
-rKV
+iBm
 bGL
 bPD
 bKi
@@ -149897,10 +149981,10 @@ dxX
 uKG
 bwv
 lRy
-nOo
-nOo
+wkz
+wkz
 onM
-cbq
+xFY
 bMt
 rKV
 bRq
@@ -150157,7 +150241,7 @@ lEo
 gZS
 bIo
 opj
-jCt
+qlb
 xmA
 bUk
 xia
@@ -150411,10 +150495,10 @@ uMZ
 aAR
 bwv
 lRy
-nOo
-nOo
+wkz
+wkz
 aRO
-spl
+lqj
 vOq
 sSQ
 fxD
@@ -150667,7 +150751,7 @@ aYQ
 bwv
 aAR
 cXh
-rKV
+iBm
 bGD
 bIy
 bKj
@@ -150924,7 +151008,7 @@ aYP
 bFB
 aAR
 cXh
-rKV
+iBm
 eER
 vGj
 vGj

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -28919,7 +28919,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "ckL" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -34288,18 +34288,24 @@
 "cIW" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
-/area/station/science/research)
+/area/station/science/lobby)
 "cIZ" = (
 /obj/machinery/status_display{
 	name = "Дисплей статуса"
 	},
 /turf/simulated/wall,
-/area/station/science/research)
+/area/station/science/lobby)
 "cJa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
-/area/station/science/research)
+/area/station/science/lobby)
 "cJb" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -34313,7 +34319,7 @@
 	pixel_y = -8
 	},
 /turf/simulated/wall,
-/area/station/science/research)
+/area/station/science/lobby)
 "cJc" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8;
@@ -34666,16 +34672,21 @@
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKx" = (
 /obj/structure/chair/office/light{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKA" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/effect/landmark/start/assistant,
@@ -34683,7 +34694,7 @@
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKB" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair/sofa/corp,
@@ -34691,24 +34702,18 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKC" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "cKF" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -34722,7 +34727,7 @@
 	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKH" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -34737,7 +34742,7 @@
 	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cKI" = (
 /obj/structure/sign/science,
 /turf/simulated/wall,
@@ -34798,11 +34803,13 @@
 	},
 /area/station/medical/chemistry)
 "cKT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "cKV" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -35068,11 +35075,12 @@
 	pixel_x = -4
 	},
 /obj/item/stock_parts/cell/high,
+/obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cMm" = (
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
@@ -35082,7 +35090,7 @@
 	dir = 4;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cMp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -35390,7 +35398,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cNG" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/brflowers,
@@ -35398,21 +35406,21 @@
 	dir = 9
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "cNH" = (
 /obj/effect/landmark/lightsout,
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "cNJ" = (
 /obj/structure/table/glass,
 /obj/item/paicard,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cNL" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
@@ -35764,38 +35772,38 @@
 /obj/item/flash{
 	pixel_x = -5
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cPr" = (
 /obj/structure/flora/bush,
 /obj/structure/railing{
 	dir = 10
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "cPt" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cPu" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplefull"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cPw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/station/science/research)
+/area/station/science/lobby)
 "cPy" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark/lightsout,
@@ -36523,12 +36531,12 @@
 /obj/item/stack/sheet/glass,
 /obj/item/assembly/signaler,
 /obj/item/assembly/infra,
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cSn" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36554,7 +36562,7 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cSq" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/camera{
@@ -36579,7 +36587,7 @@
 	},
 /obj/structure/railing/cap/reversed,
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "cSv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -36591,7 +36599,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cSx" = (
 /obj/structure/chair/comfy/teal{
 	dir = 1
@@ -37151,6 +37159,9 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "cVb" = (
@@ -37693,7 +37704,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cWM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/directional/west,
@@ -37989,6 +38000,9 @@
 "cYj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "cYl" = (
@@ -38803,11 +38817,12 @@
 "dcO" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "dcQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -39382,6 +39397,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "dfS" = (
@@ -40023,6 +40039,9 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "djg" = (
@@ -40110,6 +40129,10 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "djQ" = (
@@ -45020,11 +45043,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "dLB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "dLJ" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/plasteel{
@@ -49415,6 +49435,19 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
+"esV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/station/science/lobby)
 "etw" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
@@ -49604,12 +49637,11 @@
 	},
 /area/station/maintenance/fore)
 "ewj" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "ewF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -53522,6 +53554,12 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"fKQ" = (
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "fKW" = (
 /obj/structure/curtain/open/shower/security{
 	icon_state = "closed"
@@ -59326,7 +59364,7 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "hCM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research,
@@ -59845,7 +59883,7 @@
 /area/station/security/permabrig)
 "hJG" = (
 /turf/simulated/floor/plasteel/stairs,
-/area/station/science/research)
+/area/station/science/lobby)
 "hJM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -62174,6 +62212,12 @@
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/carpet/cyan,
 /area/station/command/office/cmo)
+"itw" = (
+/obj/item/kirbyplants,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "itA" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -63451,6 +63495,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory_maintenance)
+"iPk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "iPy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64736,6 +64787,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"jjb" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "jjf" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner{
@@ -65529,6 +65590,10 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/virology/lab)
+"juQ" = (
+/obj/structure/sign/science,
+/turf/simulated/wall,
+/area/station/science/lobby)
 "juU" = (
 /obj/structure/morgue,
 /obj/effect/decal/cleanable/dirt,
@@ -67158,6 +67223,13 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/old_kitchen)
+"jVs" = (
+/obj/item/kirbyplants,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "jWd" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -68003,7 +68075,7 @@
 	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "kiP" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
@@ -68712,13 +68784,11 @@
 /area/station/supply/miningdock)
 "kvQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "kvR" = (
 /obj/structure/sink/kitchen/north,
 /obj/effect/decal/cleanable/ants,
@@ -70389,9 +70459,10 @@
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
 "kWO" = (
-/obj/structure/disposalpipe/junction/reversed,
-/turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "kXm" = (
 /obj/structure/kitchenspike,
 /obj/machinery/status_display/directional/east,
@@ -74920,11 +74991,8 @@
 /area/station/hallway/secondary/exit)
 "muI" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "muJ" = (
 /obj/effect/spawner/random_spawners/oil_maybe,
 /obj/effect/decal/cleanable/dirt,
@@ -75342,11 +75410,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -76809,7 +76877,7 @@
 	},
 /obj/structure/railing/cap/normal,
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "nct" = (
 /obj/machinery/constructable_frame/machine_frame,
 /obj/structure/sign/poster/official/random/east,
@@ -78544,6 +78612,30 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/toxins/mixing)
+"nBW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central)
 "nBZ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -78667,12 +78759,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/research)
 "nDZ" = (
@@ -79088,6 +79176,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/controlroom)
+"nJd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central)
 "nJn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -80707,10 +80811,10 @@
 /area/station/medical/sleeper)
 "ogM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "ogX" = (
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab Office";
@@ -82821,8 +82925,6 @@
 /area/station/legal/lawoffice)
 "oSI" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"
@@ -82948,6 +83050,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/science/research,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/science/research)
 "oVs" = (
@@ -84932,6 +85036,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"pyi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplefull"
+	},
+/area/station/science/lobby)
 "pys" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -85397,7 +85511,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "pGn" = (
 /obj/structure/falsewall,
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
@@ -85857,7 +85971,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "pMU" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -86007,7 +86121,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "pPL" = (
 /obj/structure/closet/lasertag/red,
 /turf/simulated/floor/plasteel/dark,
@@ -88459,6 +88573,18 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/apmaint)
+"qFk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "qFp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/mouse/rat,
@@ -90104,6 +90230,11 @@
 	icon_state = "dark"
 	},
 /area/station/supply/expedition)
+"rcm" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel,
+/area/station/science/lobby)
 "rcs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93678,11 +93809,14 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "skh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -94058,6 +94192,18 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
+"sqf" = (
+/obj/item/kirbyplants,
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "sqk" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -95846,10 +95992,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
-/area/station/science/research)
+/area/station/science/lobby)
 "sQr" = (
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
@@ -98050,6 +98194,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"tBN" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/science/lobby)
 "tCb" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -100116,6 +100268,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
+"uku" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "ukJ" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/alarm/directional/west,
@@ -101094,6 +101252,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/break_room)
+"uCM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "uCO" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 1
@@ -104757,7 +104927,7 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "vJt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -104866,7 +105036,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "vKK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -105612,10 +105782,10 @@
 /area/station/engineering/hardsuitstorage)
 "vWv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/white,
-/area/station/science/research)
+/area/station/science/lobby)
 "vWA" = (
 /obj/structure/toilet,
 /obj/item/bikehorn/rubberducky,
@@ -106533,6 +106703,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
+"wmv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/lobby)
 "wmx" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/disposal{
@@ -107721,6 +107898,13 @@
 /obj/effect/turf_decal/delivery/red/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"wHZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/aft)
 "wIb" = (
 /obj/structure/fluff/beach_umbrella/engine,
 /turf/simulated/floor/transparent/glass/reinforced,
@@ -108724,6 +108908,8 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -109559,7 +109745,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "xmk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -110555,7 +110741,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/grass,
-/area/station/science/research)
+/area/station/science/lobby)
 "xBO" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	autolink_id = "waste_out";
@@ -145902,8 +146088,8 @@ cIW
 cKw
 cMd
 dcO
-cPn
-cRd
+jjb
+sqf
 cSm
 cZt
 cTU
@@ -146157,11 +146343,11 @@ gfZ
 bIG
 cIW
 cKx
-cMm
-cPu
-cPu
-cMm
-cPn
+tBN
+pyi
+esV
+cKT
+uku
 cTC
 cUY
 cVs
@@ -146410,14 +146596,14 @@ cCE
 cEb
 csK
 cGY
-gfZ
-bIG
+nBW
+qFk
 cJa
-dau
+uCM
 ogM
 xme
 sjV
-cMm
+dLB
 kiB
 cKI
 cUZ
@@ -146674,7 +146860,7 @@ kvQ
 cKD
 cNF
 cPq
-kWO
+cKD
 hCA
 hCM
 dje
@@ -146927,12 +147113,12 @@ sxm
 rJD
 bIG
 cIW
-cND
-cKT
+jVs
+dLB
 cNG
 cPr
 dLB
-cPn
+uku
 cZx
 cVd
 cZG
@@ -147185,7 +147371,7 @@ lmt
 bIG
 cIW
 cKA
-cKT
+dLB
 cSu
 pGk
 dLB
@@ -147699,11 +147885,11 @@ ngp
 bIG
 cIW
 cKC
-cKT
+dLB
 ncs
 xBJ
 dLB
-cSt
+kWO
 cTT
 cVt
 daJ
@@ -147956,11 +148142,11 @@ lmt
 bIG
 cIW
 cMn
-cKT
+dLB
 vKB
 pPG
-ewj
-cSt
+dLB
+kWO
 cTR
 cVu
 cWY
@@ -148211,13 +148397,13 @@ csK
 cEU
 lmt
 bIG
-cJa
-cKF
-cKT
+rcm
+fKQ
+dLB
 cNJ
 cPt
 ckI
-cSt
+kWO
 cTT
 cVv
 sHY
@@ -148466,15 +148652,15 @@ cBn
 cCL
 vBU
 cEL
-lmt
-bIG
-cJa
-cKF
+nJd
+iPk
+ewj
+wmv
 vWv
 pML
 vJs
-cMm
-cSt
+dLB
+kWO
 cTF
 cVw
 cWQ
@@ -148727,11 +148913,11 @@ lmt
 bIG
 cIW
 cKG
-cMm
+dLB
 cPu
 cPu
-cMm
-cSt
+dLB
+kWO
 cTT
 cVx
 cWR
@@ -148985,9 +149171,9 @@ bIG
 cIW
 cKH
 cMn
-cKF
-cSt
-cRg
+fKQ
+kWO
+itw
 cSv
 cTR
 xKX
@@ -149240,12 +149426,12 @@ cEL
 lmt
 cHH
 cJb
-cKI
+juQ
 cIW
 cPw
 cPw
 cIW
-cKI
+juQ
 cTR
 cVz
 cTR
@@ -149756,7 +149942,7 @@ iQj
 dEl
 sAv
 sAv
-sAv
+wHZ
 cPy
 sAv
 sAv

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -4059,7 +4059,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "axz" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4
@@ -22572,7 +22572,7 @@
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "bCH" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/bar,
@@ -27566,7 +27566,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "bUS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28470,7 +28470,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "bXG" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/storage)
@@ -30847,13 +30847,13 @@
 "cft" = (
 /obj/structure/sign/science,
 /turf/simulated/wall,
-/area/station/science/research)
+/area/station/science/lobby)
 "cfu" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cfv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -30866,7 +30866,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cfw" = (
 /turf/simulated/wall,
 /area/station/science/research)
@@ -31125,7 +31125,7 @@
 	dir = 5;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cgv" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -31165,14 +31165,14 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cgA" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cgB" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -31180,14 +31180,14 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cgE" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cgF" = (
 /obj/structure/table/glass,
 /obj/machinery/camera{
@@ -31201,7 +31201,7 @@
 	dir = 1;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cgG" = (
 /obj/machinery/door/poddoor/shutters{
 	id_tag = "toxinaccess"
@@ -31705,7 +31705,7 @@
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cic" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
@@ -31718,7 +31718,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cig" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -32148,7 +32148,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cjN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -32162,7 +32162,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cjO" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -32472,7 +32472,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cla" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/corner{
@@ -32485,12 +32485,17 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "clb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "clc" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -32498,11 +32503,16 @@
 	pixel_y = 6
 	},
 /obj/item/paicard,
+/obj/machinery/power/apc/directional/south,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cle" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -38717,7 +38727,7 @@
 "cHM" = (
 /obj/effect/spawner/window/grilled,
 /turf/simulated/floor/plating,
-/area/station/science/research)
+/area/station/science/lobby)
 "cHO" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/saltshaker{
@@ -41885,7 +41895,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "cUF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/burnturf,
@@ -45397,6 +45407,11 @@
 /obj/machinery/atmospherics/binary/valve/open,
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
+"dNp" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/lobby)
 "dNU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50092,7 +50107,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "fUf" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -50892,7 +50907,7 @@
 /turf/simulated/floor/plasteel{
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "gnQ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -52365,6 +52380,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"gXB" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/lobby)
 "gXJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -54002,6 +54025,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"hGg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/lobby)
 "hGL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -56164,7 +56195,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "iGf" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/power/apc/directional/south,
@@ -58753,6 +58784,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/hydroponics)
+"jUk" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "whitepurple"
+	},
+/area/station/science/lobby)
 "jUK" = (
 /obj/machinery/light_switch/east,
 /obj/structure/cable/yellow{
@@ -66574,6 +66611,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"npq" = (
+/turf/simulated/wall,
+/area/station/science/lobby)
 "npx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -69043,13 +69083,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "oFF" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -72623,7 +72668,7 @@
 	dir = 4;
 	icon_state = "whitepurple"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "qnu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75452,7 +75497,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "rFq" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -77764,6 +77809,18 @@
 	icon_state = "cautioncorner"
 	},
 /area/station/engineering/atmos)
+"sNd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/station/science/lobby)
 "sNm" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave,
@@ -84468,7 +84525,7 @@
 	dir = 1;
 	icon_state = "whitehall"
 	},
-/area/station/science/research)
+/area/station/science/lobby)
 "wez" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -116869,7 +116926,7 @@ cas
 caY
 cAy
 ced
-cfw
+npq
 cft
 cib
 bCG
@@ -117126,10 +117183,10 @@ cpP
 mwW
 cnB
 bab
-cfw
+npq
 cgz
-cic
-bGl
+dNp
+hGg
 bXF
 cIu
 coH
@@ -117898,7 +117955,7 @@ nWH
 bcX
 cee
 cfu
-cic
+dNp
 iFm
 cie
 ckZ
@@ -118155,7 +118212,7 @@ cbG
 mOc
 ceh
 cfv
-fPC
+sNd
 bUR
 cie
 cla
@@ -118412,7 +118469,7 @@ bek
 bcX
 cee
 cHM
-cxO
+jUk
 wey
 cjM
 cUE
@@ -118927,8 +118984,8 @@ bdb
 cei
 cHM
 cgE
-cic
-bUy
+dNp
+gXB
 clb
 uxR
 cic
@@ -119182,7 +119239,7 @@ cbi
 ben
 bqb
 bZu
-cfw
+npq
 cgu
 qnt
 qnt


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
После мержа апстрима, подтянул [обнову](https://github.com/ParadiseSS13/Paradise/pull/25449) на карты, которая добавляет лобби в РнД.

## Changelog

:cl:
tweak: Все карты: Добавлена зона фойе РнД, дабы алярмы не так сильно выносили мозги, а инженерам было немного удобнее
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
