### PR TITLE
Move 'Change voice' verb to existing tab

### DIFF
--- a/modular_ss220/text_to_speech/code/tts_component.dm
+++ b/modular_ss220/text_to_speech/code/tts_component.dm
@@ -208,5 +208,5 @@
 /mob/living/silicon/verb/synth_change_voice()
 	set name = "Смена голоса"
 	set desc = "Express yourself!"
-	set category = "Subsystems"
+	set category = "Подсистемы"
 	change_tts_seed(src, fancy_voice_input_tgui = TRUE, new_traits = list(TTS_TRAIT_ROBOTIZE))


### PR DESCRIPTION
## Что этот PR делает
Перемещает verb "Смена голоса" во вкладку "Подсистемы" для киборгов/ИИ. Сейчас вкладки две с одинаковыми названиями, в одной из которых лежит только этот verb.

## Почему это хорошо для игры
Меньше вкладок - кайф.

## Тестирование

![image](https://github.com/user-attachments/assets/78ffb7e3-6219-4c3b-87fd-53e650b9f9ac)

## Changelog

:cl: Maxiemar
tweak: Вкладки Subsystems и Подсистемы в статус панели теперь объединены.
/:cl:
