### PR TITLE
Projectile Fixes

### DIFF
--- a/modular_ss220/balance/code/items/projectiles.dm
+++ b/modular_ss220/balance/code/items/projectiles.dm
@@ -2,16 +2,17 @@
 	///If TRUE, hit mobs even if they're on the floor and not our target
 	var/hit_prone_targets = FALSE
 
-/obj/item/projectile/set_angle(new_angle)
+/atom/handle_ricochet(obj/item/projectile/ricocheting_projectile)
 	. = ..()
-	hit_prone_targets = TRUE
+	if(.)
+		// here is confirmed ricochet - force projectile to hit targets
+		ricocheting_projectile.hit_prone_targets = TRUE
 
 /obj/item/ammo_casing/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/firer_source_atom)
 	. = ..()
 	if(!BB)
 		return
-	if(user.a_intent != INTENT_HELP)
-		BB.hit_prone_targets = TRUE
+	BB.hit_prone_targets = user.a_intent != INTENT_HELP
 
 /mob/living/carbon/human/projectile_hit_check(obj/item/projectile/P)
 	if(stat == CONSCIOUS)

--- a/modular_ss220/maps220/code/walls.dm
+++ b/modular_ss220/maps220/code/walls.dm
@@ -26,7 +26,7 @@
 	icon_state = "plastinum_wall-0"
 	base_icon_state = "plastinum_wall"
 	explosion_block = 3
-	flags_2 = RICOCHET_SHINY | RICOCHET_HARD
+	flags_ricochet = RICOCHET_SHINY | RICOCHET_HARD
 	sheet_type = /obj/item/stack/sheet/mineral/titanium
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	smoothing_groups = list(SMOOTH_GROUP_TITANIUM_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE)


### PR DESCRIPTION
## Что этот PR делает
Чинит попадание снарядов по телам в соответствии с #586.
Чинит флаги рикошета у турфа.

Fixes #1375.

## Почему это хорошо для игры
Баги плохо.

## Тестирование

<details>
<summary>Попадание в разных интентах</summary>

https://github.com/user-attachments/assets/3575944a-2d17-43fa-bbb5-866ed98c0f48

</details>

<details>
<summary>Попадание рикошетом</summary>

https://github.com/user-attachments/assets/a5f96070-b25d-4398-b718-a9d397fb12a7

</details>

## Changelog

:cl: Maxiemar
fix: Логика попадания теперь должна работать как ранее: снаряд проходит сквозь лежащую куклу в хелп интенте и не проходит в остальных.
fix: Стены белого шаттла снова отражают снаряды.
/:cl:
