### PR TITLE
Fix Ghost Bar hole

### DIFF
--- a/_maps/map_files220/generic/Admin_Zone.dmm
+++ b/_maps/map_files220/generic/Admin_Zone.dmm
@@ -9799,6 +9799,7 @@
 /turf/simulated/floor/plasteel/smooth,
 /area/ghost_bar/indoor)
 "Hz" = (
+/turf/simulated/floor/plasteel/stairs,
 /area/ghost_bar/outdoor/beach)
 "HA" = (
 /obj/item/pickaxe,


### PR DESCRIPTION
## Что этот PR делает
Залатал дыру в ~~жопе~~ гост баре, которая появилась после мерге апстрима

## Changelog

:cl:
fix: Дыра в гост-баре была плодом вашего воображения
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
