### PR TITLE
Allow comments in the changelog section

### DIFF
--- a/tools/changelog/check_changelog.py
+++ b/tools/changelog/check_changelog.py
@@ -19,7 +19,7 @@ import json
 DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
 
 CL_BODY = re.compile(r"(:cl:|🆑)[ \t]*(?P<author>.+?)?\s*\n(?P<content>(.|\n)*?)\n/(:cl:|🆑)", re.MULTILINE)
-CL_SPLIT = re.compile(r"\s*((?P<tag>\w+)\s*:)?\s*(?P<message>.*)")
+CL_SPLIT = re.compile(r"\s*(?:<!--.*-->)?((?P<tag>\w+)\s*:)?\s*(?P<message>.*)")
 
 DISCORD_TAG_EMOJI = {
     "soundadd": ":notes:",
@@ -95,7 +95,7 @@ def parse_changelog(message: str) -> dict:
         else:
             if len(cl_changes):
                 prev_change = cl_changes[-1]
-                prev_change["message"] += f" {change_parse_result['message']}"
+                prev_change["message"] += f" {message}"
             else:
                 raise Exception(f"Change with no tag: {cl_line}")
 


### PR DESCRIPTION
## Что этот PR делает
Разрешает писать комментарии в чейнджлоге, которые в сам чейнджлог не попадут.
В комментарий можно положить ссылку на ПР, оригинальный чейнджлог.
Должно быть удобно для создания ПРа скриптом.

Пример использования.
```
:cl:
add: Добавил новые вещи.
<!-- add: Added new things. (https://github.com/.../pull/1234) -->
/:cl:
