### PR TITLE
Fix unsorted modular seed sprite

### DIFF
--- a/modular_ss220/hydroponics/code/plants.dm
+++ b/modular_ss220/hydroponics/code/plants.dm
@@ -4,6 +4,11 @@
 		/obj/item/seeds/cucumber = 3,)
 	. = ..()
 
+// Unsorted seeds
+/obj/item/unsorted_seeds/New(obj/item/seeds/template, mutation_level, list/mutation_focus, seed_data_in = null)
+	. = ..()
+	icon = template.icon
+
 // Buckwheat
 /obj/item/seeds/wheat/oat
 	mutatelist = list(/obj/item/seeds/wheat/buckwheat)


### PR DESCRIPTION
## Что этот PR делает
Добавляет замену иконки на иконку исходника, как с икон стейтом
Так что наши семена должны быть с спрайтом

## Тестирование
Вырастил огурец, семена имели спрайт

## Changelog

:cl:
fix: Несортированные огурцы, угливки, гречка и горохострел должны вернуть свой спрайт
/:cl:
