### PR TITLE
Fix: DM 1643 compatibility patch

### DIFF
--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -4,10 +4,19 @@
 
 // Mutable appearances are children of images, just so you know.
 
-/mutable_appearance/New()
+// Mutable appearances erase template vars on new, because they accept an appearance to copy as an arg
+// If we have nothin to copy, we set the float plane
+
+#if DM_BUILD > 1642
+/mutable_appearance/proc/New(mutable_appearance/to_copy)
+	if(!to_copy)
+		plane = FLOAT_PLANE
+#else
+/mutable_appearance/New(mutable_appearance/to_copy)
 	..()
-	plane = FLOAT_PLANE // No clue why this is 0 by default yet images are on FLOAT_PLANE
-						// And yes this does have to be in the constructor, BYOND ignores it if you set it as a normal var
+	if(!to_copy)
+		plane = FLOAT_PLANE
+#endif
 
 // Helper similar to image()
 /proc/mutable_appearance(icon, icon_state = "", layer = FLOAT_LAYER, plane = FLOAT_PLANE, alpha = 255, appearance_flags = NONE, color)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Это черри-пик https://github.com/ss220-space/Paradise/commit/0d07c4808b73af1ec9ef0a6a61248c6f3c3d8897

Делает билд совместимым с версиями DM > 1642. На новых версиях DM'a билд не собирается.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Теперь игру можно собрать на новых версиях бульонда 😃 

## Тестирование

Одинаково нормально запускается на новой DM 1643 и старой DM 1640.

## Changelog

:cl: HereComesLurker
fix: сделал mutable_appearance совместимым с DM > 1642
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
