### PR TITLE
Fixes generic energy gun in the scp ruin

### DIFF
--- a/_maps/map_files220/RandomRuins/LavaRuins/scp_facility.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/scp_facility.dmm
@@ -928,7 +928,7 @@
 /area/ruin/powered/scpfacility)
 "KS" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/gun,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Заменяет `/obj/item/gun/energy/e_gun` (буквально является generic еганом без изменений) на `/obj/item/gun/energy/gun` в руине `scp_facility.dmm`.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Еган был generic'ом, который не предназначен для игроков. Он имел OOC описание и не имел применения в игре.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

На локальном сервере.. еган настоящий, как в оружейной СБ.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Еган в руине СЦП на Лаваленде теперь рабочий.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
