### PR TITLE
Tweak atmos access

### DIFF
--- a/modular_ss220/balance/code/access/access.dm
+++ b/modular_ss220/balance/code/access/access.dm
@@ -28,7 +28,7 @@
 
 /datum/job/atmos/New()
 	. = ..()
-	access |= list(ACCESS_ENGINE)
+	access |= list(ACCESS_ENGINE, ACCESS_ENGINE_EQUIP)
 
 /datum/job/engineer/New()
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Поднимает доступы атмоса до инжа.

## Почему это хорошо для игры
Несколько раз просили уровнять доступы инжа и атмоса. Справедливо, один не должен быть подсосом другого.

## Тестирование
Открывается ранее недоступное атмосу (апц, шкафчики).

## Changelog

:cl: Maxiemar
tweak: Атмосферный техник теперь имеет те же доступы, что и станционный инженер.
/:cl:
