### PR TITLE
Fix: gateguns and mine spawners

### DIFF
--- a/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
+++ b/modular_ss220/awaymission_gun/code/items/awaymission_gun.dm
@@ -14,11 +14,11 @@
 /obj/item/gun/energy/laser/awaymission_aeg/Initialize(mapload)
 	. = ..()
 	// Force update it incase it spawns outside an away mission and shouldnt be charged
-	on_changed_z_level(new_turf = loc.z)
+	on_changed_z_level(new_turf = loc)
 
 /obj/item/gun/energy/laser/awaymission_aeg/on_changed_z_level(turf/old_turf, turf/new_turf)
 	. = ..()
-	if(is_away_level(new_turf))
+	if(is_away_level(new_turf.z))
 		if(ismob(loc))
 			to_chat(loc, span_notice("Ваш [src] активируется, начиная аккумулировать энергию из материи сущего."))
 		selfcharge = TRUE

--- a/modular_ss220/maps220/code/mobs.dm
+++ b/modular_ss220/maps220/code/mobs.dm
@@ -452,9 +452,9 @@
 	var/jungle_mob = null
 
 /obj/effect/landmark/awaymissions/gate_lizard/mine_spawner/on_atom_entered(datum/source, atom/movable/entered)
-	if(!isliving(source))
+	if(!isliving(entered))
 		return
-	var/mob/living/M = source
+	var/mob/living/M = entered
 	if(faction && (faction in M.faction))
 		return
 	triggerlandmark(M)
@@ -1297,9 +1297,9 @@
 	var/syndi_mob = null
 
 /obj/effect/landmark/awaymissions/spacebattle/mine_spawner/on_atom_entered(datum/source, atom/movable/entered)
-	if(!isliving(source))
+	if(!isliving(entered))
 		return
-	var/mob/living/M = source
+	var/mob/living/M = entered
 	if(faction && (faction in M.faction))
 		return
 	triggerlandmark(M)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Возвращает зарядку гейтганов внутри гейта, чинит mine_spawner.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Фикс багов.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Запустил локалку: проверил отсутствие заряда на изначальных гейтганах в шкафах, их заряд внутри сектора гейта, обнуление заряда при выходе из сектора гейта.
Проверил корректную работу mine_spawner в джунглях и спейсбаттле.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Furgar
fix: гейтганы снова заряжаются в гейтах.
fix: доспаун мобов в гейтах - джунгли и спейсбаттл снова работает.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
