### PR TITLE
Fix title screen preferences tab

### DIFF
--- a/modular_ss220/title_screen/code/new_player.dm
+++ b/modular_ss220/title_screen/code/new_player.dm
@@ -16,8 +16,13 @@
 	else if(href_list["skip_antag"])
 		client << output(client.skip_antag, "title_browser:skip_antag")
 
+	else if(href_list["char_preferences"])
+		client.prefs.current_tab = TAB_CHAR
+		client.prefs.ShowChoices(user)
+
 	else if(href_list["game_preferences"])
-		client.setup_character()
+		client.prefs.current_tab = TAB_GAME
+		client.prefs.ShowChoices(user)
 
 	else if(href_list["change_picture"])
 		client.admin_change_title_screen()

--- a/modular_ss220/title_screen/code/title_screen_datum.dm
+++ b/modular_ss220/title_screen/code/title_screen_datum.dm
@@ -85,7 +85,7 @@
 	html += {"
 		<hr>
 		<a class="menu_button [viewer.skip_antag ? "bad" : "good"]" id="be_antag" href='byond://?src=[player.UID()];skip_antag=1'>[viewer.skip_antag ? "Антагонисты: Выкл." : "Антагонисты: Вкл."]</a>
-		<a class="menu_button" href='byond://?src=[player.UID()];show_preferences=1'>Настройка персонажа</a>
+		<a class="menu_button" href='byond://?src=[player.UID()];char_preferences=1'>Настройка персонажа</a>
 		<a class="menu_button" href='byond://?src=[player.UID()];game_preferences=1'>Настройки игры</a>
 		<hr>
 	"}


### PR DESCRIPTION
## Что этот PR делает
При открытии настроек игры а потом перса, не будет настроек игры

## Changelog

:cl:
fix: Кнопки настроек в лобби теперь работают как надо
/:cl:


