### PR TITLE
Fix MetaStation cigarette vendors

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -22364,10 +22364,7 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/hop)
 "bCm" = (
-/obj/machinery/economy/vending/cigarette{
-	pixel_y = 2;
-	products = list(/obj/item/storage/fancy/cigarettes/cigpack_syndicate=7,/obj/item/storage/fancy/cigarettes/cigpack_uplift=3,/obj/item/storage/fancy/cigarettes/cigpack_robust=2,/obj/item/storage/fancy/cigarettes/cigpack_carp=3,/obj/item/storage/fancy/cigarettes/cigpack_midori=1,/obj/item/storage/fancy/matches=10,/obj/item/lighter/random=4)
-	},
+/obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
 "bCo" = (
@@ -23458,9 +23455,7 @@
 /area/station/hallway/secondary/bridge)
 "bFS" = (
 /obj/machinery/alarm/directional/east,
-/obj/machinery/economy/vending/cigarette{
-	pixel_x = 2
-	},
+/obj/machinery/economy/vending/cigarette,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
## Что этот PR делает
Удаляет бредик

## Почему это хорошо для игры
Кэп может купить сиги

## Изображения изменений
MDB

## Changelog

:cl:
fix: Мета: Кэп теперь может купить сиги у себя в офисе
/:cl:
