### PR TITLE
Fix return value of pool spawner initialization

### DIFF
--- a/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
+++ b/code/game/objects/effects/spawners/random/pool/pool_spawner.dm
@@ -43,7 +43,7 @@
 		pool.guaranteed_spawners |= src
 	else
 		pool.known_spawners |= src
-	return INITIALIZE_HINT_QDEL
+	return INITIALIZE_HINT_NORMAL
 
 /obj/effect/spawner/random/pool/generate_loot_list()
 	var/datum/spawn_pool/pool = GLOB.spawn_pool_manager.get(spawn_pool_id)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Чинит спавн лута в космосе.

## Changelog

:cl: Maxiemar
fix: Исправлен спавн лута в космосе.
/:cl:

## Summary by Sourcery

Fix space loot spawning and increase the available points for loot generation to account for additional usage in centcomm and the gateway.

Bug Fixes:
- Fixed a bug that prevented space loot from spawning correctly.

Enhancements:
- Increased the available points for loot generation.