### PR TITLE
Fix `build_rust` workflow

### DIFF
--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -38,7 +38,7 @@ jobs:
       - name: PR Data
         run: |
           pr_json=$(curl -L -s --fail-with-body -H "Authorization: token ${{ github.token }}" ${{ github.event.issue.pull_request.url }})
-          if [ `jq -r '.maintainer_can_modify' <<<$pr_json` == "false" ] ; then
+          if [ `jq -r '.head.repo.id == .base.repo.id' <<<$pr_json` == "false" ] && [ `jq -r '.maintainer_can_modify' <<<$pr_json` == "false" ] ; then
             gh pr comment ${{ github.event.issue.html_url }} --body 'GitHub Actions can not push to the repository without "Allow edits and access to secrets by maintainers" checked.'
             echo "FAIL_NOTIFIED=true" >> "$GITHUB_ENV"
             exit 1


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет работу воркфлоу, когда репозитории `head` и `base` веток совпадают.
Позволяет ребилдить раст при автоматизированном мерже апстрима.

## Тестирование
Проверил фрагмент в тестовом скрипте.

## Summary by Sourcery

CI:
- Fix the build workflow to handle the case where the head and base repositories are the same.