### PR TITLE
[TM] Fix speed boost on diagonal movement

### DIFF
--- a/code/modules/mob/mob_vars.dm
+++ b/code/modules/mob/mob_vars.dm
@@ -1,6 +1,7 @@
 /mob
 	density = TRUE
 	layer = MOB_LAYER
+	appearance_flags = TILE_BOUND | LONG_GLIDE
 	animate_movement = SLIDE_STEPS
 	pressure_resistance = 8
 	throwforce = 10


### PR DESCRIPTION
## Что этот PR делает
Фиксит диагональную скорость у всех мобов, кроме хуманов (у них бага нет)

## Summary by Sourcery

Bug Fixes:
- Fixed the diagonal movement speed bug for mobs.