### PR TITLE
Fix holopad runtime

### DIFF
--- a/modular_ss220/text_to_speech/code/obj/hologram.dm
+++ b/modular_ss220/text_to_speech/code/obj/hologram.dm
@@ -1,5 +1,7 @@
 /obj/machinery/hologram/holopad/activate_holo(mob/living/user, force)
 	. = ..()
+	if(!.)
+		return
 	var/obj/effect/overlay/holo_pad_hologram/hologram = .
 	var/datum/component/tts_component/user_tts = user.GetComponent(/datum/component/tts_component)
 	hologram.AddComponent(/datum/component/tts_component, user_tts.type)


### PR DESCRIPTION
## Что этот PR делает
Чинит рантайм голопада.

```
[2024-11-05T18:24:31] Runtime in code/obj/hologram.dm:5: Cannot execute null. AddComponent().
   proc name: activate holo (/obj/machinery/hologram/holopad/activate_holo)
   usr: [NT_REDACTED] ([NT_REDACTED]) (/mob/living/silicon/ai)
   usr.loc: The floor (160,23,3) (/turf/simulated/floor/bluegrid)
   src: the holopad (/obj/machinery/hologram/holopad)
   src.loc: the floor (92,178,3) (/turf/simulated/floor/plasteel)
   call stack:
   the holopad (/obj/machinery/hologram/holopad): activate_holo
   the holopad (/obj/machinery/hologram/holopad): attack_ai
   [NT_REDACTED] (/mob/living/silicon/ai): ClickOn
   the holopad (/obj/machinery/hologram/holopad): Click
   [NT_REDACTED](/client): Click
```

## Почему это хорошо для игры
Ничего не изменилось.

## Тестирование
Нет.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->
