### PR TITLE
Tweak:Peas Shooter additional damage for zombies

### DIFF
--- a/modular_ss220/objects/code/weapons/ranged/revolvers.dm
+++ b/modular_ss220/objects/code/weapons/ranged/revolvers.dm
@@ -208,7 +208,12 @@
 	icon = 'modular_ss220/objects/icons/ammo.dmi'
 	item_state = "peashooter_bullet"
 	stamina = 5
-	damage_type = STAMINA
+	damage = 0
+
+/obj/item/projectile/bullet/midbullet_r/peas_shooter/prehit(atom/target)
+	if(HAS_TRAIT(target, TRAIT_I_WANT_BRAINS))
+		damage |= 10
+	return ..()
 
 /obj/item/projectile/bullet/midbullet_r/peas_shooter/on_hit(mob/H)
 	. = ..()


### PR DESCRIPTION
## Что этот PR делает
Добавляет повышенный урон по зомби с горохострела, прямо как на горохостреле из гатфрукта.

## Почему это хорошо для игры
Прикольная фича и пвз в сске

## Тестирование
Локалочка

## Changelog
:cl:
tweak: При стрельбе из горохострела по зомби по ним будет идти реальный урон вместе со стаминой
/:cl: