### PR TITLE
Удаление доступа у питомца снабжения

### DIFF
--- a/modular_ss220/mobs/_mobs.dme
+++ b/modular_ss220/mobs/_mobs.dme
@@ -20,6 +20,7 @@
 #include "code/simple_animal/hostile/spider.dm"
 #include "code/simple_animal/hostile/syndi_rat.dm"
 #include "code/simple_animal/hostile/undead.dm"
+#include "code/simple_animal/hostile/gorilla.dm"
 #include "code/simple_animal/pets/cat.dm"
 #include "code/simple_animal/pets/dog.dm"
 #include "code/simple_animal/pets/fashion.dm"

--- a/modular_ss220/mobs/code/simple_animal/hostile/gorilla.dm
+++ b/modular_ss220/mobs/code/simple_animal/hostile/gorilla.dm
@@ -1,0 +1,2 @@
+/obj/item/card/id/supply/cargo_gorilla
+	access = list()


### PR DESCRIPTION
Удаление доступа у питомца отдела снабжения

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Удаляет доступ у гориллы отдела снабжения

## Почему это хорошо для игры

Число незаметных проникновений в отдел снабжения снизится

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Протестировал на локальном билде толкая гориллу в шлюзы отдела снабжения, шлюзы как и ожидалось не открываются

## Changelog

:cl:
tweak: Отобран доступ у гориллы отдела снабжения
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Summary by Sourcery

Tests:
- Tested locally by pushing the gorilla into the supply airlocks.