### PR TITLE
Tweak: Гейтган больше не работает в секторе космоса

### DIFF
--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -18,7 +18,7 @@
 
 /obj/item/gun/energy/laser/awaymission_aeg/onTransitZ(old_z, new_z)
 	. = ..()
-	if(is_away_level(new_z) || (!is_station_level(new_z) && check_level_trait(new_z, REACHABLE_SPACE_ONLY)))
+	if(is_away_level(new_z))
 		if(ismob(loc))
 			to_chat(loc, span_notice("Ваш [src] активируется, начиная аккумулировать энергию из материи сущего."))
 		selfcharge = TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Гейтган больше не заряжается во всех секторах, кроме гейта.

Добро от Муниверса получено.

## Почему это хорошо для игры
Балансаге
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Вроде работает
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Гейтган, он же Exploreverse, больше не может заряжаться в каких либо секторах помимо гейта. 
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
