### PR TITLE
Chemistry Request Consoles

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -22545,7 +22545,8 @@
 	department = "Medbay";
 	departmentType = 1;
 	name = "Chemistry Requests Console";
-	pixel_x = -30
+	pixel_x = -30;
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -22541,6 +22541,12 @@
 	c_tag = "Medbay Chemistry";
 	dir = 4
 	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Chemistry Requests Console";
+	pixel_x = -30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteyellow"

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -42747,6 +42747,12 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
+/obj/machinery/requests_console{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Chemistry Requests Console";
+	pixel_y = -30
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellow"
 	},
@@ -115470,12 +115476,6 @@
 /area/station/maintenance/port)
 "xJh" = (
 /obj/machinery/smartfridge/secure/chemistry,
-/obj/machinery/requests_console{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Chemistry Requests Console";
-	pixel_y = -30
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellow"
 	},


### PR DESCRIPTION
## Что этот PR делает
Добавляет недостающую консоль на коробку.
Двигает консоль на дельте чуть в сторону, а то че она за холодильником прячется.

## Почему это хорошо для игры
Меня попросили.

## Изображения изменений
mapdiff

## Тестирование
Не было

## Changelog

:cl: Maxiemar
fix: Недостающая консоль запросов добавлена в химию меда на Кибериаде.
/:cl:
