### PR TITLE
[FIX] Whiteship invisible medical gear closet

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/whiteship.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/whiteship.dmm
@@ -1074,7 +1074,7 @@
 /area/shuttle/abandoned)
 "Ag" = (
 /obj/structure/closet{
-	icon_closed = "white";
+	icon_opened = "generic_open";
 	icon_state = "white";
 	name = "Medical gear"
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Чинит пропадающий при открытии спрайт шкафа Medical gear на вайтшипе
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Тестирование
Открыл шкаф - он не исчез!!
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Спрайт шкафа Medical gear на вайтшипе больше не пропадает при открытии
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
