### PR TITLE
Use element for red alert access

### DIFF
--- a/modular_ss220/_defines220/code/signals_obj.dm
+++ b/modular_ss220/_defines220/code/signals_obj.dm
@@ -1,2 +1,5 @@
-/// from base of [/obj/proc/atom_destruction]: (damage_flag)
+/// from base of /obj/proc/atom_destruction: (damage_flag)
 #define COMSIG_OBJ_DESTRUCTION "atom_destruction"
+
+/// from base of /obj/item/card/id: ()
+#define COMSIG_ID_GET_ACCESS "id_get_access"

--- a/modular_ss220/_defines220/code/signals_obj.dm
+++ b/modular_ss220/_defines220/code/signals_obj.dm
@@ -1,5 +1,5 @@
 /// from base of /obj/proc/atom_destruction: (damage_flag)
 #define COMSIG_OBJ_DESTRUCTION "atom_destruction"
 
-/// from base of /obj/item/card/id: ()
+/// from base of /obj/item/card/id: (list/access)
 #define COMSIG_ID_GET_ACCESS "id_get_access"

--- a/modular_ss220/security_redalert_accesses/_security_redalert_accesses.dm
+++ b/modular_ss220/security_redalert_accesses/_security_redalert_accesses.dm
@@ -1,4 +1,4 @@
 /datum/modpack/security_redalert_accesses
 	name = "Доступы СБ в красный код"
 	desc = "Добавляет доступы СБ в красный код."
-	author = "dj-34, Vallat"
+	author = "dj-34, Vallat, larentoun"

--- a/modular_ss220/security_redalert_accesses/_security_redalert_accesses.dme
+++ b/modular_ss220/security_redalert_accesses/_security_redalert_accesses.dme
@@ -1,3 +1,4 @@
 #include "_security_redalert_accesses.dm"
 
 #include "code/security_redalert_accesses.dm"
+#include "code/security_redalert_element.dm"

--- a/modular_ss220/security_redalert_accesses/code/security_redalert_accesses.dm
+++ b/modular_ss220/security_redalert_accesses/code/security_redalert_accesses.dm
@@ -1,30 +1,8 @@
-/obj/item/card/id
-	var/list/red_alert_given_access // Accesses that were given on red alert
-
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
-	red_alert_given_access = list()
-	RegisterSignal(SSsecurity_level, COMSIG_SECURITY_LEVEL_CHANGED, PROC_REF(on_security_level_update))
+	AddElement(/datum/element/red_alert_access)
 
-/obj/item/card/id/Destroy()
-	return ..()
-
-/obj/item/card/id/proc/on_red_alert()
-	if(!has_access(list(), list(ACCESS_SECURITY), access))
-		return
-	red_alert_given_access = get_region_accesses(REGION_ALL) - get_region_accesses(REGION_COMMAND)
-	red_alert_given_access -= access
-
-	access |= red_alert_given_access
-
-/obj/item/card/id/proc/after_red_alert()
-	if(!has_access(list(), list(ACCESS_SECURITY), access))
-		return
-	access -= red_alert_given_access
-	red_alert_given_access.Cut()
-
-/obj/item/card/id/proc/on_security_level_update()
-	if(SSsecurity_level.current_security_level.number_level > SEC_LEVEL_BLUE)
-		on_red_alert()
-	else
-		after_red_alert()
+/obj/item/card/id/GetAccess()
+	var/list/current_access = ..()
+	. = current_access.Copy()
+	SEND_SIGNAL(src, COMSIG_ID_GET_ACCESS, .)

--- a/modular_ss220/security_redalert_accesses/code/security_redalert_element.dm
+++ b/modular_ss220/security_redalert_accesses/code/security_redalert_element.dm
@@ -10,7 +10,7 @@
 /datum/element/red_alert_access/Detach(obj/item/card/id/source, force)
 	UnregisterSignal(source, COMSIG_ID_GET_ACCESS)
 	UnregisterSignal(source, COMSIG_PARENT_EXAMINE)
-	. = ..()
+	return ..()
 
 /datum/element/red_alert_access/proc/add_access(obj/item/card/id/source, list/new_access = list())
 	SIGNAL_HANDLER

--- a/modular_ss220/security_redalert_accesses/code/security_redalert_element.dm
+++ b/modular_ss220/security_redalert_accesses/code/security_redalert_element.dm
@@ -1,0 +1,33 @@
+/datum/element/red_alert_access
+
+/datum/element/red_alert_access/Attach(datum/target, list/access = list())
+	. = ..()
+	if(!istype(target, /obj/item/card/id))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_ID_GET_ACCESS, PROC_REF(add_access))
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE, PROC_REF(examine))
+
+/datum/element/red_alert_access/Detach(obj/item/card/id/source, force)
+	UnregisterSignal(source, COMSIG_ID_GET_ACCESS)
+	UnregisterSignal(source, COMSIG_PARENT_EXAMINE)
+	. = ..()
+
+/datum/element/red_alert_access/proc/add_access(obj/item/card/id/source, list/new_access = list())
+	SIGNAL_HANDLER
+	if(!should_give_access(source.access))
+		return
+	var/static/list/red_alert_access = get_region_accesses(REGION_ALL) - get_region_accesses(REGION_COMMAND)
+	new_access |= red_alert_access
+
+/datum/element/red_alert_access/proc/examine(obj/item/card/id/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	if(!should_give_access(source.access))
+		return
+	examine_list += span_notice("Мигает красная лампочка с надписью \"Расширенный доступ\".")
+
+/datum/element/red_alert_access/proc/should_give_access(list/access)
+	if(SSsecurity_level.current_security_level.number_level <= SEC_LEVEL_BLUE)
+		return FALSE
+	if(!has_access(list(), list(ACCESS_SECURITY), access))
+		return FALSE
+	return TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Добавляет элемент, который будет улавливать сигнал получения доступа для предоставления новых доступов, а не добавлять доступа на карту.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

По факту, доступ на карте не изменяется. Если каким-то образом пропал доступ секурити, то расширенный доступ будет отключен на карте.

Так же, теперь после получении полного доступа в красный через консоль (модификация карты), когда снижается код до синего - доступа остаются на карте

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Ловушка сигналов и `.` в сигнале взяла своё

## Changelog

:cl:
tweak: [PRIME] Расширенный доступ на карте теперь проверяется не по поднятию кода, а при проверке доступа. Этот расширенный доступ не изменяет текущий доступ карты, а лишь дополняет при проверке доступа. Иными словами, можно получить полный доступ у ГП при красном коде, и на синем коде этот доступ не пропадет с карты.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
