### PR TITLE
Fix wire splicing spawning

### DIFF
--- a/modular_ss220/wire_splicing/code/wiresplicing.dm
+++ b/modular_ss220/wire_splicing/code/wiresplicing.dm
@@ -5,20 +5,18 @@
 	name = "wiring splicing spawner"
 	icon = 'modular_ss220/wire_splicing/icons/structures_spawners.dmi'
 	icon_state = "wire_splicing"
+	/// From 0 to 100
+	var/spawn_probability = 100
 
 /obj/effect/spawner/wire_splicing/Initialize()
-	..()
-	new /obj/structure/wire_splicing(get_turf(src))
+	. = ..()
+	if(prob(spawn_probability))
+		new /obj/structure/wire_splicing(get_turf(src))
 	return INITIALIZE_HINT_QDEL
 
-// 70% chance to be nothing
 /obj/effect/spawner/wire_splicing/thirty
 	name = "wiring splicing spawner 30%"
-
-/obj/effect/spawner/wire_splicing/thirty/Initialize(mapload)
-	if(prob(70))
-		return INITIALIZE_HINT_QDEL
-	return ..()
+	spawn_probability = 30
 
 /obj/structure/wire_splicing
 	name = "wire splicing"

--- a/modular_ss220/wire_splicing/code/wiresplicing.dm
+++ b/modular_ss220/wire_splicing/code/wiresplicing.dm
@@ -7,7 +7,7 @@
 	icon_state = "wire_splicing"
 
 /obj/effect/spawner/wire_splicing/Initialize()
-	. = ..()
+	..()
 	new /obj/structure/wire_splicing(get_turf(src))
 	return INITIALIZE_HINT_QDEL
 
@@ -16,9 +16,9 @@
 	name = "wiring splicing spawner 30%"
 
 /obj/effect/spawner/wire_splicing/thirty/Initialize(mapload)
-	. = ..()
 	if(prob(70))
 		return INITIALIZE_HINT_QDEL
+	return ..()
 
 /obj/structure/wire_splicing
 	name = "wire splicing"


### PR DESCRIPTION
## Что этот PR делает
Чинит спавн разрывов проводки, чтобы они появлялись случайно, как и задумывалось. До этого они спавнились гарантированно.

## Почему это хорошо для игры
Меньше ожогов, но и меньше веселья, увы.

## Тестирование
Не во всех местах теперь появляются.

## Changelog

:cl: Maxiemar
fix: Проводка на станциях теперь реже оголяется.
/:cl:
