### PR TITLE
Rough fix for wooden decals

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -245,7 +245,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table/wood/fancy/black,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 6
 	},
 /turf/simulated/floor/carpet/red,
@@ -347,7 +347,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/cherry/end,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
 "akc" = (
@@ -487,7 +487,7 @@
 /obj/structure/table/reinforced{
 	color = "#444444"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/red,
@@ -902,7 +902,7 @@
 /obj/structure/chair/sofa/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -1701,12 +1701,6 @@
 /obj/item/food/frozen/popsicle/orangecream,
 /turf/simulated/floor/plasteel/white,
 /area/centcom/ss220/evac)
-"aVi" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
-	dir = 8
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/centcom/ss220/admin1)
 "aVm" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -2251,7 +2245,7 @@
 /turf/simulated/floor/plating/abductor,
 /area/abductor_ship)
 "biq" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -2323,7 +2317,7 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "bjD" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/carpet/royalblack,
@@ -2385,7 +2379,7 @@
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
 "bkV" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -2772,13 +2766,13 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/general)
 "buk" = (
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "bux" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green,
@@ -2945,7 +2939,7 @@
 	},
 /area/centcom/ss220/admin3)
 "bAK" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
 "bBd" = (
@@ -3103,7 +3097,7 @@
 	},
 /area/centcom/ss220/admin1)
 "bGg" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -3324,7 +3318,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/end,
 /obj/structure/rack/gunrack{
 	color = "grey"
 	},
@@ -3547,7 +3541,7 @@
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "bRD" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -4455,7 +4449,7 @@
 	},
 /area/centcom/ss220/admin3)
 "ckR" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/green,
@@ -4788,7 +4782,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ghost_bar)
 "csN" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -5214,10 +5208,10 @@
 	name = "Офисы";
 	req_one_access_txt = "101"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -5424,10 +5418,10 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/railing{
@@ -5811,10 +5805,10 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/vox)
 "cYE" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/door/poddoor/impassable{
 	id_tag = "syndFB_teleport1"
 	},
@@ -6283,10 +6277,10 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -6359,10 +6353,10 @@
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -6555,7 +6549,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
 "dpr" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -7227,7 +7221,7 @@
 /area/ghost_bar)
 "dDG" = (
 /obj/machinery/economy/vending/snack/free,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -7664,7 +7658,7 @@
 "dPy" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -7835,10 +7829,10 @@
 	name = "Переход в Отдел Специальных Операций";
 	req_access_txt = "114"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -8398,7 +8392,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/command)
 "enr" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -8539,7 +8533,7 @@
 /area/centcom/ss220/supply)
 "eqK" = (
 /obj/structure/decorative_structures/metal/statue/golden_disk,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 5
 	},
 /turf/simulated/floor/carpet/red,
@@ -9124,8 +9118,8 @@
 /obj/machinery/door/airlock/titanium/glass{
 	req_one_access_txt = "160"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/birch,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -9455,7 +9449,7 @@
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
 "eJJ" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /obj/structure/railing/cap/reversed{
 	dir = 8
 	},
@@ -9487,7 +9481,7 @@
 	},
 /area/shuttle/administration)
 "eMo" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
 	name = "UNKNOWN"
@@ -9726,7 +9720,7 @@
 "eSA" = (
 /obj/structure/table/glass,
 /obj/item/toy/hampter/deadsquad,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -9832,10 +9826,10 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/structure/railing{
@@ -9946,8 +9940,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "eYi" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/door/airlock/titanium{
@@ -10283,7 +10277,7 @@
 	},
 /area/syndicate_mothership/jail)
 "ffE" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /obj/item/kirbyplants,
@@ -11462,7 +11456,7 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/elite_squad)
 "fDq" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -11949,7 +11943,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/end,
 /obj/structure/railing{
 	dir = 8;
 	color = "#36454F"
@@ -11959,7 +11953,7 @@
 "fRY" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/decorations/sticky_decorations/flammable/pot_of_gold,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /obj/structure/curtain/black{
@@ -12565,7 +12559,7 @@
 /turf/simulated/floor/wood,
 /area/centcom/ss220/court)
 "gnt" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
 /obj/machinery/computer/shuttle/trade/sol{
@@ -13074,6 +13068,12 @@
 	name = "vox floor"
 	},
 /area/shuttle/vox)
+"gBI" = (
+/obj/effect/turf_decal/siding/wood/oak/corner{
+	dir = 8
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/centcom/ss220/admin1)
 "gBL" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 9;
@@ -13373,7 +13373,7 @@
 	},
 /area/centcom/ss220/admin2)
 "gJX" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
 "gKg" = (
@@ -13873,7 +13873,7 @@
 /obj/structure/table/reinforced{
 	color = "#444444"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 9
 	},
 /turf/simulated/floor/carpet/red,
@@ -14258,7 +14258,7 @@
 /obj/structure/light_fake/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "heP" = (
@@ -14270,7 +14270,7 @@
 /area/centcom/ss220/admin1)
 "heR" = (
 /obj/structure/chair/sofa/left,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -14328,8 +14328,8 @@
 	},
 /area/centcom/ss220/admin3)
 "hgx" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -14354,10 +14354,10 @@
 	name = "Отдел кадров";
 	req_one_access_txt = "101"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -14413,7 +14413,7 @@
 /turf/simulated/floor/carpet/black,
 /area/ghost_bar)
 "hiV" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -14458,10 +14458,10 @@
 	name = "Конференц Зал";
 	req_one_access_txt = "101"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -14689,8 +14689,8 @@
 	},
 /area/centcom/ss220/admin1)
 "hqU" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/newscaster/security_unit{
@@ -14825,7 +14825,7 @@
 /turf/simulated/wall/indestructible/fakeglass,
 /area/ninja/holding)
 "hsv" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -15085,7 +15085,7 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "hAC" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -15179,7 +15179,7 @@
 	},
 /area/ninja/holding)
 "hCS" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -15419,7 +15419,7 @@
 	color = "#36373a";
 	anchored = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/cherry/end,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
 "hIM" = (
@@ -15485,7 +15485,7 @@
 /obj/structure/table/reinforced{
 	color = "#444444"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 5
 	},
 /turf/simulated/floor/carpet/red,
@@ -15940,7 +15940,7 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
 "hSN" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/plasteel{
@@ -16790,7 +16790,7 @@
 	},
 /area/syndicate_mothership)
 "ipu" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -16813,7 +16813,7 @@
 	},
 /area/centcom/ss220/court)
 "ipZ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -16980,7 +16980,7 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "itk" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 1;
 	name = "Хранилище Канцелярии"
