### PR TITLE
Fix `build_rust` workflow (i hope)

### DIFF
--- a/.github/workflows/build_rust.yml
+++ b/.github/workflows/build_rust.yml
@@ -13,7 +13,7 @@ jobs:
       (github.event.comment.author_association == 'MEMBER') ||
       (github.event.comment.author_association == 'OWNER'))
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: create_token
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
## Что этот PR делает
Каким-то образом, `ubuntu-latest` в апстриме это `24.04`, а у нас - `22.04`. Возможно, замешано какое-то кэширование гитхаба. Пробую поставить конкретную версию, мб поможет.

https://github.com/ss220club/Paradise-SS220/actions/runs/12609052833/job/35142665814
https://github.com/ParadiseSS13/Paradise/actions/runs/12573150696/job/35045879319

## Summary by Sourcery

CI:
- Pin the Ubuntu version used by the `build_rust` workflow to `ubuntu-24.04`.