### PR TITLE
Tweak yellow light color

### DIFF
--- a/code/modules/power/lights.dm
+++ b/code/modules/power/lights.dm
@@ -297,12 +297,12 @@
 				break_light_tube(TRUE)
 		if("bulb")
 			brightness_range = 4
-			brightness_color = "#a0a080"
+			// brightness_color = "#a0a080" // SS220 EDIT: comment out
 			if(prob(5))
 				break_light_tube(TRUE)
 		if("floor")
 			brightness_range = 6
-			brightness_color = "#a0a080"
+			// brightness_color = "#a0a080" // SS220 EDIT: comment out
 			if(prob(3))
 				break_light_tube(TRUE)
 	update(FALSE, TRUE, FALSE)

--- a/modular_ss220/aesthetics/lights/code/lights.dm
+++ b/modular_ss220/aesthetics/lights/code/lights.dm
@@ -11,9 +11,11 @@
 /obj/machinery/light/small
 	icon = 'icons/obj/lighting.dmi'
 	layer = ABOVE_MOB_LAYER
+	brightness_color = "#FFF780"
 
 /obj/machinery/light/floor
 	icon = 'icons/obj/lighting.dmi'
+	brightness_color = "#FFF780"
 
 /obj/machinery/light_construct
 	icon = 'modular_ss220/aesthetics/lights/icons/lights.dmi'


### PR DESCRIPTION
## Что этот PR делает
Делает желтый свет ярче, а то как-то блекло очень.

## Почему это хорошо для игры
Красивее.

## Изображения изменений
![image](https://github.com/user-attachments/assets/87f379f6-e7d8-494b-acf3-789ebcd68204)

## Changelog

:cl: Maxiemar
tweak: Малые и напольные лампы стали ярче в обычном режиме.
/:cl:
