### PR TITLE
Fix relate jobs?

### DIFF
--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -8,9 +8,11 @@
 	var/relate_job // for relate positions and landmark
 	var/is_extra_job = FALSE // Special Jobs Window
 	var/is_main_job = TRUE // Are we the main job for this relate?
+	var/shares_slots_with_relate = FALSE
 
 /datum/job/doctor
 	relate_job = "Medical Intern"
+	shares_slots_with_relate = TRUE
 
 /datum/job/doctor/intern
 	relate_job = "Medical Doctor"
@@ -18,6 +20,7 @@
 
 /datum/job/scientist
 	relate_job = "Student Scientist"
+	shares_slots_with_relate = TRUE
 
 /datum/job/scientist/student
 	relate_job = "Scientist"
@@ -25,6 +28,7 @@
 
 /datum/job/engineer
 	relate_job = "Trainee Engineer"
+	shares_slots_with_relate = TRUE
 
 /datum/job/engineer/trainee
 	relate_job = "Station Engineer"
@@ -32,6 +36,7 @@
 
 /datum/job/officer
 	relate_job = "Security Cadet"
+	shares_slots_with_relate = TRUE
 
 /datum/job/officer/cadet
 	relate_job = "Security Officer"
@@ -46,7 +51,7 @@
 		return FALSE
 	if(check_hidden_from_job_prefs())
 		return FALSE
-	if(relate_job)
+	if(relate_job && shares_slots_with_relate)
 		return check_relate_total_positions()
 
 	return ..()
@@ -56,7 +61,7 @@
 		return FALSE
 	if(check_hidden_from_job_prefs())
 		return FALSE
-	if(relate_job)
+	if(relate_job && shares_slots_with_relate)
 		return check_relate_spawn_positions()
 
 	return ..()

--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -30,6 +30,7 @@
 /datum/job/officer
 	relate_job = "Security Cadet"
 	is_relate_positions = TRUE
+
 /datum/job/officer/cadet
 	relate_job = "Security Officer"
 
@@ -40,27 +41,40 @@
 /datum/job/is_position_available()
 	if(job_banned_gamemode)
 		return FALSE
-
 	if(check_hidden_from_job_prefs())
 		return FALSE
-
 	if(relate_job && is_relate_positions)
-		return check_relate_positions()
+		return check_relate_total_positions()
 
 	return ..()
 
-/datum/job/proc/check_relate_positions()
+/datum/job/is_spawn_position_available()
+	if(job_banned_gamemode)
+		return FALSE
+	if(check_hidden_from_job_prefs())
+		return FALSE
+	if(relate_job && is_relate_positions)
+		return check_relate_spawn_positions()
+
+	return ..()
+
+/datum/job/proc/check_relate_total_positions()
 	var/datum/job/temp = SSjobs.GetJob(relate_job)
 	if(!temp)
 		return FALSE
+	if(total_positions == -1 || temp.total_positions == -1)
+		return TRUE
 
-	var/current_count_positions = current_positions + temp.current_positions
-	var/total_count_positions = total_positions + temp.total_positions
+	return (current_positions + temp.current_positions < total_positions + temp.total_positions)
 
-	if(total_positions == -1)
-		total_count_positions = -1
+/datum/job/proc/check_relate_spawn_positions()
+	var/datum/job/temp = SSjobs.GetJob(relate_job)
+	if(!temp)
+		return FALSE
+	if(spawn_positions == -1 || temp.spawn_positions == -1)
+		return TRUE
 
-	return (current_count_positions < total_count_positions) || (total_count_positions == -1)
+	return (current_positions + temp.current_positions < spawn_positions + temp.spawn_positions)
 
 /datum/job/proc/check_hidden_from_job_prefs()
 	if(hidden_from_job_prefs)

--- a/modular_ss220/jobs/code/jobs.dm
+++ b/modular_ss220/jobs/code/jobs.dm
@@ -8,24 +8,31 @@
 	var/relate_job // for relate positions and landmark
 	var/is_relate_positions = FALSE	// Slots
 	var/is_extra_job = FALSE // Special Jobs Window
+	var/count_positions = TRUE // Do we add this position's amount for combined total/spawn positions?
 
 /datum/job/doctor
 	relate_job = "Medical Intern"
 	is_relate_positions = TRUE
+
 /datum/job/doctor/intern
 	relate_job = "Medical Doctor"
+	count_positions = FALSE
 
 /datum/job/scientist
 	relate_job = "Student Scientist"
 	is_relate_positions = TRUE
+
 /datum/job/scientist/student
 	relate_job = "Scientist"
+	count_positions = FALSE
 
 /datum/job/engineer
 	relate_job = "Trainee Engineer"
 	is_relate_positions = TRUE
+
 /datum/job/engineer/trainee
 	relate_job = "Station Engineer"
+	count_positions = FALSE
 
 /datum/job/officer
 	relate_job = "Security Cadet"
@@ -33,6 +40,7 @@
 
 /datum/job/officer/cadet
 	relate_job = "Security Officer"
+	count_positions = FALSE
 
 // ==============================
 // PROCS
@@ -65,7 +73,13 @@
 	if(total_positions == -1 || temp.total_positions == -1)
 		return TRUE
 
-	return (current_positions + temp.current_positions < total_positions + temp.total_positions)
+	var/relate_total_positions = 0
+	if(count_positions)
+		relate_total_positions += total_positions
+	if(temp.count_positions)
+		relate_total_positions += temp.total_positions
+
+	return (current_positions + temp.current_positions < relate_total_positions)
 
 /datum/job/proc/check_relate_spawn_positions()
 	var/datum/job/temp = SSjobs.GetJob(relate_job)
@@ -74,7 +88,13 @@
 	if(spawn_positions == -1 || temp.spawn_positions == -1)
 		return TRUE
 
-	return (current_positions + temp.current_positions < spawn_positions + temp.spawn_positions)
+	var/relate_spawn_positions = 0
+	if(count_positions)
+		relate_spawn_positions += spawn_positions
+	if(temp.count_positions)
+		relate_spawn_positions += temp.spawn_positions
+
+	return (current_positions + temp.current_positions < relate_spawn_positions)
 
 /datum/job/proc/check_hidden_from_job_prefs()
 	if(hidden_from_job_prefs)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Теперь трейни джобки работают следующем образом:
* Если в конфиге стоит -1 число, то они могут занимать любое количество слотов ВНУТРИ слотов основы (9 Кадетов из 9 Офицеров)
** Если и основа имеет -1, то может быть любое количество слотов (inf. Кадеты и inf. Офицеры)
* Если в конфиге стоит 0, то нельзя получить эту роль (0 Кадетов из 9 Офицеров)
* Если в конфиге стоит любое другое N число, то это значение отвечает за максимальное количество этих слотов ВНУТРИ слотов основы (N кадетов из 9 офицеров)

Данное ограничение работает ТОЛЬКО на трейни. Всякие "банщики" не были затронуты и имеют свои слоты.