### PR TITLE
Improve paradise_schema.sql

### DIFF
--- a/SQL/paradise_schema.sql
+++ b/SQL/paradise_schema.sql
@@ -710,4 +710,4 @@ CREATE TABLE `budget` (
 # Updating DB from 53.220.5 to 53.220.6
 # Adds species whitelist ~legendaxe
 
-ALTER TABLE `player` ADD `species_whitelist` JSON COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '["human"]';
+ALTER TABLE `player` ADD `species_whitelist` LONGTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ('["human"]');

--- a/SQL/updates220/53.220.5-53.220.6.sql
+++ b/SQL/updates220/53.220.5-53.220.6.sql
@@ -1,4 +1,4 @@
 # Updating DB from 53.220.5 to 53.220.6
 # Adds species whitelist ~legendaxe
 
-ALTER TABLE `player` ADD `species_whitelist` LONGTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '["human"]';
+ALTER TABLE `player` ADD `species_whitelist` LONGTEXT COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ('["human"]');


### PR DESCRIPTION
## Что этот PR делает
Перемещает все модификации схемы в конец скрипта и добавляет недостающие, но уже примененные.
Думаю, не содержит действительных изменений. Актуальную БД модифицировать не придется.

## Почему это хорошо для игры
Меньше конфликтов.

## Тестирование
Все таблицы и столбцы оказались в наличии в тестовой БД.

## Changelog

Не понадобился
