### PR TITLE
Debuff spacecash of VIP and Banker

### DIFF
--- a/modular_ss220/jobs/code/donor/job/5_tier_jobs.dm
+++ b/modular_ss220/jobs/code/donor/job/5_tier_jobs.dm
@@ -28,7 +28,7 @@
 	box = /obj/item/storage/box/engineer
 	id = /obj/item/card/id/vip_guest
 	backpack_contents = list(
-		/obj/item/stack/spacecash/c1000 = 2,
+		/obj/item/stack/spacecash/c1000 = 1,
 		/obj/item/bio_chip_implanter/death_alarm = 1,
 		/obj/item/lighter/zippo/engraved = 1,
 		/obj/item/clothing/mask/cigarette/cigar/havana = 6,
@@ -74,8 +74,7 @@
 	box = /obj/item/storage/box/engineer
 	id = /obj/item/card/id/banker
 	backpack_contents = list(
-		/obj/item/stack/spacecash/c1000 = 5,
-
+		/obj/item/stack/spacecash/c1000 = 1,
 		/obj/item/bio_chip_implanter/death_alarm = 1,
 		/obj/item/lighter/zippo/engraved = 1,
 		/obj/item/clothing/under/rank/procedure/iaa/formal/black = 1,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Дебаффает количество кэша у банкира и випа. К сожалению заменить деньги на хорошую зарплату я не смог так как не разобрался по итогу как это сделать.

## Почему это хорошо для игры
Игроки, которые раундстартом могут скупить карго, особенно при войне - это пиздец. Не забывайте что у них еще имеется раундстарт кэш на аккаунте.
Отдельно про банкира. Это роль, которая
а) ни разу не пользовались при мне по назначению, единственный раз я его застал в использовании в качестве торгаша - объективно выставляя торгаша в роль помойки.
б) имеет кол-во кэша больше чем у капитана и хранилища вместе взятые (раундстартом).
По хорошему Банкир должен быть вырезан/отключён, но мне жалко вырезать его, поэтому сделано так, как сделано.

## Changelog

:cl:
tweak: У роли Banker и VIP Corporate Guest понижен стартовый кэш. Banker 5к -> 1к, VIP 2к -> 1к.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
