### PR TITLE
Fix bad Necropolis crate

### DIFF
--- a/_maps/map_files220/generic/Lavaland.dmm
+++ b/_maps/map_files220/generic/Lavaland.dmm
@@ -10017,7 +10017,7 @@
 /obj/structure/stone_tile{
 	dir = 8
 	},
-/obj/structure/closet/crate/necropolis,
+/obj/structure/closet/crate/necropolis/tendril,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "RJ" = (


### PR DESCRIPTION
## Что этот PR делает
Заменяет пустой сундук на нормальный в Некрополисе

## Changelog

:cl:
fix: Пустой сундук в Некрополисе больше не пустой
/:cl:

