### PR TITLE
Add holopad on holodeck control room

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -8875,6 +8875,9 @@
 	id = "holodeck";
 	range = 9
 	},
+/obj/machinery/hologram/holopad{
+	pixel_y = 16
+	},
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "aGP" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -96423,6 +96423,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/service/cafeteria)
+"rlp" = (
+/obj/effect/landmark/start/assistant,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/plasteel/dark,
+/area/station/public/fitness)
 "rlB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -170873,7 +170878,7 @@ bpQ
 dPi
 csi
 psD
-hYU
+rlp
 cwk
 uMO
 cAs

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -1623,6 +1623,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/hologram/holopad{
+	pixel_y = 16
+	},
 /turf/simulated/floor/plasteel,
 /area/station/public/fitness)
 "ank" = (


### PR DESCRIPTION
## Что этот PR делает
ДОбавил по голопадику в комнату контроля голодека

## Почему это хорошо для игры
Мне не жалко

## Изображения изменений
MDB

## Тестирование
Зачем?

## Changelog

:cl:
add: В комнату контроля голодека, добавлен голопад, на всех наших картах
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
