### PR TITLE
Fix: bump_teleporter runtime

### DIFF
--- a/modular_ss220/maps220/code/effects.dm
+++ b/modular_ss220/maps220/code/effects.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 /obj/effect/bump_teleporter/singularity_pull()
 	return
 
-/obj/effect/bump_teleporter/Bumped(atom/user)
+/obj/effect/bump_teleporter/Bumped(atom/movable/user)
 	if(!ismob(user))
 		//user.loc = src.loc	//Stop at teleporter location
 		return
@@ -130,7 +130,7 @@ GLOBAL_LIST_EMPTY(bump_teleporters)
 
 	for(var/obj/effect/bump_teleporter/BT in GLOB.bump_teleporters)
 		if(BT.id == src.id_target)
-			usr.loc = BT.loc	//Teleport to location with correct id.
+			user.loc = BT.loc	//Teleport to location with correct id.
 			return
 
 /obj/effect/bump_teleporter/lambda


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет runtime ошибку.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
При движении по оси X или Y, когда персонаж натыкается на эффект, возникает runtime, а персонаж остается на месте. И для того, чтобы всё таки переместиться в следующую локацию, приходится мудрить путём движения наискось. Исправляем взаимодействие.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->


<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Скомпилировал локально, поперемещался как в гейте, так и на базе Синди-командования.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Furgar
fix: Перемещение между локациями гейта Caves нормализовано.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
