### PR TITLE
Consider `R_BAN` permission as admin permission

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -134,8 +134,8 @@
 				line += " (AFK)"
 
 		line += "<br>"
-		if(check_rights(R_BAN, FALSE, C.mob)) // Is this client an admin? // SS220 EDIT
-			if(C?.holder?.fakekey && !check_rights(R_BAN, FALSE)) // Only admins can see stealthmins // SS220 EDIT
+		if(check_rights(R_BAN, FALSE, C.mob)) // Is this client an admin? // SS220 EDIT - R_ADMIN -> R_BAN
+			if(C?.holder?.fakekey && !check_rights(R_BAN, FALSE)) // Only admins can see stealthmins // SS220 EDIT - R_ADMIN -> R_BAN
 				continue
 
 			if(C?.holder?.big_brother && !check_rights(R_PERMISSIONS, FALSE)) // Normal admins can't see Big Brother

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -134,8 +134,8 @@
 				line += " (AFK)"
 
 		line += "<br>"
-		if(check_rights(R_ADMIN, FALSE, C.mob)) // Is this client an admin?
-			if(C?.holder?.fakekey && !check_rights(R_ADMIN, FALSE)) // Only admins can see stealthmins
+		if(check_rights(R_BAN, FALSE, C.mob)) // Is this client an admin? // SS220 EDIT
+			if(C?.holder?.fakekey && !check_rights(R_BAN, FALSE)) // Only admins can see stealthmins // SS220 EDIT
 				continue
 
 			if(C?.holder?.big_brother && !check_rights(R_PERMISSIONS, FALSE)) // Normal admins can't see Big Brother


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Правит классификацию стаффа путем изменения подсчета администрации. Теперь администратором считается клиент с правом `R_BAN`, а не `R_ADMIN`, потому что разработчики получили кнопки для отладки.

## Почему это хорошо для игры
Не сбивает с толку игроков.

## Тестирование

![image](https://github.com/user-attachments/assets/853a9b4d-e699-4842-a7a6-8e0ff3035c83)
