### PR TITLE
Fix Katarina species sprite

### DIFF
--- a/modular_ss220/clothing/code/under.dm
+++ b/modular_ss220/clothing/code/under.dm
@@ -7,6 +7,7 @@
 	lefthand_file = 'modular_ss220/clothing/icons/inhands/left_hand.dmi'
 	righthand_file = 'modular_ss220/clothing/icons/inhands/right_hand.dmi'
 	item_color = "katarina_cybersuit"
+	sprite_sheets = null
 
 /obj/item/clothing/under/costume/katarina_suit
 	name = "костюм Катарины"
@@ -17,6 +18,7 @@
 	lefthand_file = 'modular_ss220/clothing/icons/inhands/left_hand.dmi'
 	righthand_file = 'modular_ss220/clothing/icons/inhands/right_hand.dmi'
 	item_color = "katarina_suit"
+	sprite_sheets = null
 
 /obj/item/clothing/under/rank/civilian/chef/red
 	name = "chef's red uniform"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет отсутствие спрайта на расовых спрайтах по типу вульпы и так далее. Заебало видеть челов, которые абузят спрайт и бегают с надписью suit :Fortune:

## Почему это хорошо для игры
Меньше багов.

## Тестирование
Протестировал на локалке.

## Changelog

:cl:
fix: Исправлено отсутствие спрайта у рас у костюма Катарины.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
