### PR TITLE
Fix ID Skins interaction

### DIFF
--- a/modular_ss220/objects/code/id_skins/_id_skins_base.dm
+++ b/modular_ss220/objects/code/id_skins/_id_skins_base.dm
@@ -26,8 +26,11 @@
 	if(skin_applied)
 		. += span_notice("Нажмите <b>Alt-Click</b> на карту, чтобы снять наклейку.")
 
-/obj/item/card/id/AltClick(mob/user)
-	if(user.stat || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED) || user.restrained())
+/obj/item/card/id/AltClick(mob/living/carbon/user)
+	if(!iscarbon(user))
+		return
+
+	if(!Adjacent(user) || user.incapacitated())
 		to_chat(user, span_warning("У вас нет возможности снять наклейку!"))
 		return
 


### PR DESCRIPTION
## Что этот PR делает
Заменил проверки снятия наклейки на стандартизированные и более надёжные

## Почему это хорошо для игры
Чел не сможет через камеру спиздить наклейка
БС магия

## Тестирование
![image](https://github.com/user-attachments/assets/bf93a50a-fcdb-4b2c-af0a-47ac662dfca3)

## Changelog

:cl:
fix: Консоли камер были наделены Блюспейс магией, из-за чего через них можно было воровать наклейки с карт. Инквизиция НТ разобралась с этой проблемой. Федерации Магов НЕ победить!
/:cl:
