### PR TITLE
Prevent Nanomaps Render failure if no changes

### DIFF
--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -43,7 +43,7 @@ jobs:
         git pull origin master
         git commit -m "NanoMap Auto-Update (`date`)" -a || true
         git push -f -u origin nanomap-render
-        result=$(gh pr create -t "Automatic NanoMap Update" -b "This pull request updates the server NanoMaps. Please review the diff images before merging." -l "NanoMaps,:scroll: CL не требуется" -H "nanomap-render" -B "master")
+        result=$(gh pr create -t "Automatic NanoMap Update" -b "This pull request updates the server NanoMaps. Please review the diff images before merging." -l "NanoMaps,:scroll: CL не требуется" -H "nanomap-render" -B "master") || true
         if echo "$result" | grep -q "No commits between master and nanomap-render"
           echo "No NanoMaps update required, skipping."
           exit 78


### PR DESCRIPTION
## Что этот PR делает
Скипает джоб, если нет изменений, вместо фейла.
Наверное, поможет и ничего не сломаю.

```
pull request create failed: GraphQL: No commits between master and nanomap-render (createPullRequest)
```

![image](https://github.com/user-attachments/assets/2d65b1fb-9d17-4c1f-badf-123e93500fc3)
