### PR TITLE
Paintable multi-tile airlocks

### DIFF
--- a/modular_ss220/objects/_objects.dme
+++ b/modular_ss220/objects/_objects.dme
@@ -45,3 +45,4 @@
 #include "code/flashlight.dm"
 #include "code/material_pouch.dm"
 #include "code/components.dm"
+#include "code\airlock_painter.dm"

--- a/modular_ss220/objects/_objects.dme
+++ b/modular_ss220/objects/_objects.dme
@@ -45,4 +45,4 @@
 #include "code/flashlight.dm"
 #include "code/material_pouch.dm"
 #include "code/components.dm"
-#include "code\airlock_painter.dm"
+#include "code/airlock_painter.dm"

--- a/modular_ss220/objects/code/airlock_painter.dm
+++ b/modular_ss220/objects/code/airlock_painter.dm
@@ -30,7 +30,6 @@
 		return
 
 	var/obj/structure/door_assembly/assembly = initial(airlock.assemblytype)
-
 	if(A.assemblytype == assembly)
 		to_chat(user, "<span class='notice'>This airlock is already painted with the \"[paint_setting]\" color scheme!</span>")
 		return
@@ -41,6 +40,5 @@
 		A.assemblytype = initial(airlock.assemblytype)
 		A.update_icon()
 		return TRUE
-
-	return TRUE
+	return
 

--- a/modular_ss220/objects/code/airlock_painter.dm
+++ b/modular_ss220/objects/code/airlock_painter.dm
@@ -3,16 +3,17 @@
 /obj/machinery/door/airlock/multi_tile
 	paintable = TRUE
 
+// Special behavior for multi-tile airlocks
 /datum/painter/airlock/paint_atom(atom/target, mob/user)
-	if(!istype(target, /obj/machinery/door/airlock/multi_tile))	// Special behavior for multi-tile airlocks
+	if(!istype(target, /obj/machinery/door/airlock/multi_tile))
 		return ..()
 	if(!paint_setting)
-		to_chat(user, "<span class='warning'>You need to select a paintjob first.</span>")
+		to_chat(user, span_warning("Сперва вам нужно выбрать стиль покраски."))
 		return
 
 	var/obj/machinery/door/airlock/A = target
 	if(!A.paintable)
-		to_chat(user, "<span class='warning'>This type of airlock cannot be painted.</span>")
+		to_chat(user, span_warning("Этот тип шлюза не может быть покрашен."))
 		return
 
 	var/static/list/multi_paint_jobs = list(
@@ -26,19 +27,18 @@
 
 	var/obj/machinery/door/airlock/airlock = multi_paint_jobs["[paint_setting]"]
 	if(isnull(airlock))
-		to_chat(user, "<span class='warning'>У выбранного стиля шлюзов нету двойной версии.</span>")
+		to_chat(user, span_warning("У выбранного стиля шлюзов нету двойной версии."))
 		return
 
 	var/obj/structure/door_assembly/assembly = initial(airlock.assemblytype)
 	if(A.assemblytype == assembly)
-		to_chat(user, "<span class='notice'>This airlock is already painted with the \"[paint_setting]\" color scheme!</span>")
+		to_chat(user, span_notice("Этот шлюз уже покрашен в цветовую схему \"[paint_setting]\"!"))
 		return
 
-	if(do_after(user, 2 SECONDS, FALSE, A))
+	if(do_after_once(user, 2 SECONDS, FALSE, A))
 		A.icon = initial(airlock.icon)
 		A.overlays_file = initial(airlock.overlays_file)
 		A.assemblytype = initial(airlock.assemblytype)
 		A.update_icon()
 		return TRUE
 	return
-

--- a/modular_ss220/objects/code/airlock_painter.dm
+++ b/modular_ss220/objects/code/airlock_painter.dm
@@ -3,19 +3,7 @@
 /obj/machinery/door/airlock/multi_tile
 	paintable = TRUE
 
-// Special behavior for multi-tile airlocks
-/datum/painter/airlock/paint_atom(atom/target, mob/user)
-	if(!istype(target, /obj/machinery/door/airlock/multi_tile))
-		return ..()
-	if(!paint_setting)
-		to_chat(user, span_warning("Сперва вам нужно выбрать стиль покраски."))
-		return
-
-	var/obj/machinery/door/airlock/A = target
-	if(!A.paintable)
-		to_chat(user, span_warning("Этот тип шлюза не может быть покрашен."))
-		return
-
+/datum/painter/airlock
 	var/static/list/multi_paint_jobs = list(
 		"Atmospherics" = /obj/machinery/door/airlock/multi_tile/atmospheric,
 		"Command" = /obj/machinery/door/airlock/multi_tile/command,
@@ -24,6 +12,20 @@
 		"Public" = /obj/machinery/door/airlock/multi_tile,
 		"Security" = /obj/machinery/door/airlock/multi_tile/security,
 	)
+
+// Special behavior for multi-tile airlocks
+/datum/painter/airlock/paint_atom(atom/target, mob/user)
+	if(!istype(target, /obj/machinery/door/airlock/multi_tile))
+		return ..()
+
+	if(!paint_setting)
+		to_chat(user, span_warning("Сперва вам нужно выбрать стиль покраски."))
+		return
+
+	var/obj/machinery/door/airlock/A = target
+	if(!A.paintable)
+		to_chat(user, span_warning("Этот тип шлюза не может быть покрашен."))
+		return
 
 	var/obj/machinery/door/airlock/airlock = multi_paint_jobs["[paint_setting]"]
 	if(isnull(airlock))
@@ -41,4 +43,3 @@
 		A.assemblytype = initial(airlock.assemblytype)
 		A.update_icon()
 		return TRUE
-	return

--- a/modular_ss220/objects/code/airlock_painter.dm
+++ b/modular_ss220/objects/code/airlock_painter.dm
@@ -1,0 +1,46 @@
+// Tweak for multi-tile airlocks, to make them paintable
+
+/obj/machinery/door/airlock/multi_tile
+	paintable = TRUE
+
+/datum/painter/airlock/paint_atom(atom/target, mob/user)
+	if(!istype(target, /obj/machinery/door/airlock/multi_tile))	// Special behavior for multi-tile airlocks
+		return ..()
+	if(!paint_setting)
+		to_chat(user, "<span class='warning'>You need to select a paintjob first.</span>")
+		return
+
+	var/obj/machinery/door/airlock/A = target
+	if(!A.paintable)
+		to_chat(user, "<span class='warning'>This type of airlock cannot be painted.</span>")
+		return
+
+	var/static/list/multi_paint_jobs = list(
+		"Atmospherics" = /obj/machinery/door/airlock/multi_tile/atmospheric,
+		"Command" = /obj/machinery/door/airlock/multi_tile/command,
+		"Engineering" = /obj/machinery/door/airlock/multi_tile/engineering,
+		"Mining" = /obj/machinery/door/airlock/multi_tile/supply,
+		"Public" = /obj/machinery/door/airlock/multi_tile,
+		"Security" = /obj/machinery/door/airlock/multi_tile/security,
+	)
+
+	var/obj/machinery/door/airlock/airlock = multi_paint_jobs["[paint_setting]"]
+	if(isnull(airlock))
+		to_chat(user, "<span class='warning'>У выбранного стиля шлюзов нету двойной версии.</span>")
+		return
+
+	var/obj/structure/door_assembly/assembly = initial(airlock.assemblytype)
+
+	if(A.assemblytype == assembly)
+		to_chat(user, "<span class='notice'>This airlock is already painted with the \"[paint_setting]\" color scheme!</span>")
+		return
+
+	if(do_after(user, 2 SECONDS, FALSE, A))
+		A.icon = initial(airlock.icon)
+		A.overlays_file = initial(airlock.overlays_file)
+		A.assemblytype = initial(airlock.assemblytype)
+		A.update_icon()
+		return TRUE
+
+	return TRUE
+


### PR DESCRIPTION
## Что этот PR делает

Добавляет возможность использовать краситель шлюзов на двойных шлюзах. При выборе стилей, у которых нету спрайтов двойных шлюзов выводит сообщение об этом пользователю.

## Почему это хорошо для игры

Больше кастомизации при строительстве.

## Изображения изменений

![image](https://github.com/ss220club/Paradise-SS220/assets/69719123/fb602e67-f08b-4c6a-93d7-c6a57aa207a1)

## Тестирование

Пробежался на локалочке, всё покрасил, всё красивенько. Багов не заметил.

## Changelog

:cl:
tweak: Двойные шлюзы теперь можно красить (но только в определённые стили).
/:cl:
