### PR TITLE
Add: New Ferry shuttles

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -1187,7 +1187,8 @@
 /area/centcom/ss220/admin1)
 "aKT" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Зона ЦК"
+	req_access_txt = "101";
+	name = "Бар"
 	},
 /turf/simulated/floor/pod/light,
 /area/centcom/ss220/supply)
@@ -2951,8 +2952,11 @@
 /area/centcom/ss220/general)
 "bKL" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plasteel,
+/obj/machinery/door/airlock/external{
+	id_tag = "ferry_away";
+	name = "Шаттл"
+	},
+/turf/simulated/floor/plating,
 /area/centcom/ss220/supply)
 "bLl" = (
 /obj/effect/turf_decal/miscellaneous/goldensiding{
@@ -5670,10 +5674,10 @@
 /area/centcom/ss220/admin2)
 "dhs" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Шаттл Нанотрейзен";
+	name = "Шаттл";
 	req_access_txt = "101"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "dhE" = (
 /obj/machinery/abductor/pad{
@@ -8840,13 +8844,6 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
-"eRQ" = (
-/obj/item/flag/ian,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "darkbluealtstrip"
-	},
-/area/centcom/ss220/supply)
 "eRW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plasteel{
@@ -12722,10 +12719,11 @@
 	},
 /area/centcom/ss220/medbay)
 "gYI" = (
-/obj/structure/mirror/magic{
-	pixel_y = -32
+/obj/machinery/door/airlock/centcom{
+	req_access_txt = "101";
+	name = "Туалеты"
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "gZt" = (
 /obj/structure/chair/stool{
@@ -13148,11 +13146,11 @@
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
 "hkd" = (
-/obj/item/flag/ian,
-/turf/simulated/floor/plasteel/dark{
-	dir = 5;
-	icon_state = "darkbluealtstrip"
+/obj/machinery/door/airlock/centcom{
+	req_access_txt = "101";
+	name = "Рабочая Зона"
 	},
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "hlh" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -22234,7 +22232,8 @@
 /area/centcom/ss220/admin1)
 "mgU" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Зона ЦК"
+	req_access_txt = "101";
+	name = "Спальня"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
@@ -22361,6 +22360,9 @@
 /area/syndicate_mothership/control)
 "mkt" = (
 /mob/living/carbon/human/skeleton,
+/obj/structure/mirror/magic{
+	pixel_y = -32
+	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "mkF" = (
@@ -30402,10 +30404,10 @@
 /area/syndicate_mothership)
 "qZh" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Блокпост";
-	req_one_access_txt = "101"
+	req_access_txt = "101";
+	name = "Зона Отдыха"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "qZj" = (
 /obj/structure/sign/flag/nanotrasen,
@@ -33380,7 +33382,8 @@
 /area/centcom/ss220/admin2)
 "syo" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Зона ЦК"
+	req_access_txt = "101";
+	name = "Рабочая Зона"
 	},
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
@@ -35113,14 +35116,13 @@
 	req_one_access_txt = "101";
 	pixel_x = 24
 	},
-/obj/machinery/door/airlock/centcom{
-	id_tag = "CC_Shitspawn_Interior_1";
-	name = "Зона ЦК";
-	req_one_access_txt = "101"
-	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "СС_BD_Shitspawn_Interior_1";
 	layer = 3
+	},
+/obj/machinery/door/airlock/centcom{
+	name = "Блокпост";
+	req_one_access_txt = "101"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
@@ -35164,14 +35166,13 @@
 	req_one_access_txt = "101";
 	pixel_x = 24
 	},
-/obj/machinery/door/airlock/centcom{
-	id_tag = "CC_Shitspawn_Exterior_1";
-	name = "Зона ЦК";
-	req_one_access_txt = "101"
-	},
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "СС_BD_Shitspawn_Exterior_1";
 	layer = 3
+	},
+/obj/machinery/door/airlock/centcom{
+	name = "Блокпост";
+	req_one_access_txt = "101"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
@@ -37616,10 +37617,10 @@
 /area/centcom/ss220/admin2)
 "uWb" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Зона ЦК";
-	req_access_txt = "101"
+	req_access_txt = "101";
+	name = "Пункт Отправки"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "uWc" = (
 /obj/structure/barricade{
@@ -37791,7 +37792,6 @@
 /area/centcom/ss220/medbay)
 "vbN" = (
 /obj/structure/light_fake,
-/obj/item/flag/ian,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkbluealtstrip"
 	},
@@ -41308,7 +41308,9 @@
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/infteam)
 "wOH" = (
-/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Комната Грязи"
+	},
 /turf/simulated/floor/plating,
 /area/centcom/ss220/supply)
 "wOK" = (
@@ -51551,7 +51553,7 @@ tgd
 tgd
 dhg
 ajH
-rzI
+vdr
 oXo
 egO
 lsI
@@ -52318,10 +52320,10 @@ adJ
 adJ
 adJ
 rzI
-hDe
-hDe
-hDe
 rzI
+hDe
+hDe
+hDe
 rzI
 rzI
 dhs
@@ -52575,7 +52577,7 @@ rtA
 rtA
 rtA
 rzI
-eRQ
+rQX
 jie
 jie
 jie
@@ -53858,7 +53860,7 @@ dTG
 rzI
 otb
 nEU
-gYI
+oVq
 rzI
 lsI
 lsI
@@ -54625,7 +54627,7 @@ adJ
 rzI
 vqf
 vqf
-syo
+gYI
 mLN
 uxt
 uxt
@@ -55659,7 +55661,7 @@ rzI
 aek
 ije
 rzI
-hkd
+eNK
 ptx
 ptx
 ptx
@@ -56178,7 +56180,7 @@ ofW
 ppK
 ofW
 ppK
-qZh
+ase
 oVq
 oVq
 jvf
@@ -56429,7 +56431,7 @@ aVm
 uxt
 uxt
 dVH
-syo
+hkd
 ppK
 ppK
 ppK
@@ -59256,7 +59258,7 @@ rzI
 gnX
 bew
 egO
-syo
+qZh
 ppK
 ppK
 ppK

--- a/_maps/map_files220/shuttles/ferry_clown.dmm
+++ b/_maps/map_files220/shuttles/ferry_clown.dmm
@@ -1,0 +1,180 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/bananium,
+/area/shuttle/transport)
+"c" = (
+/turf/simulated/wall/mineral/bananium,
+/area/shuttle/transport)
+"d" = (
+/obj/structure/window/full/shuttle{
+	color = "yellow"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"i" = (
+/obj/machinery/economy/vending/artvend/free,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"j" = (
+/obj/machinery/economy/vending/autodrobe/free,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"k" = (
+/obj/structure/sign/clown{
+	pixel_y = 32
+	},
+/obj/item/bedsheet/clown,
+/obj/structure/bed,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"l" = (
+/obj/machinery/door/airlock/bananium/glass{
+	id_tag = "s_docking_airlock";
+	name = "Шаттл Клоунов"
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = "ferry_away";
+	timid = 1;
+	width = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"m" = (
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/transport)
+"n" = (
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 8
+	},
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"q" = (
+/obj/item/flag/clown,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"r" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium/yellow,
+/area/shuttle/transport)
+"s" = (
+/obj/structure/dresser,
+/obj/item/food/snacks/grown/banana,
+/obj/item/grenade/bananade,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"t" = (
+/obj/structure/statue/bananium/clown,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"N" = (
+/obj/item/bedsheet/clown,
+/obj/structure/bed,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+"Z" = (
+/obj/item/bedsheet/clown,
+/obj/structure/bed,
+/obj/machinery/light/spot,
+/turf/simulated/floor/noslip,
+/area/shuttle/transport)
+
+(1,1,1) = {"
+a
+b
+l
+b
+a
+"}
+(2,1,1) = {"
+b
+c
+m
+c
+b
+"}
+(3,1,1) = {"
+c
+q
+m
+q
+c
+"}
+(4,1,1) = {"
+c
+i
+m
+j
+c
+"}
+(5,1,1) = {"
+d
+N
+m
+N
+d
+"}
+(6,1,1) = {"
+c
+s
+m
+s
+c
+"}
+(7,1,1) = {"
+c
+k
+m
+Z
+c
+"}
+(8,1,1) = {"
+c
+s
+m
+s
+c
+"}
+(9,1,1) = {"
+d
+N
+m
+N
+d
+"}
+(10,1,1) = {"
+c
+t
+r
+t
+c
+"}
+(11,1,1) = {"
+c
+d
+n
+d
+c
+"}
+(12,1,1) = {"
+a
+d
+d
+d
+a
+"}

--- a/_maps/map_files220/shuttles/ferry_convoy.dmm
+++ b/_maps/map_files220/shuttles/ferry_convoy.dmm
@@ -1,0 +1,280 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"c" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"d" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"f" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"g" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"h" = (
+/obj/structure/toilet,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"i" = (
+/obj/structure/closet/wardrobe/orange/prison,
+/obj/item/card/id/prisoner,
+/obj/item/card/id/prisoner,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"j" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/reversed{
+	name = "Reinforced Glass Door"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"k" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"l" = (
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/window/reinforced{
+	layer = 2.8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"m" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"n" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"q" = (
+/obj/structure/bed/mattress/dirty,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"r" = (
+/obj/machinery/economy/vending/security,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light/spot,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"s" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs{
+	pixel_y = 4
+	},
+/obj/item/restraints/handcuffs{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"t" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"D" = (
+/obj/machinery/light/small/directional/west,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"I" = (
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Зона Содержания"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"K" = (
+/obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"N" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/window/reinforced/normal{
+	dir = 1;
+	name = "Reinforced Glass Door"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"P" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/recharger/wallcharger/upgraded{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"U" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"V" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger/upgraded{
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"Z" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Шаттл Конвоя"
+	},
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = "ferry_away";
+	timid = 1;
+	width = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+
+(1,1,1) = {"
+a
+b
+c
+K
+a
+"}
+(2,1,1) = {"
+b
+c
+c
+c
+K
+"}
+(3,1,1) = {"
+c
+h
+D
+q
+c
+"}
+(4,1,1) = {"
+c
+i
+m
+q
+c
+"}
+(5,1,1) = {"
+c
+c
+I
+c
+c
+"}
+(6,1,1) = {"
+d
+P
+f
+V
+d
+"}
+(7,1,1) = {"
+d
+k
+U
+t
+d
+"}
+(8,1,1) = {"
+c
+s
+n
+r
+c
+"}
+(9,1,1) = {"
+c
+j
+n
+N
+c
+"}
+(10,1,1) = {"
+d
+l
+n
+g
+d
+"}
+(11,1,1) = {"
+d
+d
+n
+d
+d
+"}
+(12,1,1) = {"
+a
+d
+Z
+d
+a
+"}

--- a/_maps/map_files220/shuttles/ferry_medical.dmm
+++ b/_maps/map_files220/shuttles/ferry_medical.dmm
@@ -1,0 +1,297 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"c" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"d" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"h" = (
+/obj/machinery/bodyscanner{
+	dir = 2
+	},
+/obj/machinery/light/directional/north,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"i" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/syringe/insulin{
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/syringe/antiviral{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/syringe/charcoal{
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/patch/styptic{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/patch/styptic{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/patch/styptic{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/patch/silver_sulf{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/patch/silver_sulf{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/patch/silver_sulf{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/storage/pill_bottle/painkillers{
+	pixel_x = -6;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 16;
+	pixel_y = 2
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"j" = (
+/obj/structure/sign/greencross,
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"k" = (
+/obj/machinery/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -29
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"l" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Медицинский Шаттл"
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = "ferry_away";
+	timid = 1;
+	width = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"m" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"n" = (
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"q" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"r" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"s" = (
+/obj/structure/table/reinforced,
+/obj/item/handheld_defibrillator{
+	pixel_x = -3
+	},
+/obj/item/handheld_defibrillator{
+	pixel_x = 3
+	},
+/obj/machinery/light/directional/north,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"t" = (
+/obj/machinery/economy/vending/medical{
+	req_access_txt = "0"
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"w" = (
+/obj/machinery/computer/med_data,
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"B" = (
+/obj/machinery/sleeper/upgraded{
+	dir = 2
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"C" = (
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 29
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"J" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/transport)
+"N" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"P" = (
+/obj/structure/table/tray,
+/obj/item/storage/surgical_tray{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"W" = (
+/obj/structure/closet/secure_closet/medical2{
+	req_access = null
+	},
+/obj/machinery/light/directional/south,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+"Y" = (
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Кабина Пилота"
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"Z" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/iv_bag/blood/OMinus{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/iv_bag/blood/OMinus,
+/obj/item/reagent_containers/iv_bag/blood/OMinus{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/iv_bag/salglu{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/iv_bag/salglu,
+/obj/item/reagent_containers/iv_bag/salglu{
+	pixel_x = 3
+	},
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/transport)
+
+(1,1,1) = {"
+a
+b
+l
+b
+a
+"}
+(2,1,1) = {"
+b
+J
+m
+J
+b
+"}
+(3,1,1) = {"
+c
+h
+m
+q
+c
+"}
+(4,1,1) = {"
+c
+C
+m
+k
+c
+"}
+(5,1,1) = {"
+c
+B
+m
+P
+c
+"}
+(6,1,1) = {"
+d
+Z
+m
+i
+d
+"}
+(7,1,1) = {"
+d
+t
+m
+t
+d
+"}
+(8,1,1) = {"
+j
+s
+m
+W
+j
+"}
+(9,1,1) = {"
+c
+c
+Y
+c
+c
+"}
+(10,1,1) = {"
+d
+w
+r
+N
+d
+"}
+(11,1,1) = {"
+d
+d
+n
+d
+d
+"}
+(12,1,1) = {"
+a
+d
+d
+d
+a
+"}

--- a/_maps/map_files220/shuttles/ferry_tsf.dmm
+++ b/_maps/map_files220/shuttles/ferry_tsf.dmm
@@ -1,0 +1,305 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/plastitanium,
+/area/shuttle/transport)
+"c" = (
+/turf/simulated/wall/mineral/plastitanium,
+/area/shuttle/transport)
+"d" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "TSF_Shuttle_2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"e" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"g" = (
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/transport)
+"h" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/obj/machinery/status_display/directional/north,
+/obj/machinery/recharger/wallcharger/upgraded{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"i" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"j" = (
+/obj/item/flag/solgov,
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"k" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/obj/machinery/recharger/wallcharger/upgraded{
+	pixel_x = 32
+	},
+/obj/machinery/status_display/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"l" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Шаттл ТСФ"
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = "ferry_away";
+	timid = 1;
+	width = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"m" = (
+/turf/simulated/floor/catwalk,
+/area/shuttle/transport)
+"n" = (
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/transport)
+"o" = (
+/obj/structure/table/reinforced{
+	color = "#444444"
+	},
+/obj/machinery/door_control/shutter{
+	id = "TSF_Shuttle_2";
+	name = "Pilot Shutters Control"
+	},
+/turf/simulated/floor/plasteel/dark{
+	dir = 6;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"q" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
+	},
+/obj/machinery/status_display/directional/south,
+/obj/machinery/recharger/wallcharger/upgraded{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel/dark{
+	dir = 10;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"r" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"s" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 8;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"t" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
+	},
+/obj/machinery/status_display/directional/south,
+/obj/machinery/recharger/wallcharger/upgraded{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plasteel/dark{
+	dir = 6;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"D" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
+	},
+/obj/structure/sign/flag/terragov{
+	pixel_y = -32
+	},
+/obj/machinery/light/directional/south,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"H" = (
+/obj/effect/spawner/window/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "TSF_Shuttle_1"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"J" = (
+/obj/machinery/door/airlock/centcom/glass{
+	name = "Кабина Пилота"
+	},
+/obj/effect/turf_decal/delivery/blue,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/transport)
+"N" = (
+/obj/item/flag/solgov,
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/plasteel/dark{
+	dir = 10;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"O" = (
+/obj/structure/table/reinforced{
+	color = "#444444"
+	},
+/obj/machinery/door_control/shutter{
+	id = "TSF_Shuttle_1";
+	name = "Boarding Shutters Control"
+	},
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"Q" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+"R" = (
+/turf/simulated/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/transport)
+"Y" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/obj/structure/sign/flag/terragov{
+	pixel_y = 32
+	},
+/obj/machinery/light/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
+/area/shuttle/transport)
+
+(1,1,1) = {"
+a
+b
+l
+b
+a
+"}
+(2,1,1) = {"
+b
+R
+g
+R
+b
+"}
+(3,1,1) = {"
+c
+h
+s
+q
+c
+"}
+(4,1,1) = {"
+H
+e
+m
+i
+H
+"}
+(5,1,1) = {"
+c
+Y
+m
+D
+c
+"}
+(6,1,1) = {"
+H
+e
+m
+i
+H
+"}
+(7,1,1) = {"
+c
+k
+Q
+t
+c
+"}
+(8,1,1) = {"
+c
+c
+J
+c
+c
+"}
+(9,1,1) = {"
+c
+j
+s
+N
+c
+"}
+(10,1,1) = {"
+d
+O
+r
+o
+d
+"}
+(11,1,1) = {"
+d
+d
+n
+d
+d
+"}
+(12,1,1) = {"
+a
+d
+d
+d
+a
+"}

--- a/_maps/map_files220/shuttles/ferry_ussp.dmm
+++ b/_maps/map_files220/shuttles/ferry_ussp.dmm
@@ -1,0 +1,302 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"c" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"d" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"e" = (
+/obj/item/flag/ussp,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"f" = (
+/obj/structure/chair/comfy/red{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"g" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"h" = (
+/obj/item/flag/ussp,
+/obj/machinery/light/directional/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"i" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"j" = (
+/obj/structure/closet/crate,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/stamp/ussp,
+/obj/item/pen/hos{
+	name = "USSP fountain pen";
+	desc = "An expensive-looking pen."
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"k" = (
+/obj/structure/sign/poster/contraband/communist_state{
+	pixel_y = 32
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/item/reagent_containers/drinks/bottle/vodka{
+	pixel_y = 12;
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass{
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass{
+	pixel_y = 9;
+	pixel_x = 6
+	},
+/obj/machinery/light/directional/north,
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"l" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock";
+	name = "Шаттл СССП"
+	},
+/obj/docking_port/mobile{
+	dir = 4;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = "ferry_away";
+	timid = 1;
+	width = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"m" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"n" = (
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"o" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"q" = (
+/obj/item/flag/ussp,
+/obj/machinery/light/directional/south,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"r" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"s" = (
+/obj/structure/chair/comfy/red{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"t" = (
+/obj/structure/sign/poster/contraband/communist_state{
+	pixel_y = -32
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_y = 2
+	},
+/obj/item/clothing/mask/cigarette/cigar/cohiba{
+	pixel_y = 8
+	},
+/obj/item/radio/phone{
+	pixel_y = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"x" = (
+/obj/machinery/door/window/reinforced/reversed{
+	name = "Reinforced Glass Door";
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"G" = (
+/turf/simulated/wall/mineral/titanium/nodiagonal,
+/area/shuttle/transport)
+"K" = (
+/obj/machinery/door/window/reinforced/normal{
+	dir = 4;
+	name = "Reinforced Glass Door"
+	},
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"M" = (
+/obj/structure/chair/comfy/shuttle/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"N" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"O" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"R" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+"U" = (
+/turf/simulated/floor/carpet/red,
+/area/shuttle/transport)
+"Y" = (
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/transport)
+
+(1,1,1) = {"
+a
+b
+l
+b
+a
+"}
+(2,1,1) = {"
+b
+G
+o
+G
+b
+"}
+(3,1,1) = {"
+c
+h
+o
+q
+c
+"}
+(4,1,1) = {"
+d
+i
+g
+O
+d
+"}
+(5,1,1) = {"
+d
+M
+R
+Y
+d
+"}
+(6,1,1) = {"
+c
+f
+x
+f
+c
+"}
+(7,1,1) = {"
+c
+k
+U
+t
+c
+"}
+(8,1,1) = {"
+c
+s
+K
+s
+c
+"}
+(9,1,1) = {"
+c
+j
+m
+N
+c
+"}
+(10,1,1) = {"
+d
+e
+r
+e
+d
+"}
+(11,1,1) = {"
+d
+d
+n
+d
+d
+"}
+(12,1,1) = {"
+a
+d
+d
+d
+a
+"}

--- a/_maps/map_files220/shuttles/ferry_vip.dmm
+++ b/_maps/map_files220/shuttles/ferry_vip.dmm
@@ -1,0 +1,215 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/space,
+/area/space)
+"b" = (
+/obj/structure/shuttle/engine/propulsion/burst/left{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"c" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"d" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+"f" = (
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"g" = (
+/obj/machinery/computer/security{
+	dir = 8;
+	network = list("SS13","Telecomms","Research Outpost","Mining Outpost","ERT","CentComm","Thunderdome")
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"h" = (
+/obj/machinery/economy/vending/boozeomat,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"i" = (
+/obj/structure/bookcase/random,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"j" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"l" = (
+/obj/machinery/computer/shuttle/ferry/request{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"m" = (
+/obj/structure/chair/comfy/corp,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"n" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"q" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen/multi/fountain{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"r" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"s" = (
+/obj/machinery/recharger,
+/obj/structure/table/reinforced,
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/transport)
+"t" = (
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"I" = (
+/obj/structure/table/wood/fancy/black,
+/obj/item/flashlight/lamp/green,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"J" = (
+/obj/structure/shuttle/engine/propulsion/burst/right{
+	dir = 8
+	},
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/transport)
+"P" = (
+/obj/structure/closet/crate/secure/bin{
+	color = "#36373a";
+	anchored = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"U" = (
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Комната VIP"
+	},
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"V" = (
+/obj/structure/dresser,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/transport)
+"Z" = (
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Шаттл VIP"
+	},
+/obj/docking_port/mobile{
+	dir = 8;
+	dwidth = 2;
+	height = 12;
+	id = "ferry";
+	name = "ferry shuttle";
+	roundstart_move = "ferry_away";
+	timid = 1;
+	width = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/transport)
+
+(1,1,1) = {"
+a
+b
+c
+J
+a
+"}
+(2,1,1) = {"
+b
+c
+c
+c
+J
+"}
+(3,1,1) = {"
+c
+h
+m
+q
+c
+"}
+(4,1,1) = {"
+d
+i
+f
+I
+d
+"}
+(5,1,1) = {"
+d
+i
+f
+t
+d
+"}
+(6,1,1) = {"
+c
+P
+f
+V
+c
+"}
+(7,1,1) = {"
+c
+c
+U
+c
+c
+"}
+(8,1,1) = {"
+c
+s
+n
+r
+c
+"}
+(9,1,1) = {"
+c
+j
+n
+j
+c
+"}
+(10,1,1) = {"
+d
+l
+n
+g
+d
+"}
+(11,1,1) = {"
+d
+d
+n
+d
+d
+"}
+(12,1,1) = {"
+a
+d
+Z
+d
+a
+"}

--- a/modular_ss220/shuttles/_shuttles.dme
+++ b/modular_ss220/shuttles/_shuttles.dme
@@ -1,4 +1,5 @@
 #include "_shuttles.dm"
 
+#include "code/ferry_shuttles.dm"
 #include "code/lance_shuttle.dm"
 #include "code/nanotrasen_drop_pod.dm"

--- a/modular_ss220/shuttles/code/ferry_shuttles.dm
+++ b/modular_ss220/shuttles/code/ferry_shuttles.dm
@@ -1,0 +1,35 @@
+/datum/map_template/shuttle/ferry/clown
+	prefix = "_maps/map_files220/shuttles/"
+	suffix = "clown"
+	name = "clown ferry"
+	description = "Персональный шаттл клоунов, выращенный из бананов!"
+
+/datum/map_template/shuttle/ferry/convoy
+	prefix = "_maps/map_files220/shuttles/"
+	suffix = "convoy"
+	name = "prisoner convoy ferry"
+	description = "Шаттл для конвоирования заключенных."
+
+/datum/map_template/shuttle/ferry/medical
+	prefix = "_maps/map_files220/shuttles/"
+	suffix = "medical"
+	name = "medical ferry"
+	description = "Шаттл содержащий в себе немного медикаментов и операционную. В целом, всё необходимое для поддержания жизни пациента."
+
+/datum/map_template/shuttle/ferry/tsf
+	prefix = "_maps/map_files220/shuttles/"
+	suffix = "tsf"
+	name = "TSF ferry"
+	description = "Шаттл ТСФ, предназначенный для безопасной переброски личного состава в самые опасные уголки космоса."
+
+/datum/map_template/shuttle/ferry/ussp
+	prefix = "_maps/map_files220/shuttles/"
+	suffix = "ussp"
+	name = "USSP ferry"
+	description = "Шаттл СССП. В основном используется ячейкой дипломатов СССП."
+
+/datum/map_template/shuttle/ferry/vip
+	prefix = "_maps/map_files220/shuttles/"
+	suffix = "vip"
+	name = "VIP ferry"
+	description = "Шаттл, используемый для перевозки привилегированных лиц различных корпораций."


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

- Добавлено 6 новых ферри шаттлов для щитспавна админами
 1. ТСФ
 2. СССП
 3. Клоунский
 4. Медицинский
 5. Для конвоирования
 6. Для VIP-персон
 
- В зоне кастом щитспавна убраны любые упоминания о ЦК, а также кринж флаги

## Почему это хорошо для игры
Теперь у админов появилась полноценная щитспавн зона для осуществления большинства задумок с фракциями

## Изображения изменений
Смотри мапдифф

## Тестирование
Проверял в игре

## Changelog

:cl:
add: Для щитспавна админами добавлено 6 новых ферри шаттлов (ТСФ, СССП, клоунский, медицинский, для конвоирования и для VIP-персон)
tweak: Центком: В кастомной зоне щитспавна убраны любые упоминания НТ, а также флаги
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
