### PR TITLE
Gulag (Labor camp) improvements & Move Lavaland shuttles to CC

### DIFF
--- a/_maps/map_files220/generic/Lavaland.dmm
+++ b/_maps/map_files220/generic/Lavaland.dmm
@@ -127,11 +127,12 @@
 	},
 /area/mine/laborcamp)
 "aw" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 4
+/obj/structure/platform/reinforced{
+	dir = 4;
+	anchored = 1
 	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "ax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -643,9 +644,11 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "bF" = (
-/obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/plating/lavaland_air,
-/area/shuttle/mining)
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 6
+	},
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "bG" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/drinks/cans/beer,
@@ -726,24 +729,16 @@
 /turf/simulated/wall,
 /area/mine/outpost/cafeteria)
 "bO" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Labor Shuttle Airlock"
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
 	},
-/obj/docking_port/mobile/labour,
-/obj/structure/fans/tiny,
-/obj/docking_port/stationary{
-	area_type = /area/lavaland/surface/outdoors;
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_away";
-	name = "labor camp";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
-	width = 9
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "floor_large"
 	},
-/turf/simulated/floor/plating,
-/area/shuttle/siberia)
+/area/mine/laborcamp)
 "bP" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/maintenance/external,
@@ -2587,15 +2582,11 @@
 /turf/simulated/wall,
 /area/mine/outpost/maintenance/south)
 "fu" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+/obj/structure/platform/reinforced/corner{
+	anchored = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "fv" = (
 /obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/plasteel{
@@ -2889,10 +2880,14 @@
 	},
 /area/mine/outpost/hallway/west)
 "gb" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip"
+	},
+/area/lavaland/surface/outdoors)
 "gd" = (
 /turf/simulated/wall,
 /area/mine/outpost/mechbay)
@@ -3378,14 +3373,17 @@
 	},
 /area/mine/outpost/medbay)
 "hf" = (
-/obj/machinery/flasher_button{
-	id = "gulagshuttleflasher";
-	name = "Flash Control";
-	pixel_y = -26;
-	req_access_txt = "1"
+/obj/machinery/door/airlock/external{
+	id_tag = "laborcamp_away"
 	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark_large"
+	},
+/area/mine/laborcamp/security)
 "hg" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
@@ -3404,17 +3402,12 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "hj" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/platform/reinforced{
+	dir = 8;
+	anchored = 1
 	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/effect/turf_decal{
-	dir = 10
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "hl" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -3719,14 +3712,10 @@
 	},
 /area/mine/outpost/lockers)
 "iB" = (
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "dark_small"
 	},
-/obj/machinery/mineral/labor_prisoner_shuttle_console{
-	pixel_y = 32
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors)
 "iC" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -4251,8 +4240,11 @@
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/legion)
 "kI" = (
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/siberia)
+/obj/structure/platform/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "kJ" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -5375,14 +5367,26 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "pn" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/machinery/computer/shuttle/labor/one_way{
+	dir = 4
 	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/siberia)
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "pq" = (
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/siberia)
+/obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_away";
+	name = "labor camp";
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	width = 9
+	},
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "dark_small"
+	},
+/area/lavaland/surface/outdoors)
 "pt" = (
 /obj/item/radio/intercom/locked/prison{
 	pixel_y = -22;
@@ -5615,9 +5619,12 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "rM" = (
-/obj/effect/baseturf_helper/lava_land,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/obj/structure/platform/reinforced/corner{
+	dir = 4;
+	anchored = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "rO" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing/corner{
@@ -5715,10 +5722,12 @@
 /turf/simulated/floor/plating,
 /area/mine/outpost/maintenance/south)
 "sv" = (
-/obj/machinery/light/directional/east,
-/obj/structure/closet/secure_closet/brig/gulag,
-/turf/simulated/floor/plasteel,
-/area/mine/laborcamp)
+/obj/structure/platform/reinforced/corner{
+	dir = 8;
+	anchored = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "sw" = (
 /obj/structure/chair{
 	dir = 1
@@ -5817,9 +5826,11 @@
 	},
 /area/mine/outpost/hallway/east)
 "tb" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
-/area/shuttle/mining)
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 8
+	},
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "td" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -6144,7 +6155,8 @@
 "uL" = (
 /obj/effect/spawner/window/reinforced,
 /obj/machinery/flasher{
-	id = "labor"
+	id = "labor";
+	layer = 4
 	},
 /turf/simulated/floor/plating,
 /area/mine/laborcamp)
@@ -6258,12 +6270,10 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "vk" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Labor Shuttle Airlock"
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "dark_large"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors)
 "vm" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -6470,9 +6480,15 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "wt" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/simulated/floor/plating/lavaland_air,
-/area/shuttle/siberia)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 8
+	},
+/area/lavaland/surface/outdoors)
 "wC" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -6529,12 +6545,11 @@
 /turf/simulated/floor/plating,
 /area/mine/outpost/medbay)
 "wP" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/plasmareinforced{
-	dir = 1
+/obj/structure/sign/securearea{
+	name = "\improper KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/floor/plating/lavaland_air,
-/area/shuttle/siberia)
+/turf/simulated/wall/r_wall,
+/area/mine/laborcamp)
 "wS" = (
 /obj/structure/stone_tile/surrounding_tile/burnt,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -6637,8 +6652,11 @@
 	},
 /area/mine/outpost/airlock)
 "xC" = (
-/turf/simulated/wall/mineral/titanium,
-/area/shuttle/mining)
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 9
+	},
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "xD" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/random/high_chance/volcanic,
@@ -6807,6 +6825,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Labor Camp Lockers";
+	network = list("Labor Camp");
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
@@ -7023,15 +7046,8 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored)
 "zY" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Labor Camp Lockers";
-	network = list("Labor Camp");
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/west,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "Ab" = (
@@ -7230,12 +7246,6 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "AN" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/docking_port/mobile/mining,
-/obj/structure/fans/tiny,
 /obj/docking_port/stationary{
 	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
@@ -7246,9 +7256,11 @@
 	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
 	width = 7
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
-/turf/simulated/floor/plating,
-/area/shuttle/mining)
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 4
+	},
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "AP" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -7289,8 +7301,15 @@
 	},
 /area/mine/outpost/cafeteria)
 "Bg" = (
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/marker_beacon/dock_marker,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowcornersalt"
+	},
+/area/lavaland/surface/outdoors)
 "Bj" = (
 /obj/structure/rack,
 /obj/item/storage/bag/ore,
@@ -7363,6 +7382,12 @@
 /obj/structure/clockwork/wall_gear,
 /turf/simulated/wall/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
+"By" = (
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowcornersalt";
+	dir = 4
+	},
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "BB" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/random/volcanic,
@@ -7396,11 +7421,11 @@
 /turf/simulated/wall,
 /area/mine/outpost/hallway/east)
 "BP" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 5
 	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "BT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7444,8 +7469,16 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "Cf" = (
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/marker_beacon/dock_marker,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowcornersalt";
+	dir = 4
+	},
+/area/lavaland/surface/outdoors)
 "Ch" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7574,19 +7607,11 @@
 	},
 /area/mine/laborcamp/security)
 "CK" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowcornersalt";
+	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Labor Camp Shuttle";
-	network = list("Labor Camp");
-	dir = 4
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "CL" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -7629,23 +7654,15 @@
 	},
 /area/mine/laborcamp)
 "CX" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/camera{
-	c_tag = "Mining Outpost - Shuttle";
-	dir = 5;
-	network = list("Mining Outpost")
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip"
 	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "CY" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "dark_large"
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Dc" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7797,8 +7814,9 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "DT" = (
-/obj/machinery/computer/shuttle/labor/one_way,
-/obj/effect/decal/cleanable/cobweb,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
 "DU" = (
@@ -8090,14 +8108,16 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "FW" = (
-/obj/machinery/door/airlock/titanium{
-	id_tag = "s_docking_airlock";
-	name = "Labor Shuttle Airlock"
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/brig,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
-/area/shuttle/siberia)
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark_large"
+	},
+/area/mine/laborcamp/security)
 "FX" = (
 /obj/structure/ore_box,
 /obj/effect/mapping_helpers/no_lava,
@@ -8143,12 +8163,11 @@
 	},
 /area/mine/laborcamp)
 "Gn" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 10
 	},
-/obj/structure/sign/poster/official/random/south,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Gp" = (
 /obj/structure/sign/poster/contraband/clown,
 /obj/effect/spawner/random_spawners/wall_rusted_always,
@@ -8247,13 +8266,13 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "Hc" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "laborcamp_away"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark_large"
+	},
 /area/mine/laborcamp/security)
 "Hd" = (
 /obj/structure/stone_tile/surrounding_tile{
@@ -8502,6 +8521,12 @@
 	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
+"Ip" = (
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 1
+	},
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Iv" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
@@ -8590,10 +8615,15 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "IN" = (
-/obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/light/small/directional/west,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 4
+	},
+/area/lavaland/surface/outdoors)
 "IP" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -8656,6 +8686,12 @@
 /obj/structure/stone_tile/center,
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/legion)
+"Ji" = (
+/obj/structure/platform/reinforced/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Jl" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/machine,
@@ -8688,15 +8724,16 @@
 /turf/simulated/floor/lava/lava_land_surface,
 /area/lavaland/surface/outdoors/legion)
 "Jx" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/plasmareinforced{
-	dir = 1
+/obj/structure/marker_beacon/dock_marker,
+/obj/structure/railing{
+	dir = 5
 	},
-/obj/structure/window/plasmareinforced{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowcornersalt";
+	dir = 8
 	},
-/turf/simulated/floor/plating/lavaland_air,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors)
 "JC" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/decal/cleanable/dirt,
@@ -8941,18 +8978,18 @@
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors)
 "KR" = (
-/obj/machinery/flasher{
-	id = "gulagshuttleflasher";
-	pixel_x = 25
-	},
-/obj/structure/chair/comfy/shuttle{
+/obj/structure/marker_beacon/dock_marker/collision,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Labor Camp Landing Pad";
+	network = list("Labor Camp");
 	dir = 8
 	},
-/obj/effect/turf_decal{
-	dir = 9
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 8
 	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors)
 "KS" = (
 /turf/simulated/wall/boss,
 /area/lavaland/surface/outdoors/unexplored/danger)
@@ -9316,12 +9353,11 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "Nc" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
+/obj/structure/platform/reinforced{
+	anchored = 1
 	},
-/obj/machinery/light/directional/south,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "Ne" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9429,9 +9465,16 @@
 /turf/simulated/wall/mineral/iron,
 /area/lavaland/surface/outdoors)
 "NP" = (
-/obj/machinery/computer/shuttle/mining,
-/turf/simulated/floor/mineral/titanium/blue,
-/area/shuttle/mining)
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/marker_beacon/dock_marker,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowcornersalt";
+	dir = 1
+	},
+/area/lavaland/surface/outdoors)
 "NR" = (
 /obj/structure/mopbucket/full,
 /obj/item/mop,
@@ -9454,9 +9497,12 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "NW" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
-/area/shuttle/siberia)
+/obj/structure/platform/reinforced{
+	dir = 1;
+	anchored = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "NZ" = (
 /obj/structure/toilet,
 /obj/effect/decal/cleanable/cobweb,
@@ -9869,18 +9915,11 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "QZ" = (
-/obj/structure/shuttle/engine/heater,
-/obj/structure/window/plasmareinforced{
-	dir = 1
-	},
-/obj/structure/window/plasmareinforced{
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
 	dir = 4
 	},
-/obj/structure/window/plasmareinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating/lavaland_air,
-/area/shuttle/mining)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Rb" = (
 /obj/structure/grille/broken,
 /obj/structure/grille/broken,
@@ -10288,12 +10327,12 @@
 	},
 /area/mine/outpost/hallway/east)
 "TU" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "laborcamp_away"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/fans/tiny,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "floor_large"
+	},
 /area/mine/laborcamp)
 "TV" = (
 /obj/structure/grille/broken,
@@ -10405,14 +10444,13 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "Uy" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel/lavaland_air{
+	icon_state = "darkyellowaltstrip";
+	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 5
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/area/lavaland/surface/outdoors)
 "UA" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -10647,9 +10685,16 @@
 	},
 /area/mine/outpost/cafeteria)
 "VI" = (
-/obj/effect/baseturf_helper/asteroid/basalt,
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/siberia)
+/obj/machinery/door/airlock/external{
+	id_tag = "laborcamp_away"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	icon_state = "floor_large"
+	},
+/area/mine/laborcamp)
 "VJ" = (
 /obj/effect/spawner/random_spawners/wall_rusted_always,
 /turf/simulated/wall/r_wall,
@@ -10786,11 +10831,10 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Wo" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/turf/simulated/floor/mineral/titanium,
-/area/shuttle/mining)
+/obj/structure/closet/secure_closet/brig/gulag,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Wt" = (
 /obj/structure/window/reinforced/clockwork{
 	dir = 4;
@@ -10813,19 +10857,11 @@
 	},
 /area/mine/outpost/hallway/east)
 "Wx" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/restraints/handcuffs,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sign/securearea{
+	name = "\improper KEEP CLEAR: DOCKING AREA"
 	},
-/obj/machinery/flasher_button{
-	id = "gulagshuttleflasher";
-	name = "Flash Control";
-	req_access_txt = "1"
-	},
-/turf/simulated/floor/mineral/plastitanium/red,
-/area/shuttle/siberia)
+/turf/simulated/wall/r_wall,
+/area/mine/laborcamp/security)
 "WC" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/sign/nanotrasen{
@@ -12156,7 +12192,7 @@ aj
 aj
 aj
 aj
-aj
+ab
 aj
 aj
 aj
@@ -12399,21 +12435,21 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
+ab
+ab
 aj
 aj
 aj
 ab
+ab
+aj
+aj
+aj
+ab
+ab
+aj
+aj
 aj
 aj
 aj
@@ -12656,19 +12692,19 @@ aj
 aj
 aj
 aj
+ab
+Ll
+ab
+ab
+ab
+ab
+Xu
+ab
+dT
+ab
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
+ab
 aj
 aj
 aj
@@ -12912,21 +12948,21 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
+fu
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+aw
+sv
+ab
 aj
 aj
 aj
@@ -13168,23 +13204,23 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+ab
+ab
+Nc
+Bg
+IN
+IN
+IN
+IN
+IN
+IN
+IN
+IN
+IN
+Cf
+NW
+ab
+ab
 aj
 aj
 ai
@@ -13425,23 +13461,23 @@ aj
 aj
 aj
 aj
-aj
-aj
-aj
-aj
-aj
 ab
-dT
-aj
-aj
-aj
 ab
-Xu
-aj
-aj
-aj
+Nc
+gb
+iB
+iB
+iB
+iB
+iB
+iB
+iB
+iB
+iB
+Uy
+NW
 ab
-aj
+ab
 aj
 aj
 ab
@@ -13683,21 +13719,21 @@ aj
 aj
 aj
 aj
-aj
-aj
-ab
-ab
-Ll
-ab
-ab
-ab
 dT
+Nc
+gb
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+Uy
+NW
 ab
-ab
-ab
-ab
-aj
-aj
 aj
 aj
 aj
@@ -13939,22 +13975,22 @@ ab
 ab
 aj
 aj
-aj
-aj
 ab
 ab
-kI
-kI
+Nc
+gb
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+Uy
 NW
-kI
-kI
-NW
-kI
-kI
-kI
 ab
-aj
-aj
 aj
 aj
 aj
@@ -14197,22 +14233,22 @@ aj
 aj
 aj
 aj
-ab
-ab
-ab
-NW
-aw
-Bg
+ai
+Nc
+gb
 vk
-pn
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
 Uy
-CK
-wP
-wt
-ab
-ab
-aj
-aj
+NW
+ai
+ai
 aj
 aj
 ab
@@ -14454,22 +14490,22 @@ aj
 aj
 aj
 aj
-aj
-ab
 ai
-NW
-BP
-Bg
-kI
+Nc
+gb
 iB
-VI
+iB
+iB
+iB
+iB
+iB
 pq
-Jx
-wt
+iB
+iB
+Uy
+NW
+ai
 ab
-ai
-ai
-aj
 aj
 aj
 aj
@@ -14712,21 +14748,21 @@ aj
 aD
 aj
 aj
-aj
-ai
-NW
+Nc
+Jx
+wt
 Wx
 hf
-kI
+PX
 KR
-hj
-pq
+Hs
+VI
 wP
 wt
+NP
+NW
+VK
 ab
-ai
-aj
-aj
 aj
 aj
 aj
@@ -14969,21 +15005,21 @@ tj
 wY
 aj
 aj
-aj
-ab
+Ji
 kI
 kI
+PX
 FW
-kI
-kI
-kI
+PX
+Hs
+Hs
 bO
-kI
-kI
+VJ
+hj
+hj
+rM
 ab
-VK
-aj
-aj
+ab
 aj
 aj
 ab
@@ -15228,18 +15264,18 @@ aj
 aj
 cG
 cG
-PX
+cG
 PX
 Hc
 PX
-Hs
+pn
 Hs
 TU
-VJ
-ai
+Hs
+aj
+aj
 ab
-aj
-aj
+ab
 aj
 aj
 aj
@@ -16517,8 +16553,8 @@ aQ
 OE
 OU
 PX
+Wo
 op
-sv
 jn
 Hs
 bZ
@@ -19879,10 +19915,10 @@ GO
 fd
 xC
 tb
-xC
 tb
-QZ
-bF
+tb
+tb
+Gn
 kQ
 ch
 Hf
@@ -20134,12 +20170,12 @@ aj
 fo
 Qd
 xC
-xC
-IN
+CK
+CY
+CY
+CY
+CY
 CX
-fu
-Gn
-xC
 Eg
 XL
 Hf
@@ -20390,13 +20426,13 @@ aj
 FO
 fo
 tE
-tb
-NP
-Wo
-rM
-fu
-Nc
-xC
+Ip
+CY
+CY
+CY
+CY
+CY
+CX
 Eg
 XL
 Hf
@@ -20647,13 +20683,13 @@ aj
 ab
 fo
 Sa
-xC
-xC
-gb
-Cf
-fu
+BP
+By
 CY
-xC
+CY
+CY
+CY
+CX
 Eg
 ch
 vh
@@ -20905,10 +20941,10 @@ ab
 uN
 Ur
 fA
-xC
-tb
+BP
+QZ
 AN
-tb
+QZ
 QZ
 bF
 kQ

--- a/_maps/map_files220/generic/Lavaland.dmm
+++ b/_maps/map_files220/generic/Lavaland.dmm
@@ -267,6 +267,7 @@
 	},
 /area/mine/outpost/hallway/east)
 "aP" = (
+/obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -644,10 +645,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "bF" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 6
-	},
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "bG" = (
 /obj/structure/closet/crate/freezer,
@@ -3093,6 +3091,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/flasher_button{
+	id = "labor";
+	pixel_y = -24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -3711,11 +3713,6 @@
 	icon_state = "dark"
 	},
 /area/mine/outpost/lockers)
-"iB" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "dark_small"
-	},
-/area/lavaland/surface/outdoors)
 "iC" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -3901,6 +3898,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/cigbutt,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredyellowfull"
 	},
@@ -4239,12 +4237,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors/legion)
-"kI" = (
-/obj/structure/platform/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "kJ" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -5380,12 +5372,10 @@
 	height = 5;
 	id = "laborcamp_away";
 	name = "labor camp";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	turf_type = /turf/simulated/floor/plating/lavaland_air;
 	width = 9
 	},
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "dark_small"
-	},
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors)
 "pt" = (
 /obj/item/radio/intercom/locked/prison{
@@ -5825,12 +5815,6 @@
 	dir = 4
 	},
 /area/mine/outpost/hallway/east)
-"tb" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 8
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "td" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -6270,9 +6254,7 @@
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "vk" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "dark_large"
-	},
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors)
 "vm" = (
 /obj/structure/stone_tile/block{
@@ -6652,11 +6634,9 @@
 	},
 /area/mine/outpost/airlock)
 "xC" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 9
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "xD" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/random/high_chance/volcanic,
@@ -7253,13 +7233,10 @@
 	height = 5;
 	id = "mining_away";
 	name = "lavaland mine";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	turf_type = /turf/simulated/floor/plating/lavaland_air;
 	width = 7
 	},
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 4
-	},
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "AP" = (
 /obj/structure/stone_tile/block{
@@ -7383,11 +7360,17 @@
 /turf/simulated/wall/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "By" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowcornersalt";
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/restraints/handcuffs{
+	pixel_y = 4
 	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/obj/item/restraints/handcuffs,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/mine/laborcamp/security)
 "BB" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/random/volcanic,
@@ -7420,12 +7403,6 @@
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
 /area/mine/outpost/hallway/east)
-"BP" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 5
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "BT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7454,7 +7431,7 @@
 	},
 /area/mine/outpost/cafeteria)
 "Ca" = (
-/obj/machinery/economy/vending/cola/free,
+/obj/machinery/economy/vending/sovietsoda,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -7606,12 +7583,6 @@
 	icon_state = "dark"
 	},
 /area/mine/laborcamp/security)
-"CK" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowcornersalt";
-	dir = 1
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "CL" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -7653,16 +7624,6 @@
 	icon_state = "barber"
 	},
 /area/mine/laborcamp)
-"CX" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip"
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
-"CY" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "dark_large"
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "Dc" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -7927,7 +7888,7 @@
 /area/lavaland/surface/outdoors/legion)
 "EF" = (
 /obj/effect/baseturf_helper/lava_land,
-/obj/item/cigbutt,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -8162,12 +8123,6 @@
 	icon_state = "barber"
 	},
 /area/mine/laborcamp)
-"Gn" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 10
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "Gp" = (
 /obj/structure/sign/poster/contraband/clown,
 /obj/effect/spawner/random_spawners/wall_rusted_always,
@@ -8522,11 +8477,12 @@
 	},
 /area/mine/laborcamp)
 "Ip" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel{
+	icon_state = "barber"
 	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/mine/laborcamp)
 "Iv" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random_spawners/cobweb_right_rare,
@@ -8688,7 +8644,8 @@
 /area/lavaland/surface/outdoors/legion)
 "Ji" = (
 /obj/structure/platform/reinforced/corner{
-	dir = 1
+	dir = 1;
+	anchored = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -8789,7 +8746,7 @@
 /area/mine/laborcamp)
 "JV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/cigbutt,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredyellowfull"
 	},
@@ -8978,13 +8935,13 @@
 /turf/simulated/floor/lava/mapping_lava,
 /area/lavaland/surface/outdoors)
 "KR" = (
-/obj/structure/marker_beacon/dock_marker/collision,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Labor Camp Landing Pad";
 	network = list("Labor Camp");
 	dir = 8
 	},
+/obj/machinery/floodlight/anchored,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowaltstrip";
 	dir = 8
@@ -9633,10 +9590,6 @@
 	name = "Labor Camp Lockdown";
 	req_access_txt = "2"
 	},
-/obj/machinery/flasher_button{
-	id = "labor";
-	pixel_y = -34
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9717,7 +9670,7 @@
 /obj/structure/closet/secure_closet/brig/gulag,
 /obj/machinery/flasher{
 	id = "labor";
-	pixel_y = 32
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
@@ -9915,11 +9868,10 @@
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "QZ" = (
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "darkyellowaltstrip";
-	dir = 4
-	},
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel,
+/area/mine/laborcamp)
 "Rb" = (
 /obj/structure/grille/broken,
 /obj/structure/grille/broken,
@@ -11253,6 +11205,9 @@
 "YW" = (
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/shuttle/labor/one_way{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkred"
@@ -13465,15 +13420,15 @@ ab
 ab
 Nc
 gb
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
-iB
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
+vk
 Uy
 NW
 ab
@@ -14493,15 +14448,15 @@ aj
 ai
 Nc
 gb
-iB
-iB
-iB
-iB
-iB
-iB
+vk
+vk
+vk
+vk
+vk
+vk
 pq
-iB
-iB
+vk
+vk
 Uy
 NW
 ai
@@ -15006,8 +14961,8 @@ wY
 aj
 aj
 Ji
-kI
-kI
+hj
+hj
 PX
 FW
 PX
@@ -16040,7 +15995,7 @@ CI
 gu
 PX
 PK
-JZ
+QZ
 hQ
 Hs
 Lz
@@ -16550,7 +16505,7 @@ hv
 ZZ
 sP
 aQ
-OE
+By
 OU
 PX
 Wo
@@ -17072,7 +17027,7 @@ vK
 tJ
 aq
 cb
-bh
+Ip
 bh
 ap
 aj
@@ -17579,7 +17534,7 @@ JZ
 uL
 JZ
 IF
-bk
+xC
 cy
 bn
 Oh
@@ -19913,12 +19868,12 @@ aj
 fo
 GO
 fd
-xC
-tb
-tb
-tb
-tb
-Gn
+bF
+bF
+bF
+bF
+bF
+bF
 kQ
 ch
 Hf
@@ -20169,13 +20124,13 @@ aj
 aj
 fo
 Qd
-xC
-CK
-CY
-CY
-CY
-CY
-CX
+bF
+bF
+bF
+bF
+bF
+bF
+bF
 Eg
 XL
 Hf
@@ -20426,13 +20381,13 @@ aj
 FO
 fo
 tE
-Ip
-CY
-CY
-CY
-CY
-CY
-CX
+bF
+bF
+bF
+bF
+bF
+bF
+bF
 Eg
 XL
 Hf
@@ -20683,13 +20638,13 @@ aj
 ab
 fo
 Sa
-BP
-By
-CY
-CY
-CY
-CY
-CX
+bF
+bF
+bF
+bF
+bF
+bF
+bF
 Eg
 ch
 vh
@@ -20941,11 +20896,11 @@ ab
 uN
 Ur
 fA
-BP
-QZ
+bF
+bF
 AN
-QZ
-QZ
+bF
+bF
 bF
 kQ
 ch

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -1286,17 +1286,6 @@
 	water_overlay_image = null
 	},
 /area/syndicate_mothership/outside)
-"aRU" = (
-/obj/docking_port/stationary/transit{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "mining_transit";
-	name = "mining in transit";
-	width = 7
-	},
-/turf/space/transit,
-/area/space/centcomm)
 "aRZ" = (
 /obj/structure/light_fake/small{
 	dir = 8
@@ -11339,18 +11328,19 @@
 	id_tag = "s_docking_airlock"
 	},
 /obj/structure/fans/tiny,
-/obj/docking_port/stationary{
-	area_type = /area/lavaland/surface/outdoors;
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/docking_port/stationary/transit{
 	dir = 8;
 	dwidth = 2;
 	height = 5;
-	id = "laborcamp_away";
-	name = "labor camp";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
-	width = 9
+	id = "laborcamp_transit";
+	name = "labor in transit";
+	width = 9;
+	pixel_x = 32
 	},
-/obj/docking_port/mobile/labour,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/docking_port/mobile/labour{
+	roundstart_move = "laborcamp_away"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
 "gOQ" = (
@@ -38244,18 +38234,19 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/fans/tiny,
-/obj/docking_port/stationary{
-	area_type = /area/lavaland/surface/outdoors;
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/docking_port/stationary/transit{
 	dir = 8;
 	dwidth = 3;
 	height = 5;
-	id = "mining_away";
-	name = "lavaland mine";
-	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
-	width = 7
+	id = "mining_transit";
+	name = "mining in transit";
+	width = 7;
+	pixel_x = 32
 	},
-/obj/docking_port/mobile/mining,
-/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/docking_port/mobile/mining{
+	roundstart_move = "mining_away"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
 "wDR" = (
@@ -38921,17 +38912,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
-"xau" = (
-/obj/docking_port/stationary/transit{
-	dir = 8;
-	dwidth = 2;
-	height = 5;
-	id = "laborcamp_transit";
-	name = "labor in transit";
-	width = 9
-	},
-/turf/space/transit,
-/area/space/centcomm)
 "xaH" = (
 /obj/effect/decal/nanotrasen_logo_circle{
 	icon_state = "ntlogo_sec";
@@ -80629,7 +80609,7 @@ lgH
 lgH
 lgH
 lgH
-aRU
+lgH
 lgH
 lgH
 lgH
@@ -87570,7 +87550,7 @@ lgH
 lgH
 lgH
 lgH
-xau
+lgH
 lgH
 lgH
 lgH

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -2350,6 +2350,16 @@
 	icon_state = "rampbottom"
 	},
 /area/centcom/ss220/admin3)
+"bxM" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "bxN" = (
 /obj/structure/chair/comfy/black,
 /turf/simulated/floor/carpet/green,
@@ -2360,6 +2370,19 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"byg" = (
+/obj/machinery/flasher{
+	id = "gulagshuttleflasher";
+	pixel_x = 24
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal{
+	dir = 9
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "byz" = (
 /obj/effect/turf_decal/tile/neutral/full{
 	color = "#000000"
@@ -3429,6 +3452,16 @@
 	},
 /turf/simulated/floor/grass/no_creep,
 /area/centcom/ss220/admin2)
+"cbA" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/lavaland_air,
+/area/shuttle/siberia)
 "cbK" = (
 /obj/machinery/computer/communications,
 /turf/simulated/floor/plasteel/dark,
@@ -3485,6 +3518,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
+"cdG" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/mining)
 "cdI" = (
 /obj/structure/light_fake{
 	dir = 8
@@ -3706,6 +3743,14 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
+"ckK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "ckX" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/machinery/light/spot{
@@ -4087,6 +4132,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/syndicate)
+"cwF" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/simulated/floor/plating/lavaland_air,
+/area/shuttle/siberia)
 "cxe" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -6272,6 +6321,16 @@
 	icon_state = "barber"
 	},
 /area/shuttle/administration)
+"dOf" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal{
+	dir = 10
+	},
+/obj/machinery/light/directional/east,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "dOx" = (
 /obj/structure/marker_beacon/spotlight/jade,
 /turf/simulated/floor/plasteel/dark,
@@ -7189,6 +7248,15 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/jail)
+"eti" = (
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/machinery/mineral/labor_prisoner_shuttle_console{
+	pixel_y = 32
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/siberia)
 "etr" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/dromedaryco{
@@ -7410,6 +7478,9 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
+"ezO" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/mining)
 "ezR" = (
 /obj/structure/light_fake{
 	dir = 4
@@ -7844,6 +7915,19 @@
 /obj/item/food/limecakeslice,
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/ss220/general)
+"eLp" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 4
+	},
+/obj/structure/window/plasmareinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating/lavaland_air,
+/area/shuttle/mining)
 "eLW" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -10853,6 +10937,16 @@
 	icon_state = "darkredcornersalt"
 	},
 /area/syndicate_mothership/jail)
+"gDx" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/camera{
+	c_tag = "Mining Outpost - Shuttle";
+	dir = 5;
+	network = list("Mining Outpost")
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "gDW" = (
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
@@ -11198,6 +11292,12 @@
 	icon_state = "darkbrowncorners"
 	},
 /area/centcom/ss220/supply)
+"gNx" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "gNy" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/ashtray/bronze{
@@ -11234,6 +11334,25 @@
 	icon_state = "darkbrown"
 	},
 /area/syndicate_mothership/jail)
+"gOF" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock"
+	},
+/obj/structure/fans/tiny,
+/obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
+	dir = 8;
+	dwidth = 2;
+	height = 5;
+	id = "laborcamp_away";
+	name = "labor camp";
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	width = 9
+	},
+/obj/docking_port/mobile/labour,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/shuttle/siberia)
 "gOQ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutralfull"
@@ -12102,6 +12221,15 @@
 /obj/machinery/economy/vending/wallmed/syndicate/directional/north,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/infteam)
+"hoc" = (
+/obj/machinery/flasher_button{
+	id = "gulagshuttleflasher";
+	name = "Flash Control";
+	pixel_y = -24;
+	req_access_txt = "1"
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "hom" = (
 /obj/structure/light_fake{
 	dir = 4
@@ -12336,6 +12464,15 @@
 	icon_state = "dark_large"
 	},
 /area/centcom/ss220/command)
+"htc" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/fans/tiny,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/shuttle/siberia)
 "htl" = (
 /obj/machinery/computer/card/minor{
 	layer = 4
@@ -13602,6 +13739,20 @@
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/general)
+"ieY" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Labor Camp Shuttle";
+	network = list("Labor Camp");
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "ifc" = (
 /obj/structure/light_fake/small{
 	dir = 1
@@ -14379,6 +14530,10 @@
 	},
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin1)
+"iwt" = (
+/obj/effect/baseturf_helper/lava_land,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "iwE" = (
 /obj/machinery/computer/nonfunctional,
 /turf/simulated/floor/plasteel{
@@ -17552,6 +17707,9 @@
 	icon_state = "darkyellowalt"
 	},
 /area/syndicate_mothership/cargo)
+"kDv" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "kDx" = (
 /obj/machinery/door/airlock/titanium{
 	id_tag = "s_docking_airlock"
@@ -17644,6 +17802,13 @@
 /obj/structure/table/wood,
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
+"kEM" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating/lavaland_air,
+/area/shuttle/siberia)
 "kEN" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -18530,6 +18695,20 @@
 	icon_state = "darkredaltstrip"
 	},
 /area/syndicate_mothership/jail)
+"lbh" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/restraints/handcuffs,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/flasher_button{
+	id = "gulagshuttleflasher";
+	name = "Flash Control";
+	req_access_txt = "1"
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "lbm" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/spawner/aroomwarp,
@@ -18930,6 +19109,11 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/jail)
+"loY" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light/small/directional/west,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "lpw" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/spawner/window,
@@ -19459,6 +19643,9 @@
 "lAC" = (
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
+"lAX" = (
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "lAY" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -20283,6 +20470,13 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
+"mbV" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "mcm" = (
 /obj/structure/closet/crate/secure/bin{
 	color = "#36373a";
@@ -22462,6 +22656,10 @@
 	},
 /turf/simulated/floor/mineral/plastitanium,
 /area/syndicate_mothership/infteam)
+"nvs" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/turf/simulated/floor/plating/lavaland_air,
+/area/shuttle/mining)
 "nvF" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkbluealtstrip"
@@ -24052,6 +24250,10 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/jail)
+"owk" = (
+/obj/effect/baseturf_helper/asteroid/basalt,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/siberia)
 "own" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -30843,6 +31045,19 @@
 	icon_state = "darkbluecornersalt"
 	},
 /area/centcom/ss220/admin3)
+"stf" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 5
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
+"sto" = (
+/obj/machinery/computer/shuttle/mining,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "stR" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Конференц Зал";
@@ -32920,6 +33135,9 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
+"tIw" = (
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/siberia)
 "tIy" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -34928,6 +35146,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/jail)
+"uXQ" = (
+/obj/machinery/computer/shuttle/labor{
+	dir = 4
+	},
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "uXT" = (
 /obj/structure/light_fake/small,
 /obj/effect/decal/cleanable/dirt,
@@ -35131,6 +35355,12 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
+"vfi" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "vfs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -35568,6 +35798,10 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/court)
+"vqY" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/shuttle/siberia)
 "vrd" = (
 /obj/structure/flora/tree/jungle,
 /turf/simulated/floor/indestructible/grass/no_creep,
@@ -36152,6 +36386,11 @@
 "vCF" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/park)
+"vCJ" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/mining)
 "vCS" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
@@ -37325,6 +37564,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"wmt" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/simulated/floor/mineral/titanium,
+/area/shuttle/siberia)
 "wmB" = (
 /obj/structure/table/glass/reinforced/titanium{
 	color = "#dbc921";
@@ -37993,6 +38238,26 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/bar)
+"wDK" = (
+/obj/machinery/door/airlock/titanium{
+	id_tag = "s_docking_airlock"
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/fans/tiny,
+/obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "mining_away";
+	name = "lavaland mine";
+	turf_type = /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface;
+	width = 7
+	},
+/obj/docking_port/mobile/mining,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/turf/simulated/floor/plating,
+/area/shuttle/mining)
 "wDR" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkgreen"
@@ -38253,6 +38518,12 @@
 	icon_state = "dark"
 	},
 /area/syndicate_mothership/cargo)
+"wMc" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/mineral/plastitanium/red,
+/area/shuttle/siberia)
 "wMx" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 5;
@@ -40029,6 +40300,13 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/supply)
+"xLm" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/south,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/mining)
 "xLG" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/indestructible/grass/no_creep,
@@ -40406,6 +40684,9 @@
 /obj/structure/table/wood/fancy/red,
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/bar)
+"xZs" = (
+/turf/simulated/wall/mineral/titanium,
+/area/shuttle/siberia)
 "xZz" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "s_docking_airlock";
@@ -79061,12 +79342,12 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+ezO
+cdG
+ezO
+cdG
+eLp
+nvs
 lgH
 lgH
 lgH
@@ -79317,13 +79598,13 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+ezO
+ezO
+loY
+gDx
+bxM
+xLm
+ezO
 lgH
 lgH
 lgH
@@ -79574,13 +79855,13 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+cdG
+sto
+vfi
+iwt
+bxM
+mbV
+ezO
 lgH
 lgH
 lgH
@@ -79831,13 +80112,13 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+ezO
+ezO
+vCJ
+kDv
+bxM
+ckK
+ezO
 lgH
 lgH
 lgH
@@ -80089,12 +80370,12 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+ezO
+cdG
+wDK
+cdG
+eLp
+nvs
 lgH
 lgH
 lgH
@@ -85998,15 +86279,15 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+xZs
+xZs
+vqY
+xZs
+xZs
+vqY
+xZs
+xZs
+xZs
 lgH
 lgH
 lgH
@@ -86255,15 +86536,15 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+vqY
+uXQ
+lAX
+wMc
+wmt
+stf
+ieY
+kEM
+cwF
 lgH
 lgH
 lgH
@@ -86512,15 +86793,15 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+vqY
+gNx
+lAX
+xZs
+eti
+owk
+tIw
+cbA
+cwF
 lgH
 lgH
 lgH
@@ -86769,15 +87050,15 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+vqY
+lbh
+hoc
+xZs
+byg
+dOf
+tIw
+kEM
+cwF
 lgH
 lgH
 lgH
@@ -87026,15 +87307,15 @@ lgH
 lgH
 lgH
 lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
-lgH
+xZs
+xZs
+htc
+xZs
+xZs
+xZs
+gOF
+xZs
+xZs
 lgH
 lgH
 lgH

--- a/modular_ss220/maps220/code/objects.dm
+++ b/modular_ss220/maps220/code/objects.dm
@@ -88,7 +88,7 @@
 // Structure
 /obj/structure/shuttle/engine
 	icon = 'modular_ss220/maps220/icons/shuttle.dmi'
-	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/arbitraryatmosblockingvar = 1
 
 // Engines provide atmos blocking, for they move to locations with different atmos
@@ -102,6 +102,7 @@
 	recalculate_atmos_connectivity()
 	return ..()
 
+// Copy-pastes tiny fans
 /obj/structure/shuttle/engine/CanAtmosPass(direction)
 	return !arbitraryatmosblockingvar
 

--- a/modular_ss220/maps220/code/objects.dm
+++ b/modular_ss220/maps220/code/objects.dm
@@ -88,11 +88,26 @@
 // Structure
 /obj/structure/shuttle/engine
 	icon = 'modular_ss220/maps220/icons/shuttle.dmi'
-	resistance_flags = INDESTRUCTIBLE // То что у нас двигатели ломаются от пары пуль - бред
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	var/arbitraryatmosblockingvar = 1
 
+// Engines provide atmos blocking, for they move to locations with different atmos
 /obj/structure/shuttle/engine/Initialize(mapload)
 	. = ..()
 	set_light(2)
+	recalculate_atmos_connectivity()
+
+/obj/structure/shuttle/engine/Destroy()
+	arbitraryatmosblockingvar = 0
+	recalculate_atmos_connectivity()
+	return ..()
+
+/obj/structure/shuttle/engine/CanAtmosPass(direction)
+	return !arbitraryatmosblockingvar
+
+/obj/structure/shuttle/engine/get_superconductivity(direction)
+	// Mostly for stuff on Lavaland.
+	return ZERO_HEAT_TRANSFER_COEFFICIENT
 
 /obj/structure/shuttle/engine/huge
 	icon = 'modular_ss220/maps220/icons/3x3.dmi'


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
- Переносит шаттл Гулага и Шахтёров на CC-уровень, раундстартово отправляя на шахту.
- Теперь все объекты engine не передают тепло и не пропускают атмос. Сделано это чтобы избежать лишних активных турфов раундстартом.
- Визуальные и логические изменения Гулага. Добавлена красивенькая посадочная площадка, голопады, консоль вызова шаттла в СБшной зоне Гулага и прочее.

## Почему это хорошо для игры
Думайте...

## Изображения изменений

![perviy](https://github.com/user-attachments/assets/d96b109b-cf62-4a7f-bc2c-448b063795de)

![vtoroy](https://github.com/user-attachments/assets/c3debf0b-4399-4090-ad6b-23a85238bc96)

## Тестирование
Проверял на локалке.

## Changelog

:cl:
tweak: Лаваленд: Визуальные и минорные изменения "Гулага". Добавлена консоль вызова шаттла в СБшную зону, голопады и прочее.
experiment: Шаттлы Гулага и Шахтёров перенесены на CC-уровень, откуда раундстартом стартуют на Лаваленд. Ничего не должно сломаться, наверное.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