@@ -17032,7 +17032,7 @@
 /area/shuttle/administration)
 "iuT" = (
 /obj/structure/light_fake/small,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -17396,7 +17396,7 @@
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
 "iFp" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -18169,7 +18169,7 @@
 /area/centcom/ss220/admin1)
 "jdM" = (
 /obj/structure/light_fake/small,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -18450,7 +18450,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -18487,10 +18487,10 @@
 	},
 /area/ghost_bar)
 "jnv" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /obj/machinery/door/airlock/titanium/glass{
@@ -19141,7 +19141,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/structure/rack/gunrack{
@@ -19433,7 +19433,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/court)
 "jLT" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -19762,7 +19762,7 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -19877,7 +19877,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
 "jXy" = (
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/cherry/end,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
 "jXI" = (
@@ -20277,7 +20277,7 @@
 	pixel_x = 4;
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 10
 	},
 /turf/simulated/floor/carpet/red,
@@ -20305,10 +20305,10 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/shuttle/vox)
 "kkM" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/impassable{
@@ -20342,7 +20342,7 @@
 	},
 /area/centcom/ss220/evac)
 "klj" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/carpet/royalblack,
@@ -20687,10 +20687,10 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "kuJ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/airlock/hatch/syndicate/command,
@@ -20700,7 +20700,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -21112,7 +21112,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
 "kFg" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -21146,10 +21146,10 @@
 	name = "Переход в Отдел Специальных Операций";
 	req_one_access_txt = "114"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -21259,8 +21259,8 @@
 	},
 /area/centcom/ss220/admin3)
 "kHF" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -21332,10 +21332,10 @@
 /turf/simulated/floor/plating,
 /area/shuttle/syndicate_sit)
 "kJc" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -21954,7 +21954,7 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
 "kXO" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
 "kXP" = (
@@ -22373,7 +22373,7 @@
 "liW" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/drinks/trophy/gold_cup,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /obj/structure/curtain/black{
@@ -22383,10 +22383,10 @@
 /turf/simulated/floor/carpet/red,
 /area/syndicate_mothership/control)
 "ljl" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/impassable{
@@ -22449,7 +22449,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/structure/chair/comfy/corp{
@@ -22470,7 +22470,7 @@
 	},
 /area/syndicate_mothership)
 "lkA" = (
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 4
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -22878,7 +22878,7 @@
 /obj/structure/sign/bobross{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "luO" = (
@@ -23312,7 +23312,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/administration)
 "lFy" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/cherry/corner,
 /obj/structure/table/wood/fancy/orange,
 /turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
@@ -23354,7 +23354,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "lGX" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -23384,7 +23384,7 @@
 	},
 /area/trader_station/sol)
 "lIT" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/carpet/green,
@@ -23491,7 +23491,7 @@
 /turf/simulated/floor/engine,
 /area/centcom/ss220/medbay)
 "lLh" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
@@ -24092,10 +24092,10 @@
 /obj/machinery/door/airlock/titanium{
 	req_one_access_txt = "160"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/birch{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/birch{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -25188,7 +25188,7 @@
 /turf/simulated/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "mEk" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -25250,7 +25250,7 @@
 /obj/structure/chair/sofa/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -25405,7 +25405,7 @@
 	pixel_y = 7
 	},
 /obj/item/stack/sheet/mineral/gold,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /obj/structure/curtain/black{
@@ -25480,10 +25480,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ninja/outpost)
 "mNS" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -25699,10 +25699,10 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/item/kirbyplants,
@@ -25723,7 +25723,7 @@
 /area/centcom/ss220/evac)
 "mUc" = (
 /obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -25877,7 +25877,7 @@
 	name = "Борщ";
 	pixel_y = 16
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 9
 	},
 /obj/item/stack/spacecash{
@@ -25962,7 +25962,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
 "nbn" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -26875,7 +26875,7 @@
 	pixel_y = 10
 	},
 /obj/item/clothing/gloves/ring/gold,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /obj/structure/curtain/black{
@@ -27100,7 +27100,7 @@
 /area/syndicate_mothership/outside)
 "nGl" = (
 /obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -27750,7 +27750,7 @@
 /obj/structure/light_fake/spot{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -27802,10 +27802,10 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -27822,8 +27822,8 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/elite_squad)
 "nXd" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/newscaster/security_unit{
@@ -27993,7 +27993,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/end,
 /obj/structure/railing{
 	color = "#36454F";
 	dir = 10
@@ -28247,6 +28247,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/infteam)
+"olS" = (
+/obj/effect/turf_decal/siding/wood/oak/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/centcom/ss220/admin1)
 "olV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -29038,7 +29044,7 @@
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
 "oGg" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/carpet/green,
@@ -29060,7 +29066,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/centcom/ss220/general)
 "oGz" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -29431,12 +29437,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
-"oPs" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
-	dir = 1
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/centcom/ss220/admin1)
 "oPt" = (
 /obj/structure/table/glass/reinforced/titanium,
 /obj/item/soap/deluxe{
@@ -29815,7 +29815,7 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/vox_base)
 "oYc" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -30244,13 +30244,13 @@
 	},
 /area/centcom/ss220/medbay)
 "pkq" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/impassable{
@@ -30290,10 +30290,10 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership)
 "pmc" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -30970,7 +30970,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/structure/railing{
@@ -31061,7 +31061,7 @@
 /turf/simulated/floor/carpet/black,
 /area/wizard_station)
 "pKe" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -32479,10 +32479,10 @@
 	},
 /area/centcom/ss220/admin3)
 "qyb" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/machinery/door/airlock/hatch/syndicate/vault{
@@ -32997,10 +32997,10 @@
 	},
 /area/centcom/ss220/admin3)
 "qLd" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /obj/machinery/door/airlock/titanium/glass{
@@ -33025,7 +33025,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /obj/structure/sign/flag/nanotrasen{
@@ -33687,7 +33687,7 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "rdO" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/carpet/green,
@@ -34119,7 +34119,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/structure/railing{
@@ -34291,10 +34291,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "rsJ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/airlock/hatch/syndicate/command,
@@ -34490,7 +34490,7 @@
 /obj/item/clothing/suit/space/deathsquad/officer/soo_brown,
 /obj/item/clothing/suit/space/deathsquad/officer/soo_brown,
 /obj/item/clothing/suit/space/deathsquad/officer/soo_brown,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /obj/item/clothing/mask/holo_cigar,
@@ -34584,7 +34584,7 @@
 	},
 /area/centcom/ss220/admin3)
 "rvX" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
@@ -34822,10 +34822,10 @@
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
 "rDJ" = (
@@ -34980,7 +34980,7 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "rIg" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -35002,7 +35002,7 @@
 	},
 /area/vox_base)
 "rJo" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -35029,10 +35029,10 @@
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -35194,10 +35194,10 @@
 	start_showpiece_type = /obj/item/gun/projectile/revolver/mateba;
 	pixel_y = 7
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -35389,7 +35389,7 @@
 /obj/structure/sign/nuke{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/simulated/floor/wood/parquet/tile,
@@ -35448,7 +35448,7 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "rTz" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/carpet/green,
@@ -35601,7 +35601,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/end,
 /obj/structure/railing{
 	color = "#36454F";
 	dir = 4
@@ -36485,10 +36485,10 @@
 	name = "Конференц Зал";
 	req_one_access_txt = "101"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -36523,7 +36523,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/structure/light_fake/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -36880,7 +36880,7 @@
 	},
 /area/vox_base)
 "sHJ" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -37264,7 +37264,7 @@
 /obj/item/documents/syndicate/yellow,
 /obj/item/documents/syndicate/yellow/trapped,
 /obj/item/documents/syndicate,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /obj/structure/curtain/black{
@@ -37304,7 +37304,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/structure/railing{
@@ -37784,7 +37784,7 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "tbe" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /obj/item/kirbyplants,
@@ -37892,7 +37892,7 @@
 /area/shuttle/escape)
 "tdd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -38190,8 +38190,8 @@
 	},
 /area/syndicate_mothership)
 "toU" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -38646,7 +38646,7 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/end,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "tAi" = (
@@ -38668,10 +38668,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin2)
 "tAH" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/poddoor/impassable{
@@ -38694,10 +38694,10 @@
 	},
 /area/syndicate_mothership/cargo)
 "tAO" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -38802,7 +38802,7 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "tCk" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -38891,10 +38891,10 @@
 /area/syndicate_mothership/infteam)
 "tFD" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -38906,10 +38906,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin1)
 "tHa" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/machinery/door/airlock/hatch/syndicate/vault{
@@ -39026,10 +39026,10 @@
 	},
 /area/centcom/ss220/command)
 "tIT" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
 "tIW" = (
@@ -39087,10 +39087,10 @@
 /obj/machinery/door/airlock/titanium/glass{
 	req_one_access_txt = "160"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/birch{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/carpet/orange,
 /area/shuttle/trade/sol)
@@ -39207,10 +39207,10 @@
 	},
 /area/shuttle/vox)
 "tOi" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -39579,7 +39579,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
 /obj/structure/mirror/magic{
@@ -39587,7 +39587,7 @@
 	name = "mirror";
 	pixel_x = 28
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "tWx" = (
 /obj/machinery/computer/bsa_control/admin,
@@ -39955,7 +39955,7 @@
 	},
 /area/centcom/ss220/court)
 "ujQ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/carpet/royalblue,
@@ -40228,7 +40228,7 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/end,
 /obj/item/kirbyplants,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
@@ -41522,10 +41522,10 @@
 	},
 /area/shuttle/vox)
 "vaw" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
 "vaH" = (
@@ -41546,7 +41546,7 @@
 	},
 /area/syndicate_mothership/jail)
 "vbh" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/structure/railing/cap/normal{
@@ -42334,10 +42334,10 @@
 	owner = "NNC"
 	},
 /obj/item/folder/yellow,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "vud" = (
@@ -42689,10 +42689,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "vyE" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -43044,7 +43044,7 @@
 /obj/item/clothing/accessory/medal/gold{
 	pixel_y = 9
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/amaranth{
 	dir = 1
 	},
 /obj/structure/curtain/black{
@@ -43192,7 +43192,7 @@
 /area/syndicate_mothership/cargo)
 "vPu" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/plasteel{
 	icon_state = "grimy"
 	},
@@ -43516,7 +43516,7 @@
 /area/vox_base)
 "vYw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -44021,8 +44021,8 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)
 "wlr" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/chair/sofa/corp/right{
@@ -44070,7 +44070,7 @@
 	},
 /area/centcom/ss220/medbay)
 "wmd" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "wmh" = (
@@ -44147,7 +44147,7 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "woC" = (
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -44182,8 +44182,8 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "wqP" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/chair/sofa/corp/left{
@@ -44404,10 +44404,10 @@
 	req_one_access_txt = "160";
 	id_tag = "soltrader_north"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/birch{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/carpet/orange,
 /area/shuttle/trade/sol)
@@ -44834,7 +44834,7 @@
 /area/centcom/ss220/command)
 "wDE" = (
 /obj/machinery/economy/vending/cigarette/free,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -45728,10 +45728,10 @@
 	name = "Переход в Отдел Специальных Операций";
 	req_access_txt = "114"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -45902,10 +45902,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin3)
 "xfQ" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -45958,13 +45958,13 @@
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/item/kirbyplants{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/light_fake/small{
@@ -45974,7 +45974,7 @@
 /area/centcom/ss220/admin2)
 "xie" = (
 /obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -46571,8 +46571,8 @@
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Syndicate Base"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -46604,7 +46604,7 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "xww" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "xwK" = (
@@ -46902,7 +46902,7 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
 "xFs" = (
@@ -48123,8 +48123,8 @@
 	req_one_access_txt = "160";
 	id_tag = "soltrader_south"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/birch,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -55302,8 +55302,8 @@ gLx
 iHi
 enr
 biq
-oPs
-aVi
+olS
+gBI
 biq
 bkV
 iHi
@@ -59661,15 +59661,15 @@ wjg
 biq
 biq
 biq
-oPs
+olS
 utP
-aVi
+gBI
 biq
 biq
 biq
 biq
 biq
-oPs
+olS
 vaw
 tAO
 bnn

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -2307,7 +2307,7 @@
 	},
 /area/station/command/office/hos)
 "alJ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -6125,7 +6125,7 @@
 /obj/structure/noticeboard{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/item/storage/box/evidence{
@@ -9576,7 +9576,7 @@
 	pixel_y = 7;
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/item/hand_labeler{
@@ -9589,7 +9589,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/structure/filingcabinet/chestdrawer,
@@ -12757,7 +12757,7 @@
 /area/station/supply/expedition/gate)
 "aVs" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 8
 	},
 /obj/machinery/alarm/directional/west,
@@ -14120,7 +14120,7 @@
 	},
 /area/station/public/dorms)
 "aZC" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/structure/statue/chickenstatue{
 	layer = 4
 	},
@@ -14132,7 +14132,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -14444,8 +14444,8 @@
 	locked = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16142,8 +16142,8 @@
 /area/station/hallway/primary/central/nw)
 "bgT" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry,
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/cherry,
@@ -17988,8 +17988,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18206,7 +18206,7 @@
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
 "bpQ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /obj/machinery/power/apc/directional/west,
@@ -18218,7 +18218,7 @@
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "bpT" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/landmark/start/dealer,
@@ -19475,7 +19475,7 @@
 	name = "Bridge Requests Console";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -37942,7 +37942,7 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/control)
 "cSV" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood/fancy/red,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -37962,7 +37962,7 @@
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "cSW" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/structure/table/wood/fancy/red,
@@ -38386,7 +38386,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -39253,7 +39253,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/lighter/zippo/engraved,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/ai_status_display/north,
@@ -41878,7 +41878,7 @@
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/pod_4)
 "dgH" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/cooker/deepfryer{
 	foodcolor = null
@@ -42006,7 +42006,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/ai_transit_tube)
 "dhp" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/machinery/camera{
@@ -42024,7 +42024,7 @@
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "dhq" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/structure/chair/stool,
@@ -45978,7 +45978,7 @@
 	},
 /area/station/maintenance/fsmaint)
 "dJg" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/machinery/economy/slot_machine,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/service/bar/atrium)
@@ -49077,7 +49077,7 @@
 /turf/simulated/floor/wood/oak,
 /area/station/medical/psych)
 "eOd" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -49214,7 +49214,7 @@
 /obj/structure/chair/sofa/pew/right{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/abandonedbar)
 "eRh" = (
@@ -49286,7 +49286,7 @@
 	},
 /area/station/engineering/equipmentstorage)
 "eTn" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50051,7 +50051,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "fin" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/machinery/camera{
 	c_tag = "Bar South";
 	dir = 1
@@ -50378,7 +50378,7 @@
 	},
 /area/station/engineering/hallway)
 "fpl" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50843,7 +50843,7 @@
 	name = "Detective Requests Console";
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/photocopier,
@@ -53218,7 +53218,7 @@
 /area/station/hallway/secondary/exit)
 "goS" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /obj/machinery/power/apc/directional/north,
@@ -53695,7 +53695,7 @@
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/aft)
 "guR" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /obj/machinery/economy/atm/directional/north,
@@ -56851,7 +56851,7 @@
 /turf/simulated/wall,
 /area/station/maintenance/asmaint2)
 "hwE" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /obj/item/radio/intercom/directional/west,
@@ -58363,7 +58363,7 @@
 	},
 /area/station/hallway/primary/aft)
 "hXp" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/machinery/newscaster/directional/south,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/service/bar/atrium)
@@ -58555,8 +58555,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "iav" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry/corner,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -60716,7 +60716,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "iVp" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /obj/machinery/alarm/directional/west,
@@ -60948,7 +60948,7 @@
 /area/station/maintenance/aft)
 "iZE" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -62118,7 +62118,7 @@
 	},
 /area/station/engineering/supermatter_room)
 "jvX" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -62329,10 +62329,10 @@
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
 "jzO" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -63176,7 +63176,7 @@
 	},
 /area/station/maintenance/fsmaint)
 "jRb" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -63449,7 +63449,7 @@
 	},
 /area/station/security/warden)
 "jVr" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -64746,7 +64746,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/mouse/gray,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/abandonedbar)
 "kuL" = (
@@ -65774,7 +65774,7 @@
 /turf/simulated/floor/plating,
 /area/station/command/office/blueshield)
 "kNE" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68154,7 +68154,7 @@
 	},
 /area/station/engineering/hallway)
 "lFO" = (
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -68371,7 +68371,7 @@
 /area/station/security/interrogation)
 "lJT" = (
 /obj/structure/chair/sofa/pew,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -69206,7 +69206,7 @@
 /obj/item/reagent_containers/condiment/rice,
 /obj/item/reagent_containers/condiment/rice,
 /obj/item/storage/firstaid/aquatic_kit/full,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -69476,7 +69476,7 @@
 /area/station/command/office/ntrep)
 "mbZ" = (
 /obj/structure/chair/sofa/pew/left,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /obj/structure/window/basic{
@@ -71207,7 +71207,7 @@
 	},
 /area/station/security/detective)
 "mFq" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -71824,7 +71824,7 @@
 	},
 /area/station/public/toilet)
 "mUt" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -72279,7 +72279,7 @@
 /obj/machinery/door_control/bolt_control/north{
 	id = "conference"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
@@ -74248,7 +74248,7 @@
 	},
 /area/station/engineering/hallway)
 "nLp" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -74337,7 +74337,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "nNf" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/cherry/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -74417,7 +74417,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/status_display/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -74433,7 +74433,7 @@
 /obj/structure/chair/sofa/pew/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /obj/structure/window/basic{
@@ -74482,7 +74482,7 @@
 	},
 /area/station/security/execution)
 "nQW" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -75089,7 +75089,7 @@
 /area/station/medical/surgery/primary)
 "obK" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
@@ -75618,7 +75618,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/bottle/vodka,
 /obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/oak,
@@ -75994,7 +75994,7 @@
 	},
 /area/station/science/toxins/mixing)
 "orv" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/service/bar/atrium)
 "orA" = (
@@ -77916,8 +77916,8 @@
 	},
 /area/station/security/permabrig)
 "oXr" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78306,7 +78306,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/space_heater,
 /obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -79606,7 +79606,7 @@
 	},
 /area/station/engineering/emergency)
 "pAv" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/structure/statue/chickenstatue{
 	layer = 4
 	},
@@ -79618,7 +79618,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/cherry/end{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -80150,7 +80150,7 @@
 /area/station/medical/psych)
 "pMj" = (
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -81947,7 +81947,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -83302,7 +83302,7 @@
 "qNB" = (
 /obj/machinery/disposal,
 /obj/machinery/light_switch/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /obj/structure/disposalpipe/trunk{
@@ -83410,7 +83410,7 @@
 	icon_state = "closed";
 	opacity = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/cherry,
@@ -83512,7 +83512,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
 "qRS" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/structure/sign/poster/official/nanotrasen_logo{
@@ -84108,13 +84108,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "rcG" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/cherry/corner,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -85206,7 +85206,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /obj/effect/landmark/start/bar,
@@ -85591,7 +85591,7 @@
 	icon_state = "closed";
 	opacity = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/cherry,
@@ -85784,7 +85784,7 @@
 /area/station/medical/sleeper)
 "rPv" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /obj/effect/spawner/random_spawners/cobweb_right_frequent,
@@ -86834,7 +86834,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -89398,7 +89398,7 @@
 	},
 /area/station/hallway/primary/fore)
 "tai" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/service/bar/atrium)
@@ -90053,7 +90053,7 @@
 /obj/machinery/computer/account_database{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -90092,7 +90092,7 @@
 	},
 /area/station/security/brig)
 "tly" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -90281,7 +90281,7 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/bar/atrium)
 "tqp" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -90442,8 +90442,8 @@
 /turf/simulated/floor/engine,
 /area/station/medical/chemistry)
 "tth" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry,
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -92833,7 +92833,7 @@
 "ulC" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/economy/vending/cigarette,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/command/meeting_room)
 "ulK" = (
@@ -92858,7 +92858,7 @@
 	},
 /area/station/engineering/control)
 "umg" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -93260,7 +93260,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "uuE" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -93456,7 +93456,7 @@
 /area/station/engineering/gravitygenerator)
 "uwP" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/command/meeting_room)
@@ -94885,7 +94885,7 @@
 /area/station/maintenance/apmaint)
 "uYW" = (
 /obj/machinery/economy/vending/coffee,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/command/meeting_room)
 "uZe" = (
@@ -95838,7 +95838,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/end{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/polarized{
@@ -96275,7 +96275,7 @@
 "vxB" = (
 /obj/machinery/alarm/directional/north,
 /obj/machinery/economy/slot_machine,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -96423,7 +96423,7 @@
 	},
 /area/station/science/rnd)
 "vAC" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98232,7 +98232,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "wgG" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -98517,7 +98517,7 @@
 "wny" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
@@ -101407,7 +101407,7 @@
 /turf/simulated/floor/plating,
 /area/station/command/teleporter)
 "xnG" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -101583,7 +101583,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "xqV" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -102481,7 +102481,7 @@
 /area/station/maintenance/asmaint)
 "xHL" = (
 /obj/machinery/disposal,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /obj/machinery/light_switch/east,
@@ -102983,7 +102983,7 @@
 "xPw" = (
 /obj/structure/chair/sofa/pew/right,
 /obj/item/trash/semki,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -103548,7 +103548,7 @@
 /turf/simulated/floor/carpet/green,
 /area/station/public/arcade)
 "xYi" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/cable{
@@ -104165,8 +104165,8 @@
 /area/station/engineering/atmos)
 "yiY" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry,
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/cherry,

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -247,7 +247,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/oak,
@@ -426,7 +426,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/landmark/start/internal_affairs,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "aeh" = (
@@ -994,7 +994,7 @@
 	},
 /area/station/medical/break_room)
 "ahr" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -1531,7 +1531,7 @@
 /area/station/medical/surgery/primary)
 "alX" = (
 /obj/machinery/economy/vending/lawdrobe,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -1642,7 +1642,7 @@
 	id = "PrivateRoom2"
 	},
 /obj/structure/chair/comfy/brown,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy,
@@ -2058,7 +2058,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/landmark/start/dealer,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
@@ -4172,7 +4172,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/effect/landmark/start/dealer,
@@ -5361,7 +5361,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/cherry/corner,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "ayV" = (
@@ -6372,7 +6372,7 @@
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
 "aCA" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -7479,7 +7479,7 @@
 /area/station/service/chapel/bedroom)
 "aGr" = (
 /obj/structure/dresser,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy,
@@ -7789,7 +7789,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy,
@@ -8583,7 +8583,7 @@
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
 "aKw" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "aKx" = (
@@ -11385,10 +11385,10 @@
 /area/station/engineering/atmos)
 "aXH" = (
 /obj/machinery/light_switch/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -14374,7 +14374,7 @@
 	},
 /area/station/supply/miningdock)
 "bjM" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -16496,10 +16496,10 @@
 /area/station/maintenance/medmaint)
 "bta" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "btc" = (
@@ -16634,7 +16634,7 @@
 /area/station/service/hydroponics)
 "btF" = (
 /obj/structure/dresser,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy,
@@ -17078,7 +17078,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "bvS" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -17266,7 +17266,7 @@
 /area/station/medical/medbay2)
 "bwV" = (
 /obj/item/flag/nt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/oak,
@@ -17863,7 +17863,7 @@
 	},
 /area/station/hallway/primary/central/sw)
 "bzb" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "bzc" = (
@@ -18682,7 +18682,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -20372,7 +20372,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "bHK" = (
@@ -20760,31 +20760,31 @@
 /obj/structure/table/wood,
 /obj/machinery/status_display/directional/west,
 /obj/item/flashlight/lamp,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "bIZ" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "bJa" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "bJb" = (
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -20795,15 +20795,15 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "bJe" = (
 /obj/machinery/newscaster/security_unit/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/oak,
@@ -20817,7 +20817,7 @@
 "bJg" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/oak,
@@ -20839,7 +20839,7 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/toy/figure/crew/captain,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/oak,
@@ -20850,7 +20850,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -20865,14 +20865,14 @@
 	},
 /area/station/security/permabrig)
 "bJm" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "bJn" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
@@ -20880,7 +20880,7 @@
 /area/station/command/office/captain)
 "bJo" = (
 /obj/machinery/ai_status_display/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -20889,21 +20889,21 @@
 /obj/structure/sign/bobross{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "bJq" = (
 /obj/machinery/status_display/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "bJr" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/oak,
@@ -21362,7 +21362,7 @@
 	pixel_y = -4;
 	req_one_access_txt = "18"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -21385,17 +21385,17 @@
 /area/station/command/meeting_room)
 "bKM" = (
 /obj/machinery/light_switch/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "bKN" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -21461,7 +21461,7 @@
 /area/station/command/office/captain)
 "bLg" = (
 /obj/machinery/alarm/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -21486,7 +21486,7 @@
 /obj/item/clipboard,
 /obj/item/book/manual/wiki/security_space_law/black,
 /obj/item/stamp/law,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -21521,14 +21521,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "bLm" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -21942,14 +21942,14 @@
 /area/station/hallway/primary/central/north)
 "bMM" = (
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "bMN" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -21994,7 +21994,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -22059,7 +22059,7 @@
 /area/station/command/office/captain)
 "bNh" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -22555,7 +22555,7 @@
 "bOE" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -22649,7 +22649,7 @@
 /area/station/command/office/captain)
 "bOV" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/oak,
@@ -22668,7 +22668,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "bOZ" = (
@@ -22680,7 +22680,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "bPb" = (
@@ -22688,7 +22688,7 @@
 	c_tag = "Captain's Room";
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -22710,7 +22710,7 @@
 	},
 /obj/item/camera,
 /obj/item/taperecorder,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -22725,7 +22725,7 @@
 	pixel_y = 6;
 	pixel_x = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "bPf" = (
@@ -22746,7 +22746,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "bPh" = (
@@ -22755,7 +22755,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -23269,7 +23269,7 @@
 /obj/machinery/ai_status_display/west,
 /obj/item/storage/briefcase,
 /obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/oak,
@@ -23277,8 +23277,8 @@
 "bQG" = (
 /obj/item/kirbyplants,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -23289,8 +23289,8 @@
 	c_tag = "Command Meeting Room";
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -23403,7 +23403,7 @@
 /obj/machinery/photocopier/faxmachine/longrange{
 	department = "Captain's Office"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/oak,
@@ -23411,7 +23411,7 @@
 "bQU" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /obj/machinery/light/directional/south,
@@ -24566,28 +24566,28 @@
 	name = "Head of Personnel Requests Console";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "bUR" = (
 /obj/item/kirbyplants,
 /obj/machinery/keycard_auth/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "bUU" = (
 /obj/structure/table/wood,
 /obj/machinery/smartfridge/id,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -24754,7 +24754,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -25136,10 +25136,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/hop)
 "bWR" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -25497,10 +25497,10 @@
 "bYu" = (
 /obj/machinery/status_display/directional/east,
 /obj/machinery/pdapainter,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -25514,17 +25514,17 @@
 "bYy" = (
 /obj/machinery/photocopier,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain/bedroom)
 "bYA" = (
 /obj/machinery/light_switch/north,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -25933,12 +25933,12 @@
 	department = "Head of Personnel's Office"
 	},
 /obj/machinery/keycard_auth/east,
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/oak/end,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "cab" = (
 /obj/structure/closet/secure_closet/ntrep,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -25959,7 +25959,7 @@
 /area/station/command/office/ntrep)
 "cae" = (
 /obj/structure/bookcase/sop,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/oak,
@@ -25967,29 +25967,29 @@
 "caf" = (
 /obj/structure/chair/sofa/right,
 /obj/structure/sign/poster/official/random/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "cag" = (
 /obj/structure/chair/sofa,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "cah" = (
 /obj/structure/chair/sofa/corner,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "cai" = (
 /obj/item/flag/nt,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -26015,7 +26015,7 @@
 	name = "Blueshield Requests Console";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -26094,7 +26094,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -26118,7 +26118,7 @@
 	},
 /obj/item/book/manual/wiki/sop_legal,
 /obj/item/book/manual/wiki/sop_command,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -26405,7 +26405,7 @@
 "cbz" = (
 /obj/machinery/suit_storage_unit/captain/secure,
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -26521,10 +26521,10 @@
 /obj/machinery/light_switch/west{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -26551,7 +26551,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -26580,7 +26580,7 @@
 	},
 /obj/structure/sign/poster/official/random/east,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -26589,10 +26589,10 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -26615,10 +26615,10 @@
 	pixel_x = 24;
 	req_access_txt = "67"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -26664,7 +26664,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -26761,7 +26761,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -27015,7 +27015,7 @@
 /obj/item/storage/box/PDAs,
 /obj/item/storage/box/ids,
 /obj/effect/spawner/random_spawners/id_skins,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -27025,10 +27025,10 @@
 	name = "Desk Door"
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/command/ntrep,
@@ -27063,7 +27063,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -27077,10 +27077,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -27117,10 +27117,10 @@
 /obj/machinery/keycard_auth/east{
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/windoor/access/any/command/blueshield,
@@ -27143,7 +27143,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/oak,
@@ -27158,7 +27158,7 @@
 	c_tag = "Captain's Quarters";
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/oak,
@@ -27194,10 +27194,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -27237,7 +27237,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -27251,7 +27251,7 @@
 /area/station/public/fitness)
 "ceq" = (
 /obj/machinery/papershredder,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -27401,7 +27401,7 @@
 /area/station/engineering/control)
 "cfa" = (
 /obj/structure/closet/secure_closet/captains,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/oak,
@@ -27542,10 +27542,10 @@
 /turf/simulated/floor/wood/parquet,
 /area/station/service/library)
 "cfx" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -27576,10 +27576,10 @@
 "cfE" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -27598,13 +27598,13 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
 "cfK" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "cfL" = (
 /obj/item/flag/nt,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -27616,10 +27616,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -27635,10 +27635,10 @@
 /area/station/command/office/blueshield)
 "cfP" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -27828,7 +27828,7 @@
 "cgS" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/helmet/skull/Yorick,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -27891,10 +27891,10 @@
 /area/station/command/office/hop)
 "chj" = (
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
@@ -27913,10 +27913,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -27937,10 +27937,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -27950,10 +27950,10 @@
 /obj/item/reagent_containers/drinks/bottle/whiskey,
 /obj/item/reagent_containers/drinks/drinkingglass,
 /obj/item/reagent_containers/drinks/drinkingglass,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -28027,7 +28027,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -28056,14 +28056,14 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/magistrate)
 "chN" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/magistrate)
 "chO" = (
@@ -28292,10 +28292,10 @@
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/alarm/directional/east,
 /mob/living/simple_animal/pet/dog/corgi/Ian,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -28304,10 +28304,10 @@
 /obj/machinery/photocopier,
 /obj/structure/sign/poster/official/random/west,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -28322,8 +28322,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -28345,10 +28345,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -28363,8 +28363,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -28373,10 +28373,10 @@
 /obj/machinery/photocopier,
 /obj/structure/sign/poster/official/random/east,
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -28828,10 +28828,10 @@
 /area/station/hallway/primary/central/se)
 "ckp" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -28850,10 +28850,10 @@
 "cks" = (
 /obj/machinery/ai_status_display/east,
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -28988,7 +28988,7 @@
 /area/station/legal/courtroom)
 "ckP" = (
 /obj/machinery/alarm/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -29116,10 +29116,10 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/crew/ian,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -29433,10 +29433,10 @@
 "cnt" = (
 /obj/item/kirbyplants,
 /obj/machinery/light_switch/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -29744,7 +29744,7 @@
 /turf/simulated/floor/carpet/black,
 /area/station/legal/courtroom)
 "coM" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "coN" = (
@@ -29753,7 +29753,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end,
+/obj/effect/turf_decal/siding/wood/oak/end,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "coP" = (
@@ -29773,7 +29773,7 @@
 /obj/machinery/door_control/shutter/west{
 	id = "vacantstore"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -29791,7 +29791,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -29799,7 +29799,7 @@
 "coT" = (
 /obj/machinery/status_display/directional/east,
 /obj/structure/table,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -30172,7 +30172,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "cqy" = (
@@ -30190,13 +30190,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "cqB" = (
 /obj/structure/table,
 /obj/machinery/alarm/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -31264,7 +31264,7 @@
 /area/station/ai_monitored/storage/eva)
 "cvu" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -31858,7 +31858,7 @@
 /area/station/public/vacant_office/secondary)
 "cyi" = (
 /obj/structure/bookcase,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/oak,
@@ -31869,8 +31869,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -32352,7 +32352,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -32409,7 +32409,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -35209,7 +35209,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/flag/sec,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -35521,7 +35521,7 @@
 /obj/item/bedsheet/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy,
@@ -35917,7 +35917,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
 "cPQ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/oak,
@@ -35961,7 +35961,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_female)
 "cQf" = (
@@ -36205,7 +36205,7 @@
 	},
 /area/station/science/xenobiology)
 "cRb" = (
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 4
 	},
 /obj/item/kirbyplants,
@@ -40786,7 +40786,7 @@
 	},
 /mob/living/simple_animal/mouse/hamster/Representative,
 /obj/structure/bed/dogbed/pet,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -41607,7 +41607,7 @@
 /area/station/medical/medbay)
 "drp" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "drq" = (
@@ -44576,7 +44576,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy,
@@ -45494,10 +45494,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "dOn" = (
@@ -48246,7 +48246,7 @@
 /turf/simulated/floor/plasteel/grimy,
 /area/station/security/detective)
 "dZP" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -48892,10 +48892,10 @@
 "eir" = (
 /obj/machinery/economy/vending/cart,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -49299,7 +49299,7 @@
 /area/station/maintenance/old_kitchen)
 "eoI" = (
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -49556,10 +49556,10 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/explab)
 "esO" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "esV" = (
@@ -49819,7 +49819,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy,
@@ -50826,10 +50826,10 @@
 /obj/item/clothing/suit/blacktrenchcoat,
 /obj/item/clothing/head/fedora,
 /obj/machinery/status_display/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_male)
 "eOm" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
@@ -51408,14 +51408,14 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/vault)
 "eXa" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /obj/effect/landmark/start/dealer,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "eXm" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -51475,8 +51475,8 @@
 	},
 /area/station/supply/expedition)
 "eXM" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/alarm/directional/north,
@@ -51849,10 +51849,10 @@
 /area/station/medical/chemistry)
 "ffM" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -51926,14 +51926,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "fhb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -51949,7 +51949,7 @@
 /area/station/security/storage)
 "fho" = (
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -54949,10 +54949,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "gcZ" = (
@@ -55319,7 +55319,7 @@
 /obj/machinery/firealarm/directional/north,
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/sloth/paperwork,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -55675,7 +55675,7 @@
 	},
 /area/station/public/locker)
 "gqV" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /obj/effect/landmark/start/dealer,
@@ -56077,8 +56077,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -56658,7 +56658,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "gIn" = (
@@ -56793,7 +56793,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "gJQ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -56967,7 +56967,7 @@
 /area/station/supply/abandoned_boxroom)
 "gMf" = (
 /obj/machinery/papershredder,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -57046,7 +57046,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/simulated/floor/wood,
@@ -57147,7 +57147,7 @@
 	},
 /area/station/maintenance/starboard2)
 "gOG" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -57212,7 +57212,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -57278,7 +57278,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -58071,7 +58071,7 @@
 /area/station/engineering/hardsuitstorage)
 "heL" = (
 /obj/item/kirbyplants,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -58806,7 +58806,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_male)
 "hqR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -58999,7 +58999,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/simulated/floor/wood,
@@ -59494,7 +59494,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -59853,7 +59853,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/oak,
@@ -59879,7 +59879,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy,
@@ -59915,7 +59915,7 @@
 "hIj" = (
 /obj/structure/bed/psych,
 /obj/random/therapy,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/medical/psych)
 "hIE" = (
@@ -61038,7 +61038,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -61653,7 +61653,7 @@
 "ijQ" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -61690,7 +61690,7 @@
 	},
 /area/station/medical/virology/lab)
 "ikz" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -63329,7 +63329,7 @@
 /area/station/medical/virology/lab)
 "iKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -63574,7 +63574,7 @@
 /turf/simulated/floor/wood/fancy,
 /area/station/service/theatre)
 "iOy" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
 "iOA" = (
@@ -63949,10 +63949,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -64263,8 +64263,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -64352,7 +64352,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -64706,7 +64706,7 @@
 	},
 /area/station/maintenance/fsmaint)
 "jgY" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "jgZ" = (
@@ -65626,7 +65626,7 @@
 /turf/simulated/floor/wood/parquet,
 /area/station/service/library)
 "jtC" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -65783,7 +65783,7 @@
 	range = 10;
 	req_one_access_txt = "38"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -66177,7 +66177,7 @@
 	pixel_y = 6;
 	pixel_x = 6
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -66651,15 +66651,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain/bedroom)
 "jKd" = (
 /obj/machinery/photocopier,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -66783,7 +66783,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -66871,7 +66871,7 @@
 /obj/structure/sign/poster/official/random/south,
 /obj/structure/rack,
 /obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/simulated/floor/wood,
@@ -66935,7 +66935,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -67669,8 +67669,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -67812,7 +67812,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -69356,7 +69356,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -69749,7 +69749,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /obj/effect/landmark/start/dealer,
@@ -70245,7 +70245,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random/east,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy,
@@ -70357,7 +70357,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -70797,7 +70797,7 @@
 	},
 /area/station/security/processing)
 "laZ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -71101,7 +71101,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -72072,7 +72072,7 @@
 /area/station/maintenance/starboard2)
 "lvi" = (
 /obj/structure/bookcase/sop,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -72651,7 +72651,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/medmaint)
 "lDJ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -72688,10 +72688,10 @@
 	},
 /area/station/security/main)
 "lDX" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/oak,
 /area/station/command/meeting_room)
 "lEd" = (
@@ -72702,10 +72702,10 @@
 /obj/item/storage/box/keys{
 	pixel_x = -15
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -73008,8 +73008,8 @@
 	},
 /area/station/security/permabrig)
 "lIZ" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
@@ -73309,10 +73309,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "lOm" = (
@@ -73496,7 +73496,7 @@
 /area/station/medical/virology/lab)
 "lPY" = (
 /obj/machinery/suit_storage_unit/security/hos/secure,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/simulated/floor/wood,
@@ -73940,7 +73940,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -74327,7 +74327,7 @@
 "mga" = (
 /obj/item/kirbyplants,
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy,
@@ -74710,7 +74710,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -74843,7 +74843,7 @@
 	c_tag = "Brig Head of Security's Office";
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/simulated/floor/wood,
@@ -74851,7 +74851,7 @@
 "moT" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/psychiatrist,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -75678,10 +75678,10 @@
 	},
 /area/station/engineering/tech_storage)
 "mCQ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -75816,7 +75816,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "mFE" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
 "mGG" = (
@@ -75915,7 +75915,7 @@
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
 "mJJ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -76202,7 +76202,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -76266,8 +76266,8 @@
 /turf/simulated/floor/transparent/glass/reinforced,
 /area/station/maintenance/starboard2)
 "mQS" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /obj/machinery/light/nightshifted/north,
@@ -76392,7 +76392,7 @@
 	id = "PrivateRoom1"
 	},
 /obj/structure/chair/comfy/brown,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy,
@@ -76631,7 +76631,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/simulated/floor/wood,
@@ -77131,7 +77131,7 @@
 /area/station/maintenance/starboard2)
 "ncO" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -77733,8 +77733,8 @@
 "nmw" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/economy/slot_machine,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -78777,10 +78777,10 @@
 	},
 /area/station/maintenance/fore)
 "nBA" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/courtroom)
 "nBC" = (
@@ -79125,7 +79125,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -79166,7 +79166,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
 "nFQ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -79232,7 +79232,7 @@
 "nGZ" = (
 /obj/machinery/alarm/directional/east,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
@@ -79666,7 +79666,7 @@
 /obj/item/bedsheet/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy,
@@ -81416,7 +81416,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -81711,7 +81711,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /turf/simulated/floor/wood/oak,
@@ -81932,7 +81932,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -81944,7 +81944,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -82072,7 +82072,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "ovJ" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -82163,7 +82163,7 @@
 "oyu" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/simulated/floor/wood,
@@ -82473,10 +82473,10 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/oak,
 /area/station/medical/psych)
 "oDB" = (
@@ -83264,7 +83264,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain)
 "oSD" = (
@@ -83619,8 +83619,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -83699,7 +83699,7 @@
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "oZd" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -83858,7 +83858,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/magistrate)
 "pbQ" = (
@@ -84125,7 +84125,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -84289,7 +84289,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "pih" = (
@@ -85268,7 +85268,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy,
@@ -85600,7 +85600,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -85814,7 +85814,7 @@
 	},
 /obj/item/camera,
 /obj/item/taperecorder,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -86594,7 +86594,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_male)
 "pRP" = (
@@ -87357,7 +87357,7 @@
 	pixel_x = -4;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -87583,7 +87583,7 @@
 	},
 /area/station/security/brig)
 "qix" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -87718,7 +87718,7 @@
 	},
 /area/station/maintenance/fore)
 "qlh" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "qlt" = (
@@ -88440,7 +88440,7 @@
 /area/station/security/prison/cell_block/A)
 "qwR" = (
 /obj/item/flag/nt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -90214,7 +90214,7 @@
 /area/station/maintenance/starboard2)
 "qVF" = (
 /obj/machinery/economy/vending/coffee,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/oak,
@@ -90859,10 +90859,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -91273,7 +91273,7 @@
 	pixel_x = 6
 	},
 /obj/machinery/status_display/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -92131,10 +92131,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -93393,10 +93393,10 @@
 "rXg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "rXk" = (
@@ -94006,10 +94006,10 @@
 	},
 /area/station/hallway/primary/starboard)
 "sfc" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -94451,8 +94451,8 @@
 "sno" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -96311,7 +96311,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -96430,7 +96430,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/landmark/start/dealer,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
@@ -96673,7 +96673,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -96884,7 +96884,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -97286,7 +97286,7 @@
 	},
 /area/station/service/chapel)
 "teX" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -97847,7 +97847,7 @@
 /obj/machinery/light_switch/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random_spawners/cobweb_left_rare,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -98009,10 +98009,10 @@
 /area/station/engineering/tech_storage)
 "tpv" = (
 /obj/machinery/light_switch/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "tpI" = (
@@ -99269,7 +99269,7 @@
 	c_tag = "Law Office"
 	},
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -99599,7 +99599,7 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/turf_decal/delivery/hollow,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/machinery/light/small/directional/south,
@@ -100504,8 +100504,8 @@
 	},
 /area/station/maintenance/old_detective)
 "ugn" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -101245,8 +101245,8 @@
 	},
 /area/station/medical/cloning)
 "urH" = (
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -101860,7 +101860,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -101938,7 +101938,7 @@
 	},
 /area/station/public/fitness)
 "uGm" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -101946,7 +101946,7 @@
 "uGp" = (
 /obj/item/kirbyplants,
 /obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy,
@@ -102044,7 +102044,7 @@
 	},
 /area/station/hallway/primary/fore)
 "uIl" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -102340,7 +102340,7 @@
 /area/station/maintenance/fsmaint)
 "uMC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -102653,13 +102653,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "uQa" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -102785,7 +102785,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -103300,7 +103300,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -103479,7 +103479,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -103660,7 +103660,7 @@
 	dir = 1
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "veB" = (
@@ -103672,7 +103672,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy,
@@ -104274,10 +104274,10 @@
 "vol" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/head_of_personnel,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -105080,7 +105080,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/cherry/corner{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -105178,7 +105178,7 @@
 "vFK" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -105191,10 +105191,10 @@
 "vGg" = (
 /obj/machinery/economy/vending/coffee,
 /obj/structure/sign/poster/official/random/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -105332,7 +105332,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood,
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
 "vIR" = (
@@ -105735,7 +105735,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
 "vOj" = (
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/captain/bedroom)
 "vOo" = (
@@ -106117,7 +106117,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -106156,10 +106156,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/ntrep)
 "vUX" = (
@@ -107109,7 +107109,7 @@
 /obj/item/book/manual/wiki/sop_security,
 /obj/item/book/manual/wiki/sop_command,
 /obj/item/book/manual/wiki/sop_security,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/simulated/floor/wood,
@@ -107147,8 +107147,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
@@ -107613,7 +107613,7 @@
 /area/station/medical/patients_rooms)
 "wuQ" = (
 /obj/machinery/suit_storage_unit/blueshield/secure,
-/obj/effect/turf_decal/siding/wood/neutral/end{
+/obj/effect/turf_decal/siding/wood/oak/end{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
@@ -107697,7 +107697,7 @@
 /area/station/security/permabrig)
 "wvT" = (
 /obj/structure/bookcase,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/oak,
@@ -108110,7 +108110,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral/corner,
+/obj/effect/turf_decal/siding/wood/cherry/corner,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/public/vacant_store)
 "wDq" = (
@@ -108347,7 +108347,7 @@
 	layer = 4;
 	pixel_x = -4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
@@ -108712,7 +108712,7 @@
 	name = "spider bed"
 	},
 /mob/living/simple_animal/hostile/retaliate/araneus,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -109125,7 +109125,7 @@
 /obj/item/clothing/suit/browntrenchcoat,
 /obj/item/clothing/head/fedora/brownfedora,
 /obj/machinery/status_display/directional/south,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/simulated/floor/wood/fancy,
@@ -109478,7 +109478,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood,
@@ -110122,10 +110122,10 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/security_unit/west,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
 /turf/simulated/floor/wood/oak,
@@ -110286,7 +110286,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "xlQ" = (
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -110955,7 +110955,7 @@
 "xuX" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/dog/fox/fennec/fenya,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -111127,10 +111127,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hop)
 "xxQ" = (
@@ -111419,8 +111419,8 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/neutral,
-/obj/effect/turf_decal/siding/wood/neutral/corner{
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
@@ -111727,7 +111727,7 @@
 /obj/machinery/light/directional/west,
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -112170,7 +112170,7 @@
 "xOa" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/dog/brittany/Psycho,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
 /turf/simulated/floor/wood/oak,
@@ -112438,7 +112438,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy,
@@ -112900,7 +112900,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology/lab)
 "xYy" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -113024,7 +113024,7 @@
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -113181,7 +113181,7 @@
 "ydA" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /obj/machinery/firealarm/directional/west,
@@ -113284,7 +113284,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "ygh" = (
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/cherry{
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -113534,7 +113534,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/siding/wood/neutral{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 9
 	},
 /turf/simulated/floor/wood/oak,

--- a/code/datums/components/decal.dm
+++ b/code/datums/components/decal.dm
@@ -46,6 +46,11 @@
 	pic = new(temp_image)
 	pic.color = _color
 	pic.alpha = _alpha
+	/* SS220 EDIT - START */
+	var/atom/master = parent
+	if(master::color && _color)
+		pic.appearance_flags |= RESET_COLOR
+	/* SS220 EDIT - END */
 	return TRUE
 
 /datum/component/decal/proc/apply(atom/thing)


### PR DESCRIPTION
## Что этот PR делает
Грязный фикс деревянных декалей
На вебмапе больше не будет белых полосок вокруг досок, а все декали что находятся на деревянных полах, сохранят свой изначальный цвет, не красясь в цвет собственно деревяшки

Показывать нечего