### PR TITLE
[FIX] Multiaction keybinding

### DIFF
--- a/modular_ss220/keybindings/code/mob_keybinds.dm
+++ b/modular_ss220/keybindings/code/mob_keybinds.dm
@@ -1,6 +1,6 @@
 /datum/keybinding/mob/use_held_object
 	name = "Использовать вещь в руке"
-	keys = list("Y", "Z", "Southeast")
+	keys = list("Z", "Southeast")
 
 /datum/keybinding/mob/equip_held_object
 	name = "Экипировать вещь"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
В общем то закрывает вот этот ишуй https://github.com/ss220club/Paradise-SS220/issues/1218#issue-2291282636
Клавиша, (по дефолту) отвечающая за рацию, теперь не активирует предмет одновременно с этим
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Тестирование
Потыкал гранаты и разные айтемы как на видосе

## Changelog

:cl:
fix: Клавиша, по умолчанию отвечающая за рацию, теперь не активирует предмет в руке
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
