### PR TITLE
Chameleon counterfeiter теперь может прятать вещи

### DIFF
--- a/code/game/objects/items/devices/chameleon_counter.dm
+++ b/code/game/objects/items/devices/chameleon_counter.dm
@@ -16,6 +16,8 @@
 	var/saved_overlays
 	var/saved_underlays
 	var/dummy_active = FALSE
+	var/dummy_is_hiding_item = FALSE
+	var/obj/item/stored_item = null
 
 /obj/item/chameleon_counterfeiter/examine(mob/user)
 	. = ..()
@@ -75,3 +77,31 @@
 
 /obj/item/chameleon_counterfeiter/attack_self(mob/living/user)
 	matter_toggle(user)
+
+/obj/item/chameleon_counterfeiter/attackby(obj/item/W  as obj, mob/user as mob)
+
+	if(FALSE) // For cheeks
+		return
+
+	if(dummy_active && !dummy_is_hiding_item) // Hologram is active and empty
+		to_chat(user, "<span class='warning'>You secsesfuly hide \the [W] under projection</span>")
+		dummy_is_hiding_item = TRUE
+		user.drop_item()
+		W.forceMove(src)
+		stored_item = W
+
+	else
+		return ..() // А надо ли?
+
+/obj/item/chameleon_counterfeiter/attack_hand(mob/user as mob)
+	if(FALSE)
+		return
+
+	if(dummy_is_hiding_item)
+		to_chat(user, "<span class='warning'>Something was bihind [saved_name] </span>")
+		dummy_is_hiding_item = FALSE
+		user.put_in_hands(stored_item)
+		stored_item = null
+	else
+		return ..()
+


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавляет возможность спрятать предмет под активный  chameleon counterfeiter

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Больше возможностей

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Поместил id карту внутрь активированного проектора, потом её достал. 
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
