### PR TITLE
Bring scientific analyzer back

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -21490,10 +21490,7 @@
 /obj/machinery/computer/guestpass{
 	pixel_y = 30
 	},
-/obj/machinery/r_n_d/circuit_imprinter{
-	pixel_x = 3;
-	pixel_y = 5
-	},
+/obj/machinery/r_n_d/circuit_imprinter,
 /obj/machinery/button/windowtint/west{
 	id = "rnd"
 	},
@@ -65528,6 +65525,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "lTr" = (
+/obj/machinery/r_n_d/scientific_analyzer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "purple"

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -37364,6 +37364,7 @@
 /area/station/science/research)
 "cYm" = (
 /obj/machinery/alarm/directional/west,
+/obj/machinery/r_n_d/scientific_analyzer,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -30409,6 +30409,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 32
 	},
+/obj/machinery/r_n_d/scientific_analyzer,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whitepurple"


### PR DESCRIPTION
## Что этот PR делает
Не заметил пропажу анализатора после переименования. Возвращаю обратно.

## Тестирование
Нет.

## Changelog

:cl: Maxiemar
fix: Научный анализатор снова доступен в РНД.
/:cl:
