### PR TITLE
Tweaking explorers and shaft miners rooms, adding personal closets for them

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -16338,21 +16338,14 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display/north,
-/obj/item/radio{
-	pixel_y = 12
+/obj/machinery/cell_charger{
+	pixel_x = 2;
+	pixel_y = 4
 	},
-/obj/item/radio{
-	pixel_y = 6
+/obj/item/stock_parts/cell/high{
+	pixel_y = 4;
+	pixel_x = 2
 	},
-/obj/item/radio{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_y = 6;
-	pixel_x = -8
-	},
-/obj/item/radio,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -18754,7 +18747,7 @@
 /area/station/maintenance/port)
 "bso" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wardrobe/miner,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -26206,7 +26199,6 @@
 "cao" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_spawners/cobweb_left_frequent,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -26248,7 +26240,6 @@
 	},
 /obj/machinery/disposal,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random_spawners/cobweb_right_frequent,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -26678,12 +26669,16 @@
 /area/station/medical/cryo)
 "cbH" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/gps/mining,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
 "cbI" = (
+/obj/structure/table,
+/obj/item/clothing/accessory/stethoscope,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -26691,8 +26686,10 @@
 /area/station/supply/miningdock)
 "cbJ" = (
 /obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/gps/mining,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil{
+	amount = 15
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -27473,6 +27470,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/cell_charger,
+/obj/item/rcs,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -27549,7 +27547,8 @@
 "cfc" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/item/folder/yellow,
+/obj/item/pen,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -28611,7 +28610,7 @@
 	},
 /area/station/engineering/supermatter_room)
 "cjU" = (
-/obj/structure/closet/secure_closet/miner,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -28659,16 +28658,12 @@
 /turf/space,
 /area/space)
 "cko" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
 	dir = 8
 	},
 /obj/machinery/light_switch/east,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -28728,6 +28723,8 @@
 "ckx" = (
 /obj/structure/closet/secure_closet/explorer,
 /obj/machinery/light/directional/west,
+/obj/item/gun/energy/laser/awaymission_aeg/rnd,
+/obj/item/radio/off,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -29706,10 +29703,24 @@
 	},
 /area/station/command/office/cmo)
 "cnS" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen,
 /obj/machinery/alarm/directional/west,
+/obj/item/storage/belt/utility{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/box/donkpockets,
+/obj/structure/shelf/supply,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -30296,7 +30307,7 @@
 /area/station/maintenance/apmaint)
 "cqG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/wardrobe/miner,
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "brown"
@@ -34005,9 +34016,8 @@
 	},
 /area/station/engineering/control)
 "cES" = (
-/obj/structure/table,
-/obj/item/rcs,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -34474,7 +34484,7 @@
 /area/station/engineering/control)
 "cGV" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/closet/secure_closet/expedition,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkblue"
@@ -39587,11 +39597,11 @@
 	},
 /area/station/engineering/gravitygenerator)
 "cYN" = (
-/obj/structure/closet/secure_closet/expedition,
 /obj/machinery/camera/motion{
 	c_tag = "Gateway Motion Sensor";
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkblue"
@@ -39673,7 +39683,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light_switch/south,
-/obj/structure/closet/secure_closet/expedition,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -46197,7 +46207,6 @@
 	},
 /area/station/maintenance/abandonedbar)
 "dNi" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -47839,6 +47848,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "esG" = (
@@ -53864,7 +53874,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "gAk" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -54690,6 +54699,12 @@
 	icon_state = "floorgrime"
 	},
 /area/station/engineering/gravitygenerator)
+"gMS" = (
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor/plasteel{
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "gNe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/flasher{
@@ -61654,6 +61669,18 @@
 	icon_state = "darkyellowcorners"
 	},
 /area/station/engineering/hallway)
+"jou" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "jov" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65693,11 +65720,7 @@
 /area/station/maintenance/asmaint)
 "kMd" = (
 /obj/machinery/firealarm/directional/west,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -67700,9 +67723,7 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/bar/atrium)
 "lxA" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "lxB" = (
@@ -69669,6 +69690,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "mdX" = (
@@ -69950,7 +69972,6 @@
 	},
 /area/station/maintenance/aft)
 "mii" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72080,6 +72101,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
+"mYs" = (
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "mYv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -73235,6 +73260,8 @@
 /obj/structure/closet/secure_closet/explorer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/requests_console/directional/west,
+/obj/item/gun/energy/laser/awaymission_aeg/rnd,
+/obj/item/radio/off,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -74449,6 +74476,8 @@
 /obj/structure/closet/secure_closet/explorer,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/west,
+/obj/item/gun/energy/laser/awaymission_aeg/rnd,
+/obj/item/radio/off,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -75394,6 +75423,14 @@
 	icon_state = "whitehall"
 	},
 /area/station/maintenance/aft)
+"ogF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe/miner,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "ogH" = (
 /obj/effect/spawner/random_spawners/wall_rusted_maybe,
 /turf/simulated/wall,
@@ -79578,9 +79615,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/computer/security/mining{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "pzF" = (
@@ -82177,7 +82212,7 @@
 	},
 /area/station/maintenance/asmaint)
 "qvo" = (
-/obj/structure/closet/secure_closet/expedition,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkblue"
@@ -85614,9 +85649,9 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "rJo" = (
-/obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
+/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
 	},
@@ -86256,12 +86291,12 @@
 /obj/effect/turf_decal/caution{
 	dir = 4
 	},
-/obj/effect/landmark/start/shaft_miner,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -86635,9 +86670,9 @@
 /area/station/public/toilet/unisex)
 "scB" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stack/cable_coil{
-	amount = 15
+/obj/item/paper_bin{
+	pixel_x = 1;
+	pixel_y = 9
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -95004,7 +95039,6 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
 "uXM" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
@@ -95021,6 +95055,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "uYw" = (
@@ -100282,7 +100317,7 @@
 /area/station/security/prisonlockers)
 "wQa" = (
 /obj/machinery/requests_console/directional/west,
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -101471,6 +101506,8 @@
 /obj/structure/closet/secure_closet/explorer,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/directional/west,
+/obj/item/gun/energy/laser/awaymission_aeg/rnd,
+/obj/item/radio/off,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -102569,15 +102606,8 @@
 /area/station/maintenance/fsmaint)
 "xHr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/computer/security/mining,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "xHs" = (
@@ -102685,6 +102715,13 @@
 /obj/item/poster/random_contraband,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"xIK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "xJa" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -103449,12 +103486,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "xTR" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "xTV" = (
@@ -125781,7 +125818,7 @@ aaa
 cam
 xHr
 qat
-qat
+xIK
 cam
 aaa
 aab
@@ -126545,7 +126582,7 @@ bYI
 bzJ
 cbI
 fGH
-eKd
+ogF
 wQa
 cES
 kMd
@@ -126802,7 +126839,7 @@ bYH
 bzJ
 cbH
 kpA
-cfb
+mYs
 jVE
 cfb
 kQY
@@ -127061,7 +127098,7 @@ cbK
 kum
 cfm
 dNi
-cfm
+jou
 cfm
 gAk
 unR
@@ -127323,7 +127360,7 @@ cko
 cnT
 qat
 mii
-cno
+gMS
 cam
 fMn
 tQa

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -31506,6 +31506,7 @@
 "cvB" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/requests_console/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cvE" = (
@@ -32074,7 +32075,13 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cyg" = (
-/turf/simulated/wall,
+/obj/machinery/light/directional/east,
+/obj/machinery/camera{
+	c_tag = "EVA Storage";
+	dir = 8
+	},
+/obj/machinery/atmospherics/portable/canister/oxygen,
+/turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cyh" = (
 /obj/structure/window/reinforced{
@@ -32980,15 +32987,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/public/locker)
-"cBk" = (
-/obj/machinery/camera{
-	c_tag = "EVA Storage";
-	dir = 8
-	},
-/obj/machinery/requests_console/directional/east,
-/obj/machinery/light/directional/east,
-/turf/simulated/floor/plasteel/dark,
-/area/station/ai_monitored/storage/eva)
 "cBm" = (
 /obj/machinery/alarm/directional/east,
 /obj/structure/dispenser/oxygen,
@@ -152583,7 +152581,7 @@ csK
 cEs
 cEr
 cEr
-cBk
+cEr
 cEr
 cEr
 cEN

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -6685,6 +6685,16 @@
 	icon_state = "brown"
 	},
 /area/station/supply/qm)
+"aDM" = (
+/obj/structure/closet/secure_closet/explorer,
+/obj/item/gun/energy/laser/awaymission_aeg/rnd,
+/obj/item/radio/off,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkbrown"
+	},
+/area/station/supply/expedition)
 "aDN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14450,15 +14460,7 @@
 "bjG" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/rack,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 10
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 2
-	},
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purple"
@@ -31209,6 +31211,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkbrowncorners"
@@ -31442,6 +31445,7 @@
 /area/station/engineering/control)
 "cuX" = (
 /obj/machinery/light_switch/north,
+/obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrowncorners"
@@ -31481,6 +31485,9 @@
 	pixel_y = -3
 	},
 /obj/item/crowbar,
+/obj/item/stack/rods{
+	amount = 8
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cvu" = (
@@ -31497,9 +31504,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/range)
 "cvB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high,
+/obj/structure/dispenser/oxygen,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cvE" = (
@@ -31522,8 +31528,8 @@
 	},
 /area/station/hallway/secondary/bridge)
 "cvJ" = (
-/obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/suit_storage_unit/expedition,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkbrown"
@@ -31956,7 +31962,10 @@
 /area/station/engineering/control)
 "cxJ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/suit_storage_unit/expedition,
+/obj/structure/closet/secure_closet/explorer,
+/obj/item/gun/energy/laser/awaymission_aeg/rnd,
+/obj/item/radio/off,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -32128,9 +32137,9 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/explorer,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/gun/energy/laser/awaymission_aeg/rnd,
 /obj/item/radio/off,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -32243,9 +32252,9 @@
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
 /obj/structure/closet/secure_closet/explorer,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/item/gun/energy/laser/awaymission_aeg/rnd,
 /obj/item/radio/off,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -32660,10 +32669,7 @@
 	},
 /area/station/supply/expedition)
 "czW" = (
-/obj/structure/closet/secure_closet/explorer,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/item/gun/energy/laser/awaymission_aeg/rnd,
-/obj/item/radio/off,
+/obj/machinery/economy/vending/exploredrobe,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -32679,6 +32685,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
 	},
+/obj/structure/closet/crate/internals,
 /turf/simulated/floor/plasteel/dark,
 /area/station/hallway/secondary/bridge)
 "cAb" = (
@@ -32983,11 +32990,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cBm" = (
-/obj/structure/table/reinforced,
 /obj/machinery/alarm/directional/east,
-/obj/item/stack/rods{
-	amount = 8
-	},
+/obj/structure/dispenser/oxygen,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cBn" = (
@@ -33059,7 +33064,6 @@
 /area/station/supply/expedition)
 "cBw" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/economy/vending/exploredrobe,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -33330,8 +33334,17 @@
 /area/station/ai_monitored/storage/eva)
 "cCK" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/belt/utility,
-/obj/item/radio/alternative,
+/obj/item/storage/belt/utility{
+	pixel_y = -6
+	},
+/obj/item/stack/packageWrap{
+	pixel_y = 6;
+	pixel_x = -2
+	},
+/obj/item/hand_labeler{
+	pixel_y = 7;
+	pixel_x = 3
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cCL" = (
@@ -33394,7 +33407,7 @@
 /turf/simulated/floor/carpet,
 /area/station/public/vacant_office/secondary)
 "cCV" = (
-/obj/machinery/mineral/equipment_vendor/explorer,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "darkbrown"
@@ -33402,6 +33415,7 @@
 /area/station/supply/expedition)
 "cCW" = (
 /obj/machinery/light_switch/south,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrowncorners"
@@ -33439,7 +33453,7 @@
 /turf/simulated/floor/plating,
 /area/station/supply/expedition)
 "cDa" = (
-/obj/structure/dispenser/oxygen,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkbrown"
@@ -33516,9 +33530,11 @@
 /area/station/public/fitness)
 "cDs" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/item/radio/alternative{
+	pixel_x = 5
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "cDt" = (
@@ -42857,43 +42873,8 @@
 /turf/simulated/floor/plating,
 /area/station/science/genetics)
 "dte" = (
-/obj/structure/closet/crate/internals,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 8
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 8
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 8
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 8
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 8
-	},
 /obj/machinery/alarm/directional/south,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners"
 	},
@@ -47908,10 +47889,7 @@
 	},
 /area/station/security/range)
 "dTu" = (
-/obj/structure/closet/secure_closet/explorer,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/item/gun/energy/laser/awaymission_aeg/rnd,
-/obj/item/radio/off,
+/obj/machinery/mineral/equipment_vendor/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -55478,12 +55456,8 @@
 	},
 /area/station/maintenance/abandoned_garden)
 "fQh" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/regular,
 /obj/machinery/requests_console/directional/west,
+/obj/machinery/suit_storage_unit/expedition,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkbrown"
@@ -68972,6 +68946,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -76708,6 +76683,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/caution,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -89052,6 +89028,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/closet/secure_closet/exile,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "pKK" = (
@@ -93141,13 +93118,12 @@
 	},
 /area/station/medical/medbay)
 "qUb" = (
-/obj/structure/dispenser/oxygen,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "qUc" = (
@@ -104511,7 +104487,6 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/ai_transit_tube)
 "unT" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/toolbox/emergency{
 	pixel_y = 10
@@ -104522,6 +104497,7 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/shelf/supply,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -156461,7 +156437,7 @@ cvG
 csV
 fQh
 nKu
-nKu
+aDM
 cyr
 czW
 cBw
@@ -156720,7 +156696,7 @@ cul
 cBv
 cBv
 cyt
-cBv
+cCX
 cCX
 cCW
 csV
@@ -157234,7 +157210,7 @@ cuX
 cBv
 cBv
 cyu
-cBv
+cCX
 ciY
 dte
 csV

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -685,6 +685,16 @@
 	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
+"ahs" = (
+/obj/machinery/camera{
+	c_tag = "Mining Office";
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "ahv" = (
 /obj/structure/lattice,
 /obj/machinery/access_button{
@@ -4308,13 +4318,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"ayF" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "brown"
-	},
-/area/station/supply/miningdock)
 "ayH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4770,12 +4773,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aAU" = (
-/obj/item/clothing/gloves/color/rainbow,
-/obj/item/clothing/shoes/rainbow,
-/obj/item/clothing/under/color/rainbow,
-/obj/item/clothing/head/soft/rainbow,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "aAW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -5137,50 +5138,21 @@
 /turf/simulated/wall,
 /area/station/supply/miningdock)
 "aCt" = (
-/obj/structure/closet/crate,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/directional/west,
-/obj/machinery/light_switch/north{
-	pixel_x = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "brown"
-	},
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/item/gps/mining,
+/turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aCu" = (
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/security/brig)
 "aCw" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aCx" = (
 /obj/structure/closet/secure_closet/freezer/money,
@@ -5376,6 +5348,7 @@
 "aDv" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
@@ -5386,23 +5359,26 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "aDx" = (
-/obj/structure/closet/wardrobe/miner,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "brown"
-	},
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aDy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/supply/miningdock)
 "aDz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5661,12 +5637,12 @@
 	},
 /area/station/security/main)
 "aEs" = (
-/obj/structure/closet/crate,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/iron,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/closet/crate,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/iron,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aEt" = (
@@ -5730,13 +5706,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "aEB" = (
-/obj/structure/closet/crate,
 /obj/machinery/light/small/directional/east,
 /obj/item/radio/intercom/directional/east,
-/obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/computer/shuttle/mining,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aEC" = (
@@ -5944,12 +5919,8 @@
 	},
 /area/station/hallway/primary/central)
 "aFF" = (
-/obj/machinery/camera{
-	c_tag = "Mining Office";
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor/plasteel{
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
@@ -5997,12 +5968,7 @@
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
 "aFQ" = (
-/obj/structure/table,
-/obj/item/deck/cards,
-/obj/item/storage/fancy/cigarettes/cigpack_robust{
-	pixel_x = -4;
-	pixel_y = 6
-	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -6049,11 +6015,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aGh" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -6062,12 +6024,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "browncorner"
+	},
 /area/station/supply/miningdock)
 "aGi" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/table,
-/obj/item/storage/bag/dice,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -6281,26 +6246,28 @@
 	},
 /area/station/command/office/ce)
 "aGY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /obj/structure/rack,
 /obj/item/stack/ore/silver,
-/obj/item/shovel{
-	pixel_x = -5
-	},
 /obj/item/pickaxe{
 	pixel_x = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/item/shovel{
+	pixel_x = -5
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aGZ" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aHa" = (
@@ -6370,19 +6337,17 @@
 "aHr" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/directional/west,
-/turf/simulated/floor/plasteel,
-/area/station/supply/miningdock)
-"aHs" = (
-/obj/machinery/requests_console/directional/south,
-/turf/simulated/floor/plasteel,
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/supply/miningdock)
 "aHu" = (
-/obj/machinery/alarm/directional/east,
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "browncorner"
+	dir = 8;
+	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
 "aHv" = (
@@ -6746,20 +6711,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "aIN" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/supply/miningdock)
-"aIO" = (
-/obj/machinery/computer/security/mining{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
@@ -8148,14 +8102,6 @@
 /obj/machinery/light/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
-"aMS" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/station/supply/miningdock)
 "aMT" = (
 /obj/structure/closet/crate,
 /obj/item/stack/ore/glass,
@@ -10135,18 +10081,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
-"aTY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "aUa" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/drinkingglass{
@@ -10711,11 +10645,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/cafeteria)
 "aVv" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "browncorner"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "aVw" = (
 /obj/machinery/flasher{
@@ -14147,10 +14080,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bfn" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/directional/east,
+/obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
+	dir = 10;
 	icon_state = "brown"
 	},
 /area/station/supply/miningdock)
@@ -14874,10 +14808,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "bhm" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "bhn" = (
@@ -17285,11 +17219,11 @@
 /obj/machinery/conveyor/northeast{
 	id = "QMLoad2"
 	},
-/obj/machinery/status_display/supply_display/north,
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Fore";
 	dir = 6
 	},
+/obj/machinery/status_display/supply_display/north,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
 "bnX" = (
@@ -18053,7 +17987,10 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/supply/miningdock)
 "bpT" = (
 /obj/effect/landmark/burnturf,
@@ -21659,6 +21596,7 @@
 "bzV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/teleport/hub,
+/obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plating,
 /area/station/command/teleporter)
 "bzW" = (
@@ -25497,6 +25435,7 @@
 /obj/item/gun/energy/laser/awaymission_aeg/rnd,
 /obj/item/radio/off,
 /obj/machinery/requests_console/directional/south,
+/obj/item/mod/control/pre_equipped/standard/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -26189,6 +26128,7 @@
 /obj/structure/closet/secure_closet/explorer,
 /obj/item/gun/energy/laser/awaymission_aeg/rnd,
 /obj/item/radio/off,
+/obj/item/mod/control/pre_equipped/standard/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -26254,6 +26194,9 @@
 	dir = 5
 	},
 /obj/machinery/ai_status_display/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -26764,15 +26707,15 @@
 /obj/machinery/gateway{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/supply/expedition)
 "bSp" = (
-/obj/machinery/suit_storage_unit/expedition,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/machinery/economy/vending/exploredrobe,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -26918,10 +26861,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = -4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutralfull"
@@ -27581,10 +27520,6 @@
 /obj/effect/landmark/damageturf,
 /turf/simulated/floor/wood,
 /area/station/science/robotics/showroom)
-"bVe" = (
-/obj/machinery/alarm/directional/east,
-/turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
 "bVf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -28159,26 +28094,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard)
 "bWV" = (
-/obj/structure/cable/yellow{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/directional/west,
 /obj/structure/closet/secure_closet/explorer,
 /obj/item/gun/energy/laser/awaymission_aeg/rnd,
 /obj/machinery/light/directional/west,
 /obj/item/radio/off,
+/obj/item/mod/control/pre_equipped/standard/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
 	},
 /area/station/supply/expedition)
 "bWW" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -28186,48 +28112,14 @@
 	},
 /area/station/supply/expedition)
 "bWX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/supply/expedition)
-"bWY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/supply/expedition)
 "bWZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/landmark/start/explorer,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -28675,8 +28567,8 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
 "bYp" = (
-/obj/machinery/economy/vending/exploredrobe,
 /obj/machinery/light/directional/east,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -29066,7 +28958,7 @@
 /area/station/service/hydroponics)
 "bZD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -39184,16 +39076,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/medical/psych)
-"cJT" = (
-/obj/machinery/suit_storage_unit/expedition,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "darkbrown"
-	},
-/area/station/supply/expedition)
 "cJU" = (
 /obj/structure/sign/poster/contraband/random/east,
 /obj/structure/table/wood,
@@ -40587,19 +40469,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"cPD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central)
 "cPF" = (
 /obj/effect/landmark/start/doctor,
 /turf/simulated/floor/plasteel{
@@ -44594,9 +44463,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "dre" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -44725,7 +44593,7 @@
 /area/station/hallway/primary/central)
 "dwv" = (
 /obj/machinery/alarm/directional/east,
-/obj/structure/dispenser/oxygen,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -46418,6 +46286,25 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"ept" = (
+/obj/structure/shelf/supply,
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/item/storage/bag/dice,
+/obj/item/deck/cards,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/box/donkpockets,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "epF" = (
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/light/directional/east,
@@ -46459,6 +46346,7 @@
 /obj/structure/closet/secure_closet/explorer,
 /obj/item/gun/energy/laser/awaymission_aeg/rnd,
 /obj/item/radio/off,
+/obj/item/mod/control/pre_equipped/standard/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -47504,6 +47392,13 @@
 	icon_state = "white"
 	},
 /area/station/medical/medbay)
+"ePa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/mob/living/simple_animal/mouse,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "ePy" = (
 /obj/structure/chair/comfy/beige,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -48918,6 +48813,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
 "fvv" = (
+/obj/effect/turf_decal/caution,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -50153,8 +50049,9 @@
 	},
 /area/station/medical/exam_room)
 "fYU" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
@@ -52375,9 +52272,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/port)
-"hbB" = (
-/turf/simulated/wall,
-/area/station/legal/magistrate)
 "hbN" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -54964,6 +54858,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
+"igT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/bridge)
 "ihq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/yellow{
@@ -57255,6 +57161,8 @@
 	},
 /area/station/command/office/cmo)
 "joR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkbrown"
@@ -57743,6 +57651,14 @@
 /obj/structure/transit_tube/diagonal/topleft,
 /turf/space,
 /area/space/nearstation)
+"jDo" = (
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "jDD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -62039,6 +61955,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "vault"
 	},
@@ -62527,6 +62446,15 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"lEV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "lFm" = (
 /obj/machinery/shower{
 	dir = 8
@@ -63383,13 +63311,10 @@
 	},
 /area/station/command/bridge)
 "lWv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/explorer,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkbrown"
@@ -65949,6 +65874,12 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
+"ned" = (
+/obj/structure/closet/wardrobe/miner,
+/turf/simulated/floor/plasteel{
+	icon_state = "browncorner"
+	},
+/area/station/supply/miningdock)
 "nej" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -66654,21 +66585,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/surgery/observation)
-"nuy" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/central)
 "nuC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -67990,6 +67906,31 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"obn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/bridge)
 "obJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69221,6 +69162,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
+"oOb" = (
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "oOg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -70532,6 +70479,15 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/armory/secure)
+"ptK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/supply/expedition)
 "ptU" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/wood,
@@ -72486,6 +72442,27 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"qmF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "qmL" = (
 /obj/machinery/alarm/directional/north,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -74016,17 +73993,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/supply/miningdock)
 "rbv" = (
 /obj/machinery/door/airlock/security/glass{
@@ -76393,6 +76368,11 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"shs" = (
+/obj/machinery/alarm/directional/east,
+/obj/structure/closet/secure_closet/exile,
+/turf/simulated/floor/plasteel,
+/area/station/ai_monitored/storage/eva)
 "shY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -76410,6 +76390,14 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/research)
+"siO" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/requests_console/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "sjx" = (
 /obj/structure/chair{
 	dir = 1
@@ -78486,23 +78474,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"tfk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
-/obj/machinery/door/airlock/mining,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/supply/expedition)
 "tfl" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/prisonlockers)
@@ -78652,6 +78623,13 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/security/warden)
+"tid" = (
+/obj/machinery/mineral/equipment_vendor,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "tig" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -79044,15 +79022,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"tsE" = (
-/obj/structure/girder,
-/obj/effect/spawner/lootdrop{
-	icon_state = "grille";
-	loot = list(/obj/structure/grille=8,/obj/structure/grille/broken=2);
-	name = "normal or broken grille spawner"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "ttb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79602,6 +79571,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/expedition,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/mining,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79955,9 +79931,6 @@
 	},
 /area/station/medical/surgery/secondary)
 "tST" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -80029,6 +80002,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
+"tVI" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/supply/miningdock)
 "tVJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -82857,6 +82837,19 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
+"vnA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkbrown"
+	},
+/area/station/supply/expedition)
 "vnQ" = (
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/air,
@@ -84260,10 +84253,12 @@
 /turf/simulated/floor/grass,
 /area/station/maintenance/aft2)
 "wbz" = (
-/obj/machinery/suit_storage_unit/expedition,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbrown"
@@ -84808,6 +84803,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"wqy" = (
+/obj/machinery/light_switch/north{
+	pixel_x = 6
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/miningdock)
 "wri" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -85147,11 +85152,6 @@
 "wyn" = (
 /turf/simulated/wall,
 /area/station/medical/paramedic)
-"wyB" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/firealarm/directional/west,
-/turf/simulated/floor/plasteel,
-/area/station/command/teleporter)
 "wyE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -87308,10 +87308,7 @@
 	},
 /area/station/security/prisonlockers)
 "xCD" = (
-/obj/machinery/door/airlock/mining/glass{
-	id_tag = "mining_home";
-	locked = 1
-	},
+/obj/machinery/door/airlock/mining/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/fans/tiny,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
@@ -87456,6 +87453,13 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"xGK" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkbrown"
+	},
+/area/station/supply/expedition)
 "xGP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -88321,6 +88325,7 @@
 	name = "Teleporter Shutters Access Control";
 	req_access_txt = "62"
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
 "yap" = (
@@ -105408,8 +105413,8 @@ awE
 sGI
 aOB
 aaa
-aaa
-aaa
+aCs
+iZl
 aCs
 aCs
 xCD
@@ -105665,9 +105670,9 @@ aOB
 avW
 aOB
 aOB
-aOB
-aOB
-aOB
+aCs
+tVI
+siO
 aDv
 aEK
 aCw
@@ -105922,14 +105927,14 @@ auw
 awK
 rCt
 rWf
-aOB
+aCs
 aAU
-aOB
-aDv
 aGg
-aVv
+aGg
 aEK
-aIO
+aGg
+aGg
+aGg
 aCs
 bnW
 avK
@@ -106179,14 +106184,14 @@ fAH
 aHv
 adY
 xMN
-aOB
-aOB
-aOB
-aFF
-aGg
-aVv
-aHs
 aCs
+ahs
+aFF
+aFF
+lEV
+aVv
+aEK
+ned
 aCs
 aMD
 aRo
@@ -106436,12 +106441,12 @@ fuy
 aHv
 adY
 jGH
-bmq
-aOB
+aCs
+wqy
 aCt
 aDx
-aEK
-aVv
+ept
+oOb
 aEK
 gas
 aKe
@@ -106693,8 +106698,8 @@ cuz
 avY
 vtP
 hZy
-aTY
 aOW
+qmF
 rbu
 bpS
 aDy
@@ -106948,15 +106953,15 @@ atd
 akt
 auz
 aKy
-jGH
-aOB
-aOB
-aOB
-ayF
-eiR
+ePa
+adY
+aCs
+jDo
 aEK
+eiR
+aGg
 bhm
-aMS
+aGg
 aVl
 aVl
 jyW
@@ -107207,8 +107212,8 @@ aOB
 aKy
 jGH
 aOB
-aAP
-aOB
+aCs
+tid
 bfn
 eiR
 aFQ
@@ -107464,13 +107469,13 @@ adY
 aKy
 aDB
 fuy
-tsE
-aOB
-aOB
+aCs
+aCs
+aCs
 aMq
-aOB
-aOB
-aOB
+aCs
+aCs
+aCs
 aVl
 aPw
 aMW
@@ -107720,8 +107725,8 @@ ate
 awh
 hka
 aKd
-adY
-bmA
+fuy
+aAP
 aOB
 bmK
 bgA
@@ -108491,7 +108496,7 @@ adY
 aGl
 aOB
 ppw
-adY
+fuy
 bmq
 adY
 wce
@@ -112906,7 +112911,7 @@ bMS
 bxq
 bOS
 bSi
-bVe
+bOR
 bOR
 bOR
 jGU
@@ -113163,7 +113168,7 @@ bMS
 bMS
 bMS
 bMS
-bMS
+shs
 bYw
 bYw
 bYw
@@ -113419,7 +113424,7 @@ bOJ
 xYo
 bzV
 yaj
-wyB
+bMW
 bMW
 bMS
 bMS
@@ -119291,7 +119296,7 @@ lHy
 abZ
 abZ
 abZ
-hbB
+abZ
 abZ
 aZU
 baL
@@ -119845,9 +119850,9 @@ bNh
 bQD
 bSo
 lst
-fvv
+ptK
 ccm
-bWY
+tST
 bZD
 vtR
 caM
@@ -120096,19 +120101,19 @@ bDl
 qgk
 qgk
 qgk
-bJp
-bLg
+obn
+igT
 tIl
+vnA
 dre
-fYU
 dre
 fYU
 joR
 bWZ
 lWv
-tfk
-cPD
-nuy
+bNh
+caM
+nWH
 bfJ
 cej
 cmo
@@ -120357,12 +120362,12 @@ bJC
 bLg
 bNh
 wbz
+abp
 bSp
-bSp
-cJT
+xGK
 dwv
 bYp
-abp
+xGK
 bNh
 aKI
 cMh


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет на все карты личные шкафы для шахтёров и гейтеров. Ранее они были лишь на Дельте у шахтёров.
Расширяет комнату шахтёров на Мете.
Удаляет 2 аптечки шахтёров и 2 аптечки гейтеров на Дельте. Удаляет 4 аптечки гейтеров из гейтрума на Коробке. У гейтеров есть аптечки в шкафах, а у шахтёров на всех картах по одной.
Добавляет 1 аптечку и коробку донков шахтёрам на Мете. Добавляет коробку донков шахтёрам на Коробке.
Добавляет шкаф с чипами изгнания на Дельту и Мету
Добавляет зарядник для киборгов в гейтрум на Мете.
Удаляет хранилища модов и южный шлюз в гейтруме на Мете. (МАЛО МЕСТА!).

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Даёт возможность исполнять своё СРП шахтёрам и не выносить артефакты за пределы отдела. А у гейтеров вообще СРП нет. 
Снизит процент гейтеров с контрабандой/шахтёров с артефактами, гуляющих по станции.
Игроки любит присваивать чужое. Личный шкафчик заставит их потрудиться чуть больше, чем обычно. 
Чипы изгнания должны быть на всех картах, т.к. у нас есть гейт.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<details>
<summary>Коробка</summary>
<h1>Гейт</h1>

![image](https://github.com/user-attachments/assets/07582790-91e1-4a7c-8132-247e7a3f2850)
<h1>Шахтёрский док</h1>

![image](https://github.com/user-attachments/assets/d7d754f2-1953-4f03-ac2d-53dbe7854a4b)
</details>
<details>
<summary>Дельта</summary>
<h1>Гейт</h1>

![image](https://github.com/user-attachments/assets/64e4ff02-a58e-4cd5-8796-a2f6487fc1b6)
<h1>Ева</h1>

![image](https://github.com/user-attachments/assets/56bd75b4-0122-43b0-86cf-9c120e7fdc24)
</details>
<details>
<summary>Мета</summary>
<h1>Гейт</h1>

![image](https://github.com/user-attachments/assets/5d5d1f2d-ed02-4e32-a3c6-56021b8f563a)
<h1>Шахтёрский док</h1>

![image](https://github.com/user-attachments/assets/995740f0-0be3-4799-b25e-1b199d2beadc)
</details>

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Побегал на локалке, вроде файн

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: У гейтеров и шахтёров на всех картах появились личные шкафы для складирования снаряжения и артефактов.
del: На Дельте отдел карго лишился четырёх аптечек чтобы покрыть расходы на новые личные шкафы для гейтеров.
tweak: Слегка изменены комнаты гейтеров, шахтёров и гейтрум на всех картах.
fix: Шкаф с чипами изгнания (exile) теперь есть в ЕВА хранилище на каждой карте.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
