### PR TITLE
FIX: RnD server & Xeno Glass Door | BoxStation

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -30698,11 +30698,13 @@
 	},
 /obj/machinery/door/window/reinforced/normal{
 	dir = 8;
-	name = "Server Interior Door"
+	name = "Server Interior Door";
+	superconductivity = 0
 	},
 /obj/machinery/door/window/reinforced/normal{
 	dir = 4;
-	name = "Server Exterior Door"
+	name = "Server Exterior Door";
+	superconductivity = 0
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -99493,7 +99495,8 @@
 "wIr" = (
 /obj/machinery/door/window/classic/reversed{
 	dir = 1;
-	name = "Kill Chamber"
+	name = "Kill Chamber";
+	superconductivity = 0
 	},
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -103137,7 +103140,8 @@
 /area/station/maintenance/fsmaint)
 "xUX" = (
 /obj/machinery/door/window/classic/reversed{
-	name = "Kill Chamber"
+	name = "Kill Chamber";
+	superconductivity = 0
 	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "xenobio1";


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Фикс стеклянных дверей для стабилизации температур в серверной РнД и Ксено
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
РнД наконец не будет продувать
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
Не требуется
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Не требуется
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: BoxStation | Стеклянные створки в серверной РнД и Ксено больше продувают РнД
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
