### PR TITLE
Add a photocopier to Magistrate's office

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -6946,8 +6946,14 @@
 /area/station/legal/magistrate)
 "aAN" = (
 /obj/structure/table,
-/obj/item/taperecorder,
-/obj/item/megaphone,
+/obj/item/taperecorder{
+	pixel_x = -7;
+	pixel_y = -5
+	},
+/obj/item/megaphone{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /obj/machinery/button/windowtint/east{
 	id = "Magistrate";
 	pixel_y = 6;
@@ -7387,14 +7393,29 @@
 /area/station/maintenance/fore)
 "aCi" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/pen/multi/gold,
-/obj/item/stamp/magistrate,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/pen/multi/gold{
+	pixel_x = -22;
+	pixel_y = 8
+	},
+/obj/item/clothing/head/helmet/skull/Yorick{
+	pixel_x = 7;
+	pixel_y = 9
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "aCj" = (
 /obj/structure/table,
-/obj/item/paper_bin/nanotrasen,
+/obj/item/paper_bin/nanotrasen{
+	pixel_x = 4
+	},
+/obj/item/stamp/magistrate{
+	pixel_y = 7;
+	pixel_x = -7
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "aCl" = (
@@ -8301,7 +8322,10 @@
 /area/station/legal/courtroom)
 "aFm" = (
 /obj/structure/table,
-/obj/item/gavelblock,
+/obj/item/gavelblock{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /obj/item/gavelhammer,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable{
@@ -8311,6 +8335,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/spawner/lootdrop/officetoys,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/magistrate)
 "aFn" = (
@@ -8325,7 +8350,6 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/magistrate)
 "aFp" = (
-/obj/structure/table,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8334,19 +8358,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/pen/multi,
-/obj/effect/spawner/lootdrop/officetoys,
-/obj/item/clothing/head/helmet/skull/Yorick,
+/obj/machinery/photocopier,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/magistrate)
 "aFq" = (
 /obj/structure/table,
 /obj/item/folder/blue{
-	pixel_x = 10;
-	pixel_y = 4
+	pixel_x = 7;
+	pixel_y = 1
 	},
 /obj/item/paper_bin{
-	pixel_x = -4;
+	pixel_x = -6;
 	pixel_y = 4
 	},
 /obj/structure/cable{
@@ -8358,8 +8380,12 @@
 	dir = 4
 	},
 /obj/item/folder/yellow{
-	pixel_x = 14;
-	pixel_y = 4
+	pixel_x = 10;
+	pixel_y = 1
+	},
+/obj/item/pen/multi{
+	pixel_x = -6;
+	pixel_y = 8
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/legal/magistrate)

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -5876,6 +5876,11 @@
 "aFd" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/magistrate,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "aFe" = (
@@ -7761,7 +7766,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -27919,8 +27924,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "bWp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -48715,7 +48720,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "frX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -54246,7 +54251,6 @@
 /area/station/science/toxins/mixing)
 "hQZ" = (
 /obj/structure/closet/secure_closet/magistrate,
-/obj/machinery/alarm/directional/north,
 /obj/item/megaphone,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
@@ -58746,6 +58750,9 @@
 	pixel_y = -4
 	},
 /obj/item/clothing/head/helmet/skull/Yorick,
+/obj/item/radio/intercom/department/security{
+	pixel_y = 22
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "jXo" = (
@@ -61150,9 +61157,6 @@
 /area/station/engineering/control)
 "lcg" = (
 /obj/structure/filingcabinet,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -65266,11 +65270,10 @@
 	},
 /area/station/medical/storage)
 "mUi" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/power/apc/directional/east,
+/obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -67970,11 +67973,6 @@
 /area/station/security/brig)
 "och" = (
 /obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -69799,6 +69797,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "pds" = (
@@ -79497,6 +79500,11 @@
 	},
 /obj/item/stamp/magistrate,
 /obj/effect/spawner/lootdrop/officetoys,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "tHA" = (
@@ -80139,8 +80147,10 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "uaU" = (
-/obj/item/radio/intercom/department/security{
-	pixel_y = 22
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -83529,6 +83539,14 @@
 "vHD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -84324,6 +84342,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -27924,8 +27924,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "bWp" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -47386,6 +47386,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"eLF" = (
+/obj/structure/closet/secure_closet/magistrate,
+/obj/item/megaphone,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/magistrate)
 "eLQ" = (
 /obj/structure/closet/secure_closet/medical3,
 /turf/simulated/floor/plasteel{
@@ -51668,6 +51675,12 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"gLQ" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/magistrate)
 "gMh" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52361,13 +52374,8 @@
 /area/station/maintenance/solar_maintenance/port)
 "hbB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/wall,
+/area/station/legal/magistrate)
 "hbN" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -54250,8 +54258,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "hQZ" = (
-/obj/structure/closet/secure_closet/magistrate,
-/obj/item/megaphone,
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -57249,6 +57260,17 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/medical/genetics,
 /turf/simulated/floor/grass/no_creep,
 /area/station/science/genetics)
+"jrc" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "jrp" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -61156,7 +61178,9 @@
 	},
 /area/station/engineering/control)
 "lcg" = (
-/obj/structure/filingcabinet,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -65620,6 +65644,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central)
+"mYX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "mZb" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
@@ -75922,16 +75953,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "rWn" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/turf/simulated/floor/plasteel{
+	icon_state = "cult"
+	},
+/area/station/legal/magistrate)
 "rWr" = (
 /obj/structure/rack,
 /obj/item/storage/fancy/crayons,
@@ -80147,10 +80175,10 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "uaU" = (
-/obj/machinery/power/apc/directional/north,
 /obj/structure/cable/yellow{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
@@ -83978,6 +84006,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
+"vUU" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fore)
 "vUV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -118711,7 +118747,7 @@ asV
 apz
 hQZ
 lcg
-kXX
+rWn
 abZ
 tQN
 abZ
@@ -118966,9 +119002,9 @@ qeK
 fPT
 qeK
 apz
-abZ
-abZ
-abZ
+eLF
+gLQ
+kXX
 abZ
 aZU
 aNC
@@ -119222,12 +119258,12 @@ fRm
 pRp
 gRm
 lHy
-ajg
-nPD
-alW
+abZ
+abZ
+abZ
 hbB
-rWn
-gbu
+abZ
+aZU
 baL
 aMk
 aMk
@@ -119480,11 +119516,11 @@ urH
 arf
 wGv
 aWv
-azu
+nPD
 ahd
-api
-ajg
-aNC
+vUU
+jrc
+gbu
 aNC
 oxT
 etj
@@ -119737,7 +119773,7 @@ wMy
 hIP
 hjE
 ajg
-akT
+mYX
 alW
 api
 ajg


### PR DESCRIPTION
## Что этот PR делает
Добавляет магистрату на коробке и мете по принтеру.
Небольшая перестановка в офисе, чтоб влезло как надо.

## Почему это хорошо для игры
Не надо ходить к агентам за принтером.

## Изображения изменений
mapdiff

## Тестирование
Есть принтер, печатает.

## Changelog

:cl: Maxiemar
tweak: В офисы магистратов на станциях поставили принтер.
tweak: Офис магистрата на Цереброне незначительно расширен.
/:cl:
