### PR TITLE
Tweak: Adds playtime requirement for Vox Raiders and Blood Brothers (Modular Edition)

### DIFF
--- a/modular_ss220/antagonists/_antagonists.dm
+++ b/modular_ss220/antagonists/_antagonists.dm
@@ -4,6 +4,15 @@
 	author = "Gaxeer, dj-34, PhantomRU"
 
 /datum/modpack/antagonists/initialize()
+	GLOB.role_playtime_requirements |= list(
+		ROLE_BLOOD_BROTHER = 20,
+		ROLE_VOX_RAIDER = 20
+	)
+	GLOB.special_role_times |= list(
+		ROLE_BLOOD_BROTHER = 21,
+		ROLE_VOX_RAIDER = 21
+	)
+
 	GLOB.huds += new/datum/atom_hud/antag/hidden()
 	GLOB.special_roles |= ROLE_BLOOD_BROTHER
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Тоже самое что и это https://github.com/ss220club/Paradise-SS220/pull/1522, но модульно

И Я НЕ ЗНАЮ БУДЕТ ЛИ ОНО ТАК РАБОТАТЬ, но по крайней мере локалка работает и на том спасибо.

## Changelog

:cl:
tweak: Теперь для игры на Воксах-Рейдерах и Братьях по крови нужно наиграть часы на экипаже.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
