### PR TITLE
Allow admins to set non votable maps

### DIFF
--- a/code/modules/admin/verbs/mapping_verbs.dm
+++ b/code/modules/admin/verbs/mapping_verbs.dm
@@ -190,8 +190,9 @@ GLOBAL_VAR_INIT(intercom_range_display_status, 0)
 	var/list/map_datums = list()
 	for(var/x in subtypesof(/datum/map))
 		var/datum/map/M = x
-		if(initial(M.voteable))
-			map_datums["[initial(M.fluff_name)] ([initial(M.technical_name)])"] = M // Put our map in
+		// SS220 EDIT - START
+		map_datums["[initial(M.fluff_name)] ([initial(M.technical_name)])"] = M // Put our map in
+		// SS220 EDIT - END
 
 	var/target_map_name = input(usr, "Select target map", "Next map", null) as null|anything in map_datums
 


### PR DESCRIPTION
## Что этот PR делает
Разрешает администрации устанавливать карты, недоступные для голосования. Не знаю, зачем было это запрещать. Простого способа выполнить это иначе не нахожу.

## Почему это хорошо для игры
Возможно попробовать другие карты и покритиковать.

## Тестирование
Выставить можно, проверить загрузку на локалке не удалось.

![image](https://github.com/user-attachments/assets/abb16d3d-5e35-44ca-811c-b117f0759bee)

## Changelog

:cl: Maxiemar
tweak: Администрации теперь проще установить карты, недоступные для голосования.
/:cl:
