### PR TITLE
[Spellcheck] "Вы уверен" заменено на "Вы уверены" при респавне

### DIFF
--- a/modular_ss220/verbs/code/verbs.dm
+++ b/modular_ss220/verbs/code/verbs.dm
@@ -49,7 +49,7 @@
 		to_chat(usr, span_warning("Вы должны подождать ещё [GLOB.configuration.ss220_misc.respawn_delay] минут чтобы возродиться!"))
 		return
 
-	if(alert("Вы уверен что хотите возродиться?", "Возрождение", "Да", "Нет") != "Да")
+	if(alert("Вы уверены что хотите возродиться?", "Возрождение", "Да", "Нет") != "Да")
 		return
 
 	log_game("[key_name(usr)] has respawned.")


### PR DESCRIPTION
## Что этот PR делает
Добавляем букву "ы"

## Почему это хорошо для игры
да просто так... никак не хорошо... вообще плохой ПР...

## Тестирование
Верю в свои силы

## Changelog

:cl:
spellcheck: Очепятка в сообщении при возрождении исправлена
/:cl: