### PR TITLE
[Spellcheck] Убираем плюсик из оповещения об уязвимости сети

### DIFF
--- a/code/modules/events/door_runtime.dm
+++ b/code/modules/events/door_runtime.dm
@@ -1,7 +1,7 @@
 /datum/event/door_runtime
 
 /datum/event/door_runtime/announce()
-	GLOB.minor_announcement.Announce("Вредоносное программное обеспечение обнаружено в системе контроля шл+юзов. Задействованы протоколы изоляции. Пожалуйста, сохраняйте спокойствие.", "ВНИМАНИЕ: Уязвимость сети.", 'sound/AI/door_runtimes.ogg')
+	GLOB.minor_announcement.Announce("Вредоносное программное обеспечение обнаружено в системе контроля шлюзов. Задействованы протоколы изоляции. Пожалуйста, сохраняйте спокойствие.", "ВНИМАНИЕ: Уязвимость сети.", 'sound/AI/door_runtimes.ogg')
 
 /datum/event/door_runtime/start()
 	for(var/obj/machinery/door/D in GLOB.airlocks)


### PR DESCRIPTION
## Что этот PR делает
Убирает плюсик из слова "шлюзов" в ивенте об уязвимости сети т.к. эти плюсики в оповещениях не работают (и я не уверен, что работают вообще)

## Почему это хорошо для игры
В данный момент выглядит как очепятка. Глаза болят

## Изображения
Вот отсюда \\/
![изображение](https://github.com/ss220club/Paradise-SS220/assets/47046463/ca537eeb-d8cc-4c52-8be7-d48419311feb)


## Тестирование
Верю в свои силы

## Changelog

:cl:
spellcheck: Убрал плюсик из слова "шлюзов" в ивенте об уязвимости сети
/:cl:
