### PR TITLE
Qol changes for auto ERT

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -7959,7 +7959,7 @@
 /obj/machinery/door_control/no_emag/east{
 	id = "CC_Armory";
 	name = "Оружейная";
-	req_one_access_txt = "114"
+	req_one_access_txt = "110"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/admin3)
@@ -10740,7 +10740,7 @@
 	color = "#80ff80";
 	id = "CC_Armory_Green";
 	name = "Оружейная - Уровень 1";
-	req_one_access_txt = "114"
+	req_one_access_txt = "110"
 	},
 /turf/simulated/floor/plasteel/dark{
 	dir = 5;
@@ -22421,19 +22421,17 @@
 "ljX" = (
 /obj/structure/rack/gunrack,
 /obj/item/gun/energy/disabler{
-	pixel_y = 10
+	pixel_x = -6
 	},
 /obj/item/gun/energy/disabler{
-	pixel_y = 6
+	pixel_x = -3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3
 	},
 /obj/item/gun/energy/disabler{
-	pixel_y = 2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = -2
-	},
-/obj/item/gun/energy/disabler{
-	pixel_y = -6
+	pixel_x = 6
 	},
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkgreen"
@@ -27853,7 +27851,7 @@
 /obj/machinery/door_control/no_emag/north{
 	name = "Pod Door Control";
 	id = "ert_shuttle_door";
-	req_one_access_txt = "109"
+	req_one_access_txt = "110"
 	},
 /turf/simulated/floor/plasteel/dark{
 	dir = 9;
@@ -43668,7 +43666,7 @@
 /obj/machinery/door_control/no_emag/south{
 	name = "Pod Door Control";
 	id = "ert_shuttle_door";
-	req_one_access_txt = "109"
+	req_one_access_txt = "110"
 	},
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkbluealtstrip"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавлен доступ к оружейной зоне лидерам ЕРТ и оружейной уровня AMBER в частности. Это позволит авто-ЕРТ самостоятельно выдвигаться на станцию с какой-никакой экипировкой в отсутствии админов.

## Почему это хорошо для игры
Авто-ЕРТ не будет сосать.

## Тестирование
Вроде.

## Changelog

:cl:
tweak: ЦК: Добавлен доступ к оружейной зоне лидерам ЕРТ и оружейной уровня AMBER в частности. Это позволит авто-ЕРТ самостоятельно выдвигаться на станцию с какой-никакой экипировкой в отсутствии админов.
tweak: ЦК: Бластдоры к поду ЕРТ теперь под доступом лидера ЕРТ.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
