### PR TITLE
Fix expedition room lack of camera

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -29990,6 +29990,10 @@
 /area/station/supply/miningdock)
 "cqB" = (
 /obj/machinery/suit_storage_unit/expedition,
+/obj/machinery/camera{
+	c_tag = "Expedition Room";
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -70695,7 +70699,6 @@
 "mRf" = (
 /obj/item/bedsheet/hop,
 /obj/structure/bed,
-/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
 "mRJ" = (
@@ -82368,7 +82371,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "qVK" = (
 /obj/structure/cable{
@@ -85322,7 +85325,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/mining,
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "shz" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавил недостающую камеру в комнату экспедиторов, сменил им раскраску двери в техи, в крысу удалил лишнюю аиралярму в комнате хопа

## Changelog

:cl:
fix: Кибериада: Добавлена недостающая камера в комнате экспедиторов, покрашены двери в техи, удалена лишняя аир-алярма в комнате ХоПа.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
