### PR TITLE
Delete general med access from chemistry on meta

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -85607,7 +85607,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/medical/chemistry,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteyellowfull"


### PR DESCRIPTION
## Что этот PR делает
Ёбнул доступ врачам в химию на мете, так как на остальных картах его нет

## Почему это хорошо для игры
Баланс восстановлен

## Тестирование
Nuh uh

## Changelog

:cl:
del: Мета: Удалён стандартный мед. доступ с дверей в химию
/:cl:
