### PR TITLE
Separate loot pool for CC

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -337,6 +337,7 @@
 "aoD" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -2076,6 +2077,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/fans/tiny/invisible,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -5713,6 +5715,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/light_fake/small,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -11818,8 +11821,7 @@
 /area/centcom/ss220/supply)
 "haI" = (
 /obj/effect/turf_decal/delivery/red,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -17961,8 +17963,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -19973,8 +19974,8 @@
 /area/syndicate_mothership)
 "lKt" = (
 /obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
+/obj/structure/closet/crate,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -20849,16 +20850,6 @@
 /obj/machinery/computer/shuttle/sit,
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
-"mjW" = (
-/obj/structure/light_fake/spot{
-	dir = 1
-	},
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowalt"
-	},
-/area/syndicate_mothership/cargo)
 "mkf" = (
 /obj/structure/chair/comfy/red{
 	dir = 1
@@ -22240,14 +22231,6 @@
 	icon_state = "darkyellowfull"
 	},
 /area/syndicate_mothership/cargo)
-"neJ" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkyellowalt"
-	},
-/area/syndicate_mothership/cargo)
 "neL" = (
 /obj/machinery/economy/slot_machine,
 /turf/simulated/floor/carpet/arcade,
@@ -22455,13 +22438,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/control)
-"nlb" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "nlc" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/gamma/space)
@@ -23153,8 +23129,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23578,8 +23553,7 @@
 /area/syndicate_mothership/outside)
 "nRS" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -24730,8 +24704,7 @@
 "oEC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/delivery/red,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25393,9 +25366,8 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "oYr" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "darkyellowalt"
@@ -33866,6 +33838,7 @@
 	icon_state = "cardboard_syndicate"
 	},
 /obj/effect/turf_decal/delivery/white,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34405,9 +34378,8 @@
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
 "upU" = (
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkyellowalt"
@@ -36691,6 +36663,7 @@
 "vEg" = (
 /obj/structure/light_fake/spot,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellowalt"
@@ -38194,8 +38167,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -38751,16 +38723,6 @@
 	icon_state = "darkbluealt"
 	},
 /area/centcom/ss220/admin1)
-"wLN" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/common/depot,
-/obj/structure/closet/secure_closet/depot,
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "dark"
-	},
-/area/syndicate_mothership/cargo)
 "wMc" = (
 /obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
@@ -40125,6 +40087,7 @@
 	dir = 1
 	},
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -42638,7 +42601,7 @@ rQg
 brK
 vjy
 bed
-wLN
+tJL
 aoD
 rQg
 bnK
@@ -42895,7 +42858,7 @@ rQg
 dqv
 dcn
 bed
-wLN
+tJL
 jKB
 rQg
 apg
@@ -43152,7 +43115,7 @@ vVk
 vVk
 hlh
 vVk
-lKt
+jKB
 dxV
 rQg
 cNI
@@ -43410,7 +43373,7 @@ iLT
 hOq
 rQg
 aoD
-lKt
+jKB
 rQg
 fgd
 lpx
@@ -44683,7 +44646,7 @@ slN
 slN
 oYr
 vVk
-neJ
+cex
 slN
 slN
 nbj
@@ -44940,7 +44903,7 @@ slN
 slN
 vEg
 rQg
-mjW
+sKq
 slN
 slN
 nbj
@@ -46493,8 +46456,8 @@ iLT
 iLT
 gfa
 rQg
-lKt
-lKt
+jKB
+jKB
 rQg
 fgd
 mAS
@@ -47008,7 +46971,7 @@ kMv
 dcn
 mpV
 tJL
-lKt
+jKB
 rQg
 apg
 qFx
@@ -47265,7 +47228,7 @@ sRe
 vHq
 mpV
 boW
-lKt
+jKB
 rQg
 bnK
 lpx
@@ -50571,7 +50534,7 @@ fnU
 gOQ
 tCJ
 bcl
-nlb
+ovP
 haI
 jsg
 haI

--- a/modular_ss220/balance/code/loot/pools.dm
+++ b/modular_ss220/balance/code/loot/pools.dm
@@ -1,3 +1,114 @@
+// CC loot pool
+/datum/spawn_pool/centcommloot
+	id = "central_command_spawn_pool"
+	available_points = INFINITY
+
+/obj/effect/spawner/random/pool/centcommloot
+	icon = 'icons/effects/random_spawners.dmi'
+	icon_state = "giftbox"
+	spawn_pool_id = "central_command_spawn_pool"
+
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1
+	spawn_loot_chance = 40
+	loot = list(
+		// Loot schema: costumes, toys, useless gimmick items
+		/obj/item/clothing/mask/gas/syndicate,
+		/obj/item/clothing/shoes/magboots/syndie,
+		/obj/item/clothing/suit/jacket/bomber/syndicate,
+		/obj/item/clothing/suit/storage/iaa/blackjacket/armored,
+		/obj/item/clothing/under/syndicate/combat,
+		/obj/item/clothing/under/syndicate/sniper,
+		/obj/item/coin/antagtoken/syndicate,
+		/obj/item/deck/cards/syndicate,
+		/obj/item/lighter/zippo/gonzofist,
+		/obj/item/soap/syndie,
+		/obj/item/stamp/chameleon,
+		/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
+		/obj/item/storage/toolbox/syndicate,
+		/obj/item/suppressor,
+		/obj/item/toy/syndicateballoon,
+		/obj/item/storage/secure/briefcase/syndie,
+	)
+
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier2
+	spawn_loot_chance = 40
+	loot = list(
+		/obj/item/ammo_box/magazine/m10mm,
+		/obj/item/clothing/gloves/color/black/thief,
+		/obj/item/clothing/shoes/chameleon/noslip,
+		/obj/item/clothing/under/syndicate/silicon_cham,
+		/obj/item/clothing/mask/chameleon/voice_change,
+		/obj/item/flash/cameraflash,
+		/obj/item/gun/projectile/automatic/toy/pistol/riot,
+		/obj/item/lighter/zippo/gonzofist,
+		/obj/item/mod/module/chameleon,
+		/obj/item/mod/module/holster/hidden,
+		/obj/item/mod/module/noslip,
+		/obj/item/mod/module/visor/night,
+		/obj/item/mod/module/plate_compression,
+		/obj/item/reagent_containers/hypospray/autoinjector/hyper_medipen,
+		/obj/item/reagent_containers/hypospray/autoinjector/nanocalcium,
+		/obj/item/stack/sheet/mineral/gold{amount = 20},
+		/obj/item/stack/sheet/mineral/plasma{amount = 20},
+		/obj/item/stack/sheet/mineral/silver{amount = 20},
+		/obj/item/stack/sheet/mineral/uranium{amount = 20},
+		/obj/item/stamp/chameleon,
+		/obj/item/storage/backpack/duffel/syndie/med/surgery,
+		/obj/item/storage/backpack/satchel_flat,
+		/obj/item/storage/belt/military,
+		/obj/item/storage/box/syndie_kit/camera_bug,
+		/obj/item/storage/box/syndie_kit/chameleon,
+		/obj/item/storage/box/syndie_kit/space,
+	)
+
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier3
+	spawn_loot_chance = 40
+	loot = list(
+		/obj/item/borg/upgrade/syndicate,
+		/obj/item/clothing/glasses/hud/security/chameleon,
+		/obj/item/clothing/glasses/thermal,
+		/obj/item/clothing/shoes/magboots/elite,
+		/obj/item/door_remote/omni/access_tuner,
+		/obj/item/encryptionkey/binary,
+		/obj/item/jammer,
+		/obj/item/mod/module/power_kick,
+		/obj/item/mod/module/visor/thermal,
+		/obj/item/pen/edagger,
+		/obj/item/pinpointer/advpinpointer,
+		/obj/item/stack/sheet/mineral/diamond{amount = 10},
+		/obj/item/storage/belt/sheath/snakesfang,
+		/obj/item/storage/box/syndidonkpockets,
+		/obj/item/storage/box/syndie_kit/stechkin,
+		/obj/item/mod/control/pre_equipped/traitor,
+		/obj/item/mod/module/stealth,
+	)
+
+/obj/effect/spawner/random/pool/centcommloot/syndicate/tier4
+	loot = list(
+		/obj/item/bio_chip_implanter/proto_adrenalin,
+		/obj/item/chameleon,
+		/obj/item/gun/medbeam,
+		/obj/item/gun/projectile/automatic/sniper_rifle/toy,
+		/obj/item/melee/energy/sword/saber,
+		/obj/item/mod/control/pre_equipped/traitor_elite,
+		/obj/item/organ/internal/cyberimp/arm/razorwire,
+		/obj/item/organ/internal/cyberimp/brain/sensory_enhancer,
+		/obj/item/reagent_containers/hypospray/autoinjector/stimulants,
+		/obj/item/shield/energy,
+		/obj/item/weaponcrafting/gunkit/universal_gun_kit,
+		/obj/item/storage/box/syndie_kit/teleporter,
+		/obj/item/cqc_manual,
+	)
+
+/obj/effect/spawner/random/pool/centcommloot/syndicate/mixed
+	loot = list(
+		/obj/effect/spawner/random/pool/centcommloot/syndicate/tier1 = 30,
+		/obj/effect/spawner/random/pool/centcommloot/syndicate/tier2 = 20,
+		/obj/effect/spawner/random/pool/centcommloot/syndicate/tier3 = 5,
+		/obj/effect/spawner/random/pool/centcommloot/syndicate/tier4 = 1,
+	)
+
+// space loot pool
 /datum/spawn_pool/spaceloot
 	available_points = 2200 // tweak available points considering centcomm and away mission
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет отдельный пул для лута ЦК (Синди ЦК, если быть точнее).

Удаляет лишние шкафы депота (если на ЦК появлялся какой-то лут - спавнилось по два шкафа, оба из которых нельзя передвигать. А если не спавнилось - был один несдвигаемый шкаф).

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

ЦК - гиммик зона, на которую не должны распространяться рамки "баланса". По этой причине все спавнеры на ней имеют стоимость в 0 очков, а сам пул имеет бесконечное количество очков для траты. Иными словами, можно спавнить что угодно и сколь угодно, не влияя на баланс игроков.

Кол-во очков лута для космоса не трогаю, т.к. в планах ещё сделать отдельный пул для гейтов, и потом уже снизить до 1700 для космоса, как на оффах.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Запустил локалку, лут появился и без лишних шкафов.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

NPFC

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
