### PR TITLE
Tweak: No AI interaction with SM Drop Button

### DIFF
--- a/modular_ss220/sm_space_drop/code/sm_drop_button.dm
+++ b/modular_ss220/sm_space_drop/code/sm_drop_button.dm
@@ -50,6 +50,9 @@
 	if(active)
 		return
 
+	if(isAI(user))
+		return
+
 	add_fingerprint(user)
 	use_power(5)
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Closes https://github.com/ss220club/Paradise-SS220/issues/1221
Убирает возможность у ИИ взаимодействовать с кнопкой сброса СМ

## Почему это хорошо для игры
ИИ не должен иметь возможность силой мысли разбивать стёкла и нажимать кнопку ручного (я только что сам выдумал) сброса

## Тестирование
Проверил в игре

## Changelog

:cl:
tweak: ИИ больше не может взаимодействовать с кнопкой сброса СМ
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
