### PR TITLE
[TM] Disable harddel

### DIFF
--- a/code/controllers/subsystem/SSgarbage.dm
+++ b/code/controllers/subsystem/SSgarbage.dm
@@ -251,7 +251,14 @@ SUBSYSTEM_DEF(garbage)
 	var/type = D.type
 	var/refID = text_ref(D)
 
-	// del(D) SS220 EDIT - disable hard del (performance tweak)
+	// SS220 EDIT START - disable hard del (performance tweak)
+#ifdef GAME_TESTS
+	del(D)
+#else
+	if(istype(D, /client))
+		del(D) // this allows player kicking
+#endif
+	// SS220 EDIT END
 
 	tick = (TICK_USAGE - tick + ((world.time - ticktime) / world.tick_lag * 100))
 


### PR DESCRIPTION
## Что этот PR делает
Отключает харддел на проде

## Summary by Sourcery

Enhancements:
- Disable hard deletion in production to improve performance.