### PR TITLE
Add RPS into the emote panel

### DIFF
--- a/modular_ss220/_defines220/code/emote.dm
+++ b/modular_ss220/_defines220/code/emote.dm
@@ -77,6 +77,7 @@
 #define EMOTE_HUMAN_WINK 			"Подмигнуть"
 #define EMOTE_HUMAN_HIGHFIVE 		"Дать пять"
 #define EMOTE_HUMAN_HANDSHAKE 		"Пожать руку"
+#define EMOTE_HUMAN_RPS				"Камень, ножницы, бумага"
 #define EMOTE_HUMAN_SNAP 			"Щёлкнуть пальцами"
 #define EMOTE_HUMAN_CRACK 			"Хрустеть пальцами"
 #define EMOTE_HUMAN_FART 			"Пёрнуть"

--- a/modular_ss220/emotes/code/emote_names.dm
+++ b/modular_ss220/emotes/code/emote_names.dm
@@ -280,6 +280,9 @@
 /datum/emote/living/carbon/human/highfive/handshake
 	name = EMOTE_HUMAN_HANDSHAKE
 
+/datum/emote/living/carbon/human/highfive/rps
+	name = EMOTE_HUMAN_RPS
+
 /datum/emote/living/carbon/human/hug
 	name = EMOTE_HUMAN_HUG
 

--- a/modular_ss220/emotes/code/emote_verbs.dm
+++ b/modular_ss220/emotes/code/emote_verbs.dm
@@ -120,6 +120,11 @@
 	set category = "Эмоции"
 	emote("slap", intentional = TRUE)
 
+/mob/living/carbon/human/verb/emote_rps()
+	set name = "○ " + EMOTE_HUMAN_RPS + " "
+	set category = "Эмоции"
+	emote("rps", intentional = TRUE)
+
 /// Exercise Emotes ///
 /mob/living/carbon/human/verb/emote_exercise()
 	set name = "⚝ " + EMOTE_EXERCISE


### PR DESCRIPTION
## Что этот PR делает
Добавил «камень-ножницы-бумага» в эмоут панель

## Почему это хорошо для игры
Можно играть в «камень-ножницы-бумага»

## Changelog

:cl:
add: «Камень-ножницы-бумага» теперь в эмоут панели, можете играть
/:cl:

