### PR TITLE
Fix: Neon shoes overlay

### DIFF
--- a/modular_ss220/clothing/code/shoes.dm
+++ b/modular_ss220/clothing/code/shoes.dm
@@ -4,8 +4,8 @@
 
 /* Neon Shoes */
 /obj/item/clothing/shoes/black/neon
-	name = "неоновые кросовки"
-	desc = "Пара чёрных кросовок с светодиодными вставками."
+	name = "неоновые кроссовки"
+	desc = "Пара чёрных кроссовок с светодиодными вставками."
 	icon = 'modular_ss220/clothing/icons/object/shoes.dmi'
 	icon_state = "neon"
 	icon_override = 'modular_ss220/clothing/icons/mob/shoes.dmi'
@@ -27,7 +27,7 @@
 			toggle_glow(user)
 
 /obj/item/clothing/shoes/black/neon/attack_self(mob/user)
-	var/choice = tgui_input_list(user, "Что вы хотите сделать?", "Неоновые кросовки", list("Переключить подсветку", "Сменить цвет"))
+	var/choice = tgui_input_list(user, "Что вы хотите сделать?", "Неоновые кроссовки", list("Переключить подсветку", "Сменить цвет"))
 	switch(choice)
 		if("Переключить подсветку")
 			toggle_glow(user)
@@ -97,7 +97,7 @@
 
 /// Opens user input for changing neon color
 /obj/item/clothing/shoes/black/neon/proc/change_color(mob/user)
-	var/temp = input(user, "Пожалуйста, выберите цвет.", "Цвет кросовок") as color
+	var/temp = input(user, "Пожалуйста, выберите цвет.", "Цвет кроссовок") as color
 	color = temp
 	light_color = temp
 	reload_neon_overlay(user)

--- a/modular_ss220/clothing/code/shoes.dm
+++ b/modular_ss220/clothing/code/shoes.dm
@@ -54,7 +54,7 @@
 /obj/item/clothing/shoes/black/neon/proc/apply_neon_overlay(mob/user)
 	if(!user)
 		return
-	neon_overlay = mutable_appearance('modular_ss220/clothing/icons/mob/shoes.dmi', "neon_overlay", EMISSIVE_PLANE)
+	neon_overlay = mutable_appearance('modular_ss220/clothing/icons/mob/shoes.dmi', "neon_overlay")
 	neon_overlay.color = color
 	user.add_overlay(neon_overlay)
 
@@ -69,19 +69,19 @@
 /obj/item/clothing/shoes/black/neon/proc/reload_neon_overlay(mob/user)
 	if(!user)
 		return
-	var/mob/living/carbon/human/H = user
-	if(neon_overlay)
-		remove_neon_overlay(user)
-		if(H.get_item_by_slot(SLOT_HUD_SHOES))
-			apply_neon_overlay(user)
+	if(!neon_overlay)
+		return
+
+	remove_neon_overlay(user)
+	if(user.get_item_by_slot(SLOT_HUD_SHOES))
+		apply_neon_overlay(user)
 
 /// Toggles neon overlay and light emit
 /obj/item/clothing/shoes/black/neon/proc/toggle_glow(mob/user)
 	if(!user)
 		return
-	var/mob/living/carbon/human/H = user
 	// Toggle neon overlay
-	if(!glow_active && H.get_item_by_slot(SLOT_HUD_SHOES))
+	if(!glow_active && user.get_item_by_slot(SLOT_HUD_SHOES))
 		apply_neon_overlay(user)
 	else if(neon_overlay)
 		remove_neon_overlay(user)

--- a/modular_ss220/clothing/code/shoes.dm
+++ b/modular_ss220/clothing/code/shoes.dm
@@ -1,6 +1,8 @@
+/* Datums */
 /datum/action/item_action/change_color
-	name = "Change color"
+	name = "Change Color"
 
+/* Neon Shoes */
 /obj/item/clothing/shoes/black/neon
 	name = "неоновые кросовки"
 	desc = "Пара чёрных кросовок с светодиодными вставками."
@@ -12,45 +14,95 @@
 	actions_types = list(/datum/action/item_action/toggle_light, /datum/action/item_action/change_color)
 	dyeable = FALSE
 	color = null
