### PR TITLE
Nerf necropolis' spellbooks

### DIFF
--- a/_maps/map_files220/generic/Lavaland.dmm
+++ b/_maps/map_files220/generic/Lavaland.dmm
@@ -11004,7 +11004,7 @@
 	dir = 1
 	},
 /obj/structure/sacrificealtar,
-/obj/item/spellbook/oneuse/random,
+/obj/item/spellbook/oneuse/random/necropolis,
 /turf/simulated/floor/indestructible/boss,
 /area/lavaland/surface/outdoors/legion)
 "Zv" = (

--- a/modular_ss220/objects/_objects.dme
+++ b/modular_ss220/objects/_objects.dme
@@ -44,6 +44,7 @@
 #include "code/posters.dm"
 #include "code/shuttle.dm"
 #include "code/smartfridge.dm"
+#include "code/spellbook.dm"
 #include "code/tribune.dm"
 #include "code/key.dm"
 #include "code/musician.dm"

--- a/modular_ss220/objects/code/spellbook.dm
+++ b/modular_ss220/objects/code/spellbook.dm
@@ -1,0 +1,5 @@
+/obj/item/spellbook/oneuse/random/necropolis/initialize()
+	var/static/list/banned_spells = typesof(/obj/item/spellbook/oneuse/mime, /obj/item/spellbook/oneuse/emp, /obj/item/spellbook/oneuse/mindswap)
+	var/real_type = pick(subtypesof(/obj/item/spellbook/oneuse) - banned_spells)
+	new real_type(loc)
+	qdel(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Удаляет возможность заспавнить книгу майндсвапа в Некрополе.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Потому что она ничего хорошего в раунд не привносит. Сам спавнер изначально был добавлен модульно, но взят с оффов, а на оффах он в руинах не используется, следовательно не балансно!!!

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

запустил локалочку и заспавнил кучу `/obj/item/spellbook/oneuse/random/necropolis`.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: В Некрополе больше нельзя найти книгу майндсвапа.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Summary by Sourcery

Tests:
- Tested spawning multiple Necropolis spellbooks in a local environment.