### PR TITLE
Fix: send only one frame to redis

### DIFF
--- a/modular_ss220/redis220/code/news.dm
+++ b/modular_ss220/redis220/code/news.dm
@@ -19,7 +19,7 @@
 		"author_ckey" = author_ckey,
 		"title" = title,
 		"body" = body,
-		"img" = icon2base64(img),
+		"img" = icon2base64(icon(img, frame = 1)),
 		"censor_flags" = censor_flags,
 		"admin_locked" = admin_locked,
 		"view_count" = view_count,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Изначально, иконка имеет все кадры анимации в себе, так что лучше слать только первый. Ну либо формировать из них гифку, но это будет кринж
