### PR TITLE
Fix missing floor light sprite

### DIFF
--- a/modular_ss220/aesthetics/lights/code/lights.dm
+++ b/modular_ss220/aesthetics/lights/code/lights.dm
@@ -12,6 +12,9 @@
 	icon = 'icons/obj/lighting.dmi'
 	layer = ABOVE_MOB_LAYER
 
+/obj/machinery/light/floor
+	icon = 'icons/obj/lighting.dmi'
+
 /obj/machinery/light_construct
 	icon = 'modular_ss220/aesthetics/lights/icons/lights.dmi'
 	layer = ABOVE_MOB_LAYER
@@ -20,10 +23,16 @@
 	icon = 'icons/obj/lighting.dmi'
 	layer = ABOVE_MOB_LAYER
 
+/obj/machinery/light_construct/floor
+	icon = 'icons/obj/lighting.dmi'
+
 /obj/item/mounted/frame/light_fixture
 	icon = 'modular_ss220/aesthetics/lights/icons/lights.dmi'
 
 /obj/item/mounted/frame/light_fixture/small
+	icon = 'icons/obj/lighting.dmi'
+
+/obj/item/mounted/frame/light_fixture/floor
 	icon = 'icons/obj/lighting.dmi'
 
 /obj/item/flashlight/lamp


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет отсутствующий спрайт флур лайта после мерге апстрима.

## Изображения изменений
![image](https://github.com/user-attachments/assets/3bbd4e2d-49d8-4af3-91e0-bc38854ad318)

## Тестирование
Посмотрел в редакторе карт, остальное - с божьей помощью.

## Changelog

:cl:
fix: Исправлен отсутствующий спрайт у напольной лампы.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
