### PR TITLE
Fix autolinking of mech fabricator

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -23052,7 +23052,7 @@
 	},
 /area/station/science/robotics/chargebay)
 "bNj" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator/station,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkpurple"
@@ -23713,7 +23713,7 @@
 	},
 /area/station/science/server)
 "bPy" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator/station,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -42342,8 +42342,8 @@
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
 "drE" = (
-/obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/mecha_part_fabricator/station,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "drF" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -55801,12 +55801,12 @@
 	},
 /area/station/medical/medbay)
 "iAO" = (
-/obj/machinery/mecha_part_fabricator{
-	output_dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/mecha_part_fabricator/station{
+	output_dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)


### PR DESCRIPTION
## Что этот PR делает
Чинит линковку фабрикатора.

## Почему это хорошо для игры
Не нужен пароль от сервера раундстартом.

## Тестирование
На коробке сработало.

## Changelog

:cl: Maxiemar
fix: Фабрикатор снова автоматически подключен к серверам РНД.
/:cl:
