### PR TITLE
autosurgeons now work in cc cargo

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -14830,11 +14830,11 @@
 "iOx" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
-/obj/item/autosurgeon,
-/obj/item/autosurgeon,
-/obj/item/autosurgeon,
-/obj/item/autosurgeon,
-/obj/item/autosurgeon,
+/obj/item/autosurgeon/organ,
+/obj/item/autosurgeon/organ,
+/obj/item/autosurgeon/organ,
+/obj/item/autosurgeon/organ,
+/obj/item/autosurgeon/organ,
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "iOD" = (


### PR DESCRIPTION
## Что этот PR делает
Фиксит путь автохирургов в карго на ЦК.

## Почему это хорошо для игры
Автохирурги теперь работают

## Изображения изменений
Маппдиф

## Тестирование
Наверное работает

## Changelog

:cl:
fix: Автохирурги в карго на ЦК теперь не липовые, а рабочие
/:cl:
