### PR TITLE
Tweak Check Antagonists

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -437,13 +437,18 @@
 			dat += check_role_table("Cultists", SSticker.mode.cult_team.members)
 			dat += "<a href='byond://?src=[UID()];check_teams=1'>View Cult Team & Controls</a><br>"
 
-		if(length(SSticker.mode.traitors))
-			dat += check_role_table("Traitors", SSticker.mode.traitors)
-
 		// SS220 EDIT - START
 		if(length(SSticker.mode.blood_brothers))
 			dat += check_role_table("Blood Brothers", SSticker.mode.blood_brothers)
+			dat += "<a href='byond://?src=[UID()];check_teams=1'>View Blood Brothers Team & Controls</a><br>"
+
+		if(length(SSticker.mode.vox_raiders))
+			dat += check_role_table("Vox Raiders", SSticker.mode.vox_raiders)
+			dat += "<a href='byond://?src=[UID()];check_teams=1'>View Vox Raiders Team & Controls</a><br>"
 		// SS220 EDIT - END
+
+		if(length(SSticker.mode.traitors))
+			dat += check_role_table("Traitors", SSticker.mode.traitors)
 
 		if(length(SSticker.mode.implanted))
 			dat += check_role_table("Mindslaves", SSticker.mode.implanted)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Closes https://github.com/ss220club/Paradise-SS220/issues/1581
- Добавляет Вокс-Рейдеров в Check Antagonists.
- Добавляет кнопку просмотра команды для Вокс-рейдеров и Кровных Братьев.

## Почему это хорошо для игры
Удобство для админов.

## Изображения изменений
![image](https://github.com/user-attachments/assets/a0d7906c-8106-4980-a458-3c406cf35429)

## Тестирование
Проверил на локалке.

## Changelog

:cl:
tweak: Вокс-Рейдеры добавлены в Check Antagonists.
tweak: Добавлена доп. кнопка просмотра команды Вокс-Рейдеров и Кровных Братьев в Check Antagonists.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
