### PR TITLE
Rearrange some cameras on Cyberiad

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -45512,7 +45512,7 @@
 "dEc" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
-	c_tag = "Engineering Atmospherics Control Room";
+	c_tag = "Engineering Atmospherics Control Room - East";
 	network = list("SS13","Engineering");
 	dir = 9
 	},
@@ -82299,7 +82299,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Atmospherics Control Room";
+	c_tag = "Engineering Atmospherics Control Room - West";
 	network = list("SS13","Engineering");
 	dir = 4
 	},

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -23901,6 +23901,10 @@
 /area/station/hallway/primary/central/sw)
 "bQj" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/camera{
+	c_tag = "Bridge South";
+	dir = 4
+	},
 /turf/simulated/floor/transparent/glass,
 /area/station/command/bridge)
 "bQq" = (
@@ -38008,10 +38012,6 @@
 	dir = 8;
 	name = "Mix to Filter"
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Atmospherics Control Room";
-	network = list("SS13","Engineering")
-	},
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = 28
 	},
@@ -45511,6 +45511,11 @@
 /area/station/maintenance/fpmaint)
 "dEc" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/camera{
+	c_tag = "Engineering Atmospherics Control Room";
+	network = list("SS13","Engineering");
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
@@ -82293,6 +82298,11 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Engineering Atmospherics Control Room";
+	network = list("SS13","Engineering");
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -100045,6 +100055,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Turbine";
+	network = list("SS13","Engineering");
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Чуть двигает камеры, чуть добавляет.

## Почему это хорошо для игры
Чуть меньше слепых зон ИИ там, где они не задумывались.

## Изображения изменений

<details>
<summary>Spoiler</summary>

![image](https://github.com/user-attachments/assets/84db5aea-f496-4884-81ea-3cd655bdf214)
![image](https://github.com/user-attachments/assets/1a9b7192-005f-4849-a5fe-ed2810b743dc)
![image](https://github.com/user-attachments/assets/65d13a7a-b867-4f40-baa7-f25d953937ba)

</details>

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
На ИИ видно, шлюзы доступны.

## Changelog

:cl: Maxiemar
tweak: На Кибериаде немного изменено местоположение камер. Теперь чуть меньше слепых зон.
/:cl:
