### PR TITLE
Make training laser have `WEIGHT_CLASS_NORMAL`

### DIFF
--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -30,5 +30,8 @@
 /obj/item/gun/energy/laser/tag
 	w_class = WEIGHT_CLASS_NORMAL
 
+/obj/item/gun/energy/laser/practice
+	w_class = WEIGHT_CLASS_NORMAL
+
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
## Что этот PR делает
Уменьшает вес `/obj/item/gun/energy/laser/practice`, чтобы он снова помещался в рюкзак.

## Почему это хорошо для игры
Не знаю, просто попросили.

## Тестирование
Я верю.

## Changelog

:cl: Maxiemar
tweak: Тренировочный лазерный карабин снова помещается в рюкзак.
/:cl:
