### PR TITLE
Translate: NCT office area

### DIFF
--- a/code/game/area/ss13_areas/procedure_areas.dm
+++ b/code/game/area/ss13_areas/procedure_areas.dm
@@ -1,4 +1,4 @@
 
 /area/station/procedure/trainer_office
-	name = "\improper Trainer's Office"
+	name = "Офис Профессионального Тренера НТ"
 	icon_state = "procedure_nct"


### PR DESCRIPTION
Перевод названия зоны офиса NCT

## Summary by Sourcery

Chores:
- Translate "Trainer\'s Office" to "Офис Профессионального Тренера НТ".