+	/// Neon overlay that applies on mob
+	var/mutable_appearance/neon_overlay
+	/// Does it emit light?
 	var/glow_active = FALSE
-	var/brightness_on = 2
-
-/obj/item/clothing/shoes/black/neon/attack_self(mob/living/user)
-	var/choice = tgui_input_list(user, "Что вы хотите сделать?", "Неоновые кросовки", list("Переключить подсветку", "Сменить цвет"))
-	switch(choice)
-		if("Переключить подсветку")
-			turn_glow()
-		if("Сменить цвет")
-			change_color()
-
-/obj/item/clothing/shoes/black/neon/update_icon_state()
-	. = ..()
-
-/obj/item/clothing/shoes/black/neon/proc/turn_glow()
-	if(!glow_active)
-		set_light(brightness_on)
-		var/mutable_appearance/neon_overlay = mutable_appearance('modular_ss220/clothing/icons/mob/shoes.dmi',"neon_overlay")
-		neon_overlay.color = color
-		add_overlay(neon_overlay)
-		glow_active = TRUE
-	else
-		set_light(0)
-		cut_overlays()
-		glow_active = FALSE
-	update_icon_state()
-
-/obj/item/clothing/shoes/black/neon/proc/change_color(mob/living/user as mob)
-	var/temp = input(usr, "Пожалуйста, выберите цвет.", "Цвет кросовок") as color
-	color = temp
-	light_color = temp
-	update_icon_state()
 
 /obj/item/clothing/shoes/black/neon/ui_action_click(mob/user, actiontype)
 	if(actiontype == /datum/action/item_action/change_color)
-		change_color()
+		change_color(user)
 	else if(actiontype == /datum/action/item_action/toggle_light)
-		turn_glow()
+		toggle_glow(user)
 
+/obj/item/clothing/shoes/black/neon/attack_self(mob/user)
+	var/choice = tgui_input_list(user, "Что вы хотите сделать?", "Неоновые кросовки", list("Переключить подсветку", "Сменить цвет"))
+	switch(choice)
+		if("Переключить подсветку")
+			toggle_glow(user)
+		if("Сменить цвет")
+			change_color(user)
+
+/obj/item/clothing/shoes/black/neon/equipped(mob/user, slot)
+	. = ..()
+	if(!neon_overlay && glow_active && slot == SLOT_HUD_SHOES)
+		apply_neon_overlay(user)
+
+/obj/item/clothing/shoes/black/neon/dropped(mob/user)
+	. = ..()
+	if(neon_overlay)
+		remove_neon_overlay(user)
+
+/obj/item/clothing/shoes/black/neon/Destroy()
+	var/mob/living/user
+	if(neon_overlay)
+		remove_neon_overlay(user)
+	return ..()
+
+/// Applies neon overlay and gets color on it
+/obj/item/clothing/shoes/black/neon/proc/apply_neon_overlay(mob/user)
+	if(!user)
+		return
+	neon_overlay = mutable_appearance('modular_ss220/clothing/icons/mob/shoes.dmi', "neon_overlay", EMISSIVE_PLANE)
+	neon_overlay.color = color
+	user.add_overlay(neon_overlay)
+
+/// Completely removes the neon overlay
+/obj/item/clothing/shoes/black/neon/proc/remove_neon_overlay(mob/user)
+	if(!user)
+		return
+	user.cut_overlay(neon_overlay)
+	QDEL_NULL(neon_overlay)
+
+/// Reloads neon overlay (usually used after a color change)
+/obj/item/clothing/shoes/black/neon/proc/reload_neon_overlay(mob/user)
+	var/mob/living/carbon/human/H = user
+	if(!user)
+		return
+	if(neon_overlay)
+		remove_neon_overlay(user)
+		if(H.get_item_by_slot(SLOT_HUD_SHOES))
+			apply_neon_overlay(user)
+
+/// Toggles neon overlay and light emit
+/obj/item/clothing/shoes/black/neon/proc/toggle_glow(mob/user)
+	var/mob/living/carbon/human/H = user
+	if(!user)
+		return
+	// Toggle neon overlay
+	if(!glow_active && H.get_item_by_slot(SLOT_HUD_SHOES))
+		apply_neon_overlay(user)
+	else if(neon_overlay)
+		remove_neon_overlay(user)
+	// Toggle light emit
+	if(!glow_active)
+		set_light(2)
+		glow_active = TRUE
+	else
+		set_light(0)
+		glow_active = FALSE
+
+	update_icon_state()
+
+/// Opens user input for changing neon color
+/obj/item/clothing/shoes/black/neon/proc/change_color(mob/user)
+	var/temp = input(user, "Пожалуйста, выберите цвет.", "Цвет кросовок") as color
+	color = temp
+	light_color = temp
+	reload_neon_overlay(user)
+	update_icon_state()
+
+/* Shark Shoes */
 /obj/item/clothing/shoes/shark
 	name = "акульи тапочки"
 	desc = "Эти тапочки сделаны из акульей кожи, или нет?"

--- a/modular_ss220/clothing/code/shoes.dm
+++ b/modular_ss220/clothing/code/shoes.dm
@@ -67,9 +67,9 @@
 
 /// Reloads neon overlay (usually used after a color change)
 /obj/item/clothing/shoes/black/neon/proc/reload_neon_overlay(mob/user)
-	var/mob/living/carbon/human/H = user
 	if(!user)
 		return
+	var/mob/living/carbon/human/H = user
 	if(neon_overlay)
 		remove_neon_overlay(user)
 		if(H.get_item_by_slot(SLOT_HUD_SHOES))
@@ -77,9 +77,9 @@
 
 /// Toggles neon overlay and light emit
 /obj/item/clothing/shoes/black/neon/proc/toggle_glow(mob/user)
-	var/mob/living/carbon/human/H = user
 	if(!user)
 		return
+	var/mob/living/carbon/human/H = user
 	// Toggle neon overlay
 	if(!glow_active && H.get_item_by_slot(SLOT_HUD_SHOES))
 		apply_neon_overlay(user)

--- a/modular_ss220/clothing/code/shoes.dm
+++ b/modular_ss220/clothing/code/shoes.dm
@@ -14,16 +14,17 @@
 	actions_types = list(/datum/action/item_action/toggle_light, /datum/action/item_action/change_color)
 	dyeable = FALSE
 	color = null
-	/// Neon overlay that applies on mob
-	var/mutable_appearance/neon_overlay
 	/// Does it emit light?
 	var/glow_active = FALSE
+	/// Neon overlay that applies on mob
+	var/mutable_appearance/neon_overlay
 
 /obj/item/clothing/shoes/black/neon/ui_action_click(mob/user, actiontype)
-	if(actiontype == /datum/action/item_action/change_color)
-		change_color(user)
-	else if(actiontype == /datum/action/item_action/toggle_light)
-		toggle_glow(user)
+	switch(actiontype)
+		if(/datum/action/item_action/change_color)
+			change_color(user)
+		if(/datum/action/item_action/toggle_light)
+			toggle_glow(user)
 
 /obj/item/clothing/shoes/black/neon/attack_self(mob/user)
 	var/choice = tgui_input_list(user, "Что вы хотите сделать?", "Неоновые кросовки", list("Переключить подсветку", "Сменить цвет"))

--- a/modular_ss220/loadout/code/donor.dm
+++ b/modular_ss220/loadout/code/donor.dm
@@ -1,5 +1,5 @@
 /datum/gear/donor/neon_shoes
-	display_name = "Неоновые кросовки"
+	display_name = "Неоновые кроссовки"
 	path = /obj/item/clothing/shoes/black/neon
 	donator_tier = 1
 	cost = 1


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Fixes https://github.com/ss220club/Paradise-SS220/issues/470
 - Исправляет работу оверлея неоновых ботинок
 - Код отсортирован

## Почему это хорошо для игры
Оверлей будет отображаться корректно

## Изображения изменений
https://github.com/ss220club/Paradise-SS220/assets/20109643/6488c929-6289-4784-a02e-73ff90f88908

## Тестирование
Проверял в игре

## Changelog

:cl:
fix: Неоновые ботинки теперь корректно накладывают оверлей подсветки (да-да, оно было сломано).
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
