### PR TITLE
Set general access for vacant office on Kerberos

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -14563,11 +14563,11 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/lawoffice)
 "bkb" = (
-/obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/window/reinforced/polarized/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/vacant_office/secondary)
 "bkd" = (
@@ -31683,7 +31683,8 @@
 "cxc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room"
+	id_tag = "pub_room";
+	polarized_glass = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -57459,7 +57460,8 @@
 "gyY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room"
+	id_tag = "pub_room";
+	polarized_glass = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -80158,7 +80160,8 @@
 "nnM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room"
+	id_tag = "pub_room";
+	polarized_glass = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -83425,11 +83428,11 @@
 	},
 /area/station/hallway/secondary/exit/maintenance)
 "oeY" = (
-/obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/spawner/window/reinforced/polarized/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/vacant_office/secondary)
 "oeZ" = (
@@ -88708,11 +88711,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "pJv" = (
-/obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/spawner/window/reinforced/polarized/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/vacant_office/secondary)
 "pJw" = (
@@ -96153,9 +96156,13 @@
 /area/station/maintenance/medmaint)
 "rUS" = (
 /obj/machinery/door_control/bolt_control/north{
-	id = "pub_room"
+	id = "pub_room";
+	pixel_x = 6
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/button/windowtint/north{
+	pixel_x = -6
+	},
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "rVa" = (
@@ -108277,8 +108284,8 @@
 /turf/simulated/floor/engine,
 /area/station/science/toxins/mixing)
 "vBU" = (
-/obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable,
+/obj/effect/spawner/window/reinforced/polarized/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/vacant_office/secondary)
 "vBV" = (
@@ -109415,7 +109422,8 @@
 "vTv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room"
+	id_tag = "pub_room";
+	polarized_glass = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -111918,7 +111926,6 @@
 	},
 /area/station/hallway/primary/central/north)
 "wHF" = (
-/obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -111933,6 +111940,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/spawner/window/reinforced/polarized/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/vacant_office/secondary)
 "wHH" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -31691,7 +31691,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/wood/oak,
 /area/station/public/vacant_office/secondary)
 "cxd" = (
@@ -57469,7 +57468,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "gzd" = (
@@ -80168,7 +80166,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/wood/oak,
 /area/station/public/vacant_office/secondary)
 "nnZ" = (
@@ -109427,7 +109424,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "vTJ" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -31683,8 +31683,7 @@
 "cxc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	polarized_glass = 1
+	id_tag = "pub_room"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -31692,6 +31691,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/mapping_helpers/airlock/polarized,
 /turf/simulated/floor/wood/oak,
 /area/station/public/vacant_office/secondary)
 "cxd" = (
@@ -57460,8 +57460,7 @@
 "gyY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	polarized_glass = 1
+	id_tag = "pub_room"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -57470,6 +57469,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/mapping_helpers/airlock/polarized,
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "gzd" = (
@@ -80160,8 +80160,7 @@
 "nnM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	polarized_glass = 1
+	id_tag = "pub_room"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -80169,6 +80168,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/mapping_helpers/airlock/polarized,
 /turf/simulated/floor/wood/oak,
 /area/station/public/vacant_office/secondary)
 "nnZ" = (
@@ -109422,8 +109422,7 @@
 "vTv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
-	id_tag = "pub_room";
-	polarized_glass = 1
+	id_tag = "pub_room"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
@@ -109432,6 +109431,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/polarized,
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "vTJ" = (


### PR DESCRIPTION
## Что этот PR делает
Изменяет доступ на шлюзах свободного офиса на Дельте. На оффах там общий, все равно с обеих сторон свободный коридор.
Добавляет в комнату кнопку для затемнения окон.

## Почему это хорошо для игры
Возможно порой сократить путь.

## Изображения изменений
mapdiff

## Тестирование
Зашел ассистентом, затемнил окна, сижу.

## Changelog

:cl: Maxiemar
fix: Свободный офис возле мостика на Дельте теперь имеет общий доступ.
tweak: Свободный офис возле мостика на Дельте теперь имеет затемняющиеся окна.
/:cl:
