### PR TITLE
Tweak Blob announce time

### DIFF
--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -1,6 +1,7 @@
 #include "_balance.dm"
 
 #include "code/access/access.dm"
+#include "code/events/blob.dm"
 #include "code/items/projectiles.dm"
 #include "code/items/weapons.dm"
 #include "code/items/storage/surgical_tray.dm"

--- a/modular_ss220/balance/code/events/blob.dm
+++ b/modular_ss220/balance/code/events/blob.dm
@@ -1,0 +1,4 @@
+// Increases announce time
+/datum/event/blob
+	announceWhen	= 420
+	endWhen			= 480


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Увеличивает время когда начинается появляется анонс о Блобе с 3 минут до 7 минут.

## Почему это хорошо для игры
Может Блоб не будет так сильно сосать от всей станции. А вообще, просьба Мунивёрса, но я посчитал что можно и мейнам, так как проблема ебки Блоба на мейне актуальна как никогда.

## Тестирование
Оно компилируется.

## Changelog

:cl:
tweak: Время объявления о биоугрозе в виде Блоба было увеличено с 3 минут до 7 минут. Экспериментально.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
