### PR TITLE
Forbid to sharpen melee energy weapons

### DIFF
--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -2,10 +2,11 @@
 
 #include "code/access/access.dm"
 #include "code/events/blob.dm"
+#include "code/items/melee.dm"
 #include "code/items/projectiles.dm"
-#include "code/items/weapons.dm"
-#include "code/items/storage/surgical_tray.dm"
 #include "code/items/storage/closets.dm"
+#include "code/items/storage/surgical_tray.dm"
+#include "code/items/weapons.dm"
 #include "code/jobs/warden.dm"
 #include "code/mobs/aliens/larva.dm"
 #include "code/species/machine.dm"

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -1,0 +1,10 @@
+/obj/item/melee/energy
+	var/sharpening_allowed = FALSE
+
+/obj/item/melee/energy/try_sharpen(obj/item/item, amount, max_amount)
+	if(!sharpening_allowed)
+		return COMPONENT_BLOCK_SHARPEN_BLOCKED
+	return ..()
+
+/obj/item/melee/energy/cleaving_saw
+	sharpening_allowed = TRUE


### PR DESCRIPTION
## Что этот PR делает
Запрещает точить энергетическое ближнее оружие.

## Почему это хорошо для игры
Сокращение бредика.

## Тестирование
Проверил разное энергетическое оружие на всех камнях - не точится.

## Changelog

:cl: Maxiemar
tweak: Ликвидирована возможность точить энергетическое оружие ближнего боя.
/:cl:

## Summary by Sourcery

Disallow sharpening energy melee weapons, except for the cleaving saw.

New Features:
- Add a new variable to energy melee weapons to control whether they can be sharpened.

Bug Fixes:
- Prevent energy melee weapons from being sharpened, reducing exploits.