### PR TITLE
Fix: remove hedset on ghostbar

### DIFF
--- a/_maps/map_files220/generic/Admin_Zone.dmm
+++ b/_maps/map_files220/generic/Admin_Zone.dmm
@@ -1527,9 +1527,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/medical3{
-	req_access = null
-	},
+/obj/structure/closet/secure_closet/medical_ghostbar,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},

--- a/modular_ss220/aesthetics/closets/code/closets.dm
+++ b/modular_ss220/aesthetics/closets/code/closets.dm
@@ -9,3 +9,26 @@
 
 /obj/structure/closet/secure_closet/personal/cabinet
 	icon = 'modular_ss220/aesthetics/closets/icons/closets.dmi'
+
+// MARK: Ghost Bar
+/obj/structure/closet/secure_closet/medical_ghostbar
+	name = "medical doctor's locker"
+	icon_state = "med_secure"
+	opened_door_sprite = "white_secure"
+
+/obj/structure/closet/secure_closet/medical_ghostbar/populate_contents()
+	if(prob(50))
+		new /obj/item/storage/backpack/medic(src)
+	else
+		new /obj/item/storage/backpack/satchel_med(src)
+	new /obj/item/storage/backpack/duffel/medical(src)
+	new /obj/item/clothing/under/rank/medical/doctor(src)
+	new /obj/item/clothing/suit/storage/labcoat(src)
+	new /obj/item/clothing/shoes/white(src)
+	new /obj/item/clothing/gloves/color/latex/nitrile(src)
+	new /obj/item/defibrillator/loaded(src)
+	new /obj/item/handheld_defibrillator(src)
+	new /obj/item/handheld_defibrillator(src)
+	new /obj/item/storage/belt/medical(src)
+	new /obj/item/clothing/glasses/hud/health(src)
+	new /obj/item/clothing/shoes/sandal/white(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Удалил наушник из гостбара. Вроде бы все.

## Почему это хорошо для игры

Больше никаких трансляций сборника пикантных анекдотов Романа Трахтенберга из гостбара для станции

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

локалка, работает

## Changelog

:cl:
fix: Удален наушник из гостбара. Больше никаких трансляций сборников анекдотов для станции.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
