### PR TITLE
Paramedic room tweaks

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -24707,9 +24707,16 @@
 /area/station/maintenance/disposal/west)
 "bXo" = (
 /obj/structure/table/glass,
-/obj/machinery/light_switch/north,
+/obj/machinery/light_switch/north{
+	pixel_x = -6
+	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/item/soap,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/button/windowtint/west{
+	id = "paramedic";
+	pixel_x = 6;
+	pixel_y = 24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -38932,7 +38939,9 @@
 	},
 /area/station/hallway/primary/aft)
 "dgD" = (
-/obj/effect/spawner/window/reinforced/grilled,
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "paramedic"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/paramedic)
 "dgE" = (
@@ -40436,12 +40445,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/abandonedbar)
 "dnJ" = (
-/obj/machinery/disposal,
 /obj/machinery/camera{
 	c_tag = "Medbay Paramedic";
 	network = list("Medbay","SS13");
 	dir = 1
 	},
+/obj/structure/closet/paramedic,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -40725,7 +40734,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
 "dpf" = (
-/obj/structure/closet/paramedic,
 /obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
@@ -48340,6 +48348,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "paramedic"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/paramedic,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -30982,6 +30982,12 @@
 /area/station/medical/reception)
 "cop" = (
 /obj/structure/closet/secure_closet/paramedic,
+/obj/machinery/light_switch/west,
+/obj/machinery/button/windowtint/west{
+	id = "paramedic";
+	pixel_y = 8;
+	range = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -68148,6 +68154,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "paramedic"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/paramedic,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
@@ -69038,6 +69047,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "paramedic"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/paramedic,
 /turf/simulated/floor/plasteel{
@@ -80776,7 +80788,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "xvh" = (
-/obj/effect/spawner/window/reinforced/grilled,
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "paramedic"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/paramedic)
 "xvi" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Кабинет парамедика:
Удаляет косметическую (нерабочую) мусорку на Дельте.
Добавляет затемняющиеся окна и кнопку для их затемнения на Дельту и Мету.
Заменяет мыло на клинер на Дельте.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Мусорка была нерабочей, хотел сделать рабочую, а там.. короче проще как и всегда было - без мусорки для парамеда.
Попутно заменил мыло на клинер, т.к. мыло неиграбельное д***мо (сори за мат) и добавил затемняющиеся окна как на Коробке, закрываться от других это классно!

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

Фото не будет, поверьте на слово, пожалуйста.

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Запустил локалку и потыкал кнопки тонировки на обеих картах.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Из кабинета парамедика на Дельте удалена косметическая мусорка.
tweak: На Дельту и Мету добавлены тонированные окна для парамедика.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Summary by Sourcery

Enhance the paramedic rooms on Delta and Meta stations by removing a non-functional trash can, adding tintable windows with a control button, and replacing soap with a cleaner on Delta station.

Enhancements:
- Remove non-functional trash can from the paramedic room on Delta station.
- Add tintable windows and a button for tinting in the paramedic rooms on Delta and Meta stations.
- Replace soap with a cleaner in the paramedic room on Delta station.