### PR TITLE
Fix: more optimal redis bandaid

### DIFF
--- a/code/controllers/subsystem/SSredis.dm
+++ b/code/controllers/subsystem/SSredis.dm
@@ -67,11 +67,12 @@ SUBSYSTEM_DEF(redis)
 // Redis integration stuff
 /datum/controller/subsystem/redis/proc/connect()
 	if(GLOB.configuration.redis.enabled)
+		/* SS220 REMOVE
 		#ifndef UNIT_TESTS // CI uses linux so dont flag up a fail there
 		if(world.system_type == UNIX)
 			stack_trace("SSredis has known to be very buggy when running on Linux with random dropouts ocurring due to interrupted syscalls. You have been warned!")
 		#endif
-
+		*/
 		var/conn_failed = rustg_redis_connect(GLOB.configuration.redis.connstring)
 		if(conn_failed)
 			log_startup_progress("Failed to connect to redis. Please inform the server host.")

--- a/modular_ss220/redis220/code/tgs_deploy_bandaid.dm
+++ b/modular_ss220/redis220/code/tgs_deploy_bandaid.dm
@@ -1,4 +1,7 @@
 /datum/tgs_event_handler/impl/HandleEvent(event_code, ...)
 	. = ..()
+	if(event_code != TGS_EVENT_DEPLOYMENT_COMPLETE)
+		return
+
 	SSredis.disconnect()
 	SSredis.connect()


### PR DESCRIPTION
Заглушил бесполезный рантайм с предупреждением и теперь перезапускаю редис только при деплоях