### PR TITLE
Both Ears Cigs

### DIFF
--- a/code/game/objects/items/weapons/cigs.dm
+++ b/code/game/objects/items/weapons/cigs.dm
@@ -22,7 +22,7 @@ LIGHTERS ARE IN LIGHTERS.DM
 	icon_state = "cigoff"
 	item_state = "cigoff"
 	throw_speed = 0.5
-	slot_flags = ITEM_SLOT_MASK
+	slot_flags = ITEM_SLOT_MASK | ITEM_SLOT_BOTH_EARS
 	w_class = WEIGHT_CLASS_TINY
 	body_parts_covered = null
 	attack_verb = null


### PR DESCRIPTION
## Что этот PR делает

Даёт возможность хранить сигарету за ухом.

## Почему это хорошо для игры

Удобство, теперь можно хранить сигарету за ухом.


## Тестирование

Локалка, сигареты можно было класть за ухо. При компиле ошибок нет (Первый ПР не судите строго)

## Changelog

:cl:

tweak: Добавил возможность класть сигареты в слот ушей 

/:cl:

## Summary by Sourcery

New Features:
- Cigarettes can now be placed in both ears.