### PR TITLE
Add some buttons to title screen for admins

### DIFF
--- a/modular_ss220/title_screen/code/new_player.dm
+++ b/modular_ss220/title_screen/code/new_player.dm
@@ -41,6 +41,10 @@
 	else if(href_list["changelog"])
 		SSchangelog.OpenChangelog(client)
 
+	else if(href_list["focus"])
+		winset(client, "paramapwindow.map", "focus=true")
+		return
+
 /mob/new_player/proc/swap_server()
 	var/list/servers =  GLOB.configuration.ss220_misc.cross_server_list
 	if(length(servers) == 0)

--- a/modular_ss220/title_screen/code/new_player.dm
+++ b/modular_ss220/title_screen/code/new_player.dm
@@ -19,6 +19,12 @@
 	else if(href_list["game_preferences"])
 		client.setup_character()
 
+	else if(href_list["change_picture"])
+		client.admin_change_title_screen()
+
+	else if(href_list["leave_notice"])
+		client.change_title_screen_notice()
+
 	else if(href_list["swap_server"])
 		swap_server()
 

--- a/modular_ss220/title_screen/code/title_screen_controls.dm
+++ b/modular_ss220/title_screen/code/title_screen_controls.dm
@@ -11,16 +11,16 @@
 	log_admin("[key_name(usr)] is changing the title screen.")
 	message_admins("[key_name_admin(usr)] is changing the title screen.")
 
-	switch(alert(usr, "Please select a new title screen.", "Title Screen", "Change", "Reset", "Cancel"))
-		if("Change")
+	switch(tgui_alert(usr, "Что делаем с изображением в лобби?", "Лобби", list("Меняем", "Сбрасываем", "Ничего")))
+		if("Меняем")
 			var/file = input(usr) as icon|null
 			if(!file)
 				return
 
 			SStitle.set_title_image(file)
-		if("Reset")
+		if("Сбрасываем")
 			SStitle.set_title_image()
-		if("Cancel")
+		if("Ничего")
 			return
 
 /**
@@ -36,12 +36,13 @@
 	log_admin("[key_name(usr)] is setting the title screen notice.")
 	message_admins("[key_name_admin(usr)] is setting the title screen notice.")
 
-	var/new_notice = input(usr, "Please input a notice to be displayed on the title screen:", "Titlescreen Notice") as text|null
-	SStitle.set_notice(new_notice)
-	if(!new_notice)
+	var/new_notice = tgui_input_text(usr, "Введи то что должно отображаться в лобби:", "Уведомление в лобби")
+	if(isnull(new_notice))
 		return
+
+	SStitle.set_notice(new_notice)
 	for(var/mob/new_player/new_player in GLOB.player_list)
-		to_chat(new_player, span_boldannounce("TITLE NOTICE UPDATED: [new_notice]"))
+		to_chat(new_player, span_boldannounce("УВЕДОМЛЕНИЕ В ЛОББИ ОБНОВЛЕНО: [new_notice]"))
 		SEND_SOUND(new_player,  sound('sound/items/bikehorn.ogg'))
 
 /**
@@ -70,11 +71,12 @@
 	log_admin("[key_name(usr)] is setting the title screen HTML.")
 	message_admins("[key_name_admin(usr)] is setting the title screen HTML.")
 
-	var/new_html = input(usr, "Please enter your desired HTML(WARNING: YOU WILL BREAK SHIT)", "DANGER: TITLE HTML EDIT") as message|null
+	var/new_html = tgui_input_text(usr, "Введи нужный HTML (ВНИМАНИЕ: ТЫ СКОРЕЕ ВСЕГО ЧТО-ТО СЛОМАЕШЬ!!!)", "РИСКОВАННО: ИЗМЕНЕНИЕ HTML ЛОББИ", max_length = 99999, multiline = TRUE, encode = FALSE)
+	if(isnull(new_html))
+		return
 
-	if(!new_html)
+	if(tgui_alert(usr, "Всё ли верно? Нигде не ошибся? Возврата нет!", "Ты подумай...", list("Рискнём", "Пожалуй нет...")) != "Рискнём")
 		return
 
 	SStitle.set_title_html(new_html)
-
 	message_admins("[key_name_admin(usr)] has changed the title screen HTML.")

--- a/modular_ss220/title_screen/code/title_screen_datum.dm
+++ b/modular_ss220/title_screen/code/title_screen_datum.dm
@@ -88,9 +88,20 @@
 		<a class="menu_button" href='byond://?src=[player.UID()];show_preferences=1'>Настройка персонажа</a>
 		<a class="menu_button" href='byond://?src=[player.UID()];game_preferences=1'>Настройки игры</a>
 		<hr>
-		<a class="menu_button" href='byond://?src=[player.UID()];swap_server=1'>Сменить сервер</a>
 	"}
-	html += {"</div>"}
+
+	if(check_rights_client(R_EVENT, FALSE, viewer))
+		html += {"
+			<a class="menu_button admin" href='byond://?src=[player.UID()];change_picture=1'>Изменить изображение</a>
+			<a class="menu_button admin" href='byond://?src=[player.UID()];leave_notice=1'>Оставить уведомление</a>
+			<hr>
+		"}
+
+	html += {"
+		<a class="menu_button" href='byond://?src=[player.UID()];swap_server=1'>Сменить сервер</a>
+		</div>
+	"}
+
 	html += {"
 		<div class="container_links">
 			<a class="link_button" href='byond://?src=[player.UID()];wiki=1'><i class="fab fa-wikipedia-w"></i></a>

--- a/modular_ss220/title_screen/code/title_screen_datum.dm
+++ b/modular_ss220/title_screen/code/title_screen_datum.dm
@@ -52,7 +52,7 @@
 
 	var/screen_image_url = SSassets.transport.get_asset_url(asset_cache_item = screen_image)
 	if(screen_image_url)
-		html += {"<img src="[screen_image_url]" class="bg" alt="">"}
+		html += {"<img class="bg" src="[screen_image_url]">"}
 
 	if(notice)
 		html += {"
@@ -156,6 +156,16 @@
 			function update_current_character(name) {
 				character_name_slot.textContent = name;
 			}
+
+			/* Return focus to Byond after click */
+			function reFocus() {
+				var focus = new XMLHttpRequest();
+				focus.open("GET", "?src=[player.UID()];focus=1");
+				focus.send();
+			}
+
+			document.addEventListener('mouseup', reFocus);
+			document.addEventListener('keyup', reFocus);
 		</script>
 		"}
 

--- a/modular_ss220/title_screen/html/title_screen.html
+++ b/modular_ss220/title_screen/html/title_screen.html
@@ -30,7 +30,7 @@
 				-ms-user-select: none;
 				user-select: none;
 				cursor: default;
-				position: relative;
+				position: static;
 				width: 100%;
 				height: 100%;
 				margin: 0;

--- a/modular_ss220/title_screen/html/title_screen.html
+++ b/modular_ss220/title_screen/html/title_screen.html
@@ -35,6 +35,14 @@
 				height: 100%;
 				margin: 0;
 				background-color: black;
+				scrollbar-base-color: #1c1c1c;
+				scrollbar-face-color: #3b3b3b;
+				scrollbar-3dlight-color: #252525;
+				scrollbar-highlight-color: #252525;
+				scrollbar-track-color: #1c1c1c;
+				scrollbar-arrow-color: #929292;
+				scrollbar-shadow-color: #3b3b3b;
+				scrollbar-color: #363636 #181818;
 			}
 
 			img {
@@ -167,6 +175,7 @@
 
 			.container_buttons {
 				flex: 1;
+				overflow: auto;
 				text-align: left;
 				margin: 0.5em 0.5em 0.5em 0
 			}
@@ -192,12 +201,12 @@
 			.menu_button::before {
 				content: '';
 				position: absolute;
-				top: 50%;
+				bottom: 50%;
 				left: 0;
 				width: 2px;
 				height: 0;
 				background-color: #d4dfec;
-				transform: translateY(-50%);
+				transform: translateY(50%);
 				transition: height 0.2s, background-color 0.2s;
 			}
 

--- a/modular_ss220/title_screen/html/title_screen.html
+++ b/modular_ss220/title_screen/html/title_screen.html
@@ -235,6 +235,14 @@
 				background-color: #d93f3f;
 			}
 
+			.admin:hover {
+				color: #f5b52b;
+			}
+
+			.admin::before {
+				background-color: #f2a918;
+			}
+
 			.container_links {
 				display: flex;
 			}

--- a/modular_ss220/title_screen/html/title_screen.html
+++ b/modular_ss220/title_screen/html/title_screen.html
@@ -81,7 +81,7 @@
 				left: 20em;
 				background-color: rgba(22, 22, 22, 0.85);
 				border-top: 1px solid rgba(255, 255, 255, 0.1);
-				transition: left 0.2s, padding 0.2s;
+				transition: left 0.2s, width 0.2s;
 				backdrop-filter: blur(24px);
 				z-index: 1;
 			}


### PR DESCRIPTION
## Что этот PR делает
Добавил 2 кнопки в лобби для админов, можно быстро менять пикчу или нотис

## Почему это хорошо для игры
Удобно

## Изображения изменений
![image](https://github.com/user-attachments/assets/c9153685-16ed-4fca-890b-b0449697ea30)

## Changelog

:cl:
add: Админам накинули 2 кнопки прямо в лобби: сменить арт в лобби и оставить уведомление там же.
tweak: Для тех у кого ну слишком маленький экран, добавлен скроллбар для пролистывания кнопочек
fix: В лобби больше ничего не должно скроллится по приколу
/:cl:
