### PR TITLE
Tweak megafauna loot

### DIFF
--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -8,6 +8,7 @@
 #include "code/items/storage/closets.dm"
 #include "code/jobs/warden.dm"
 #include "code/loot/pools.dm"
+#include "code/loot/megafauna.dm"
 #include "code/mobs/aliens/larva.dm"
 #include "code/species/machine.dm"
 #include "code/species/skrell.dm"

--- a/modular_ss220/balance/code/loot/megafauna.dm
+++ b/modular_ss220/balance/code/loot/megafauna.dm
@@ -1,0 +1,51 @@
+/mob/living/simple_animal/hostile/megafauna/drop_loot()
+	if(enraged || prob(75))
+		return ..()
+	new /obj/structure/closet/crate/necropolis/tendril(loc)
+
+/mob/living/simple_animal/hostile/megafauna/ancient_robot/drop_loot()
+	if(enraged || prob(75))
+		return ..()
+	new /obj/structure/closet/crate/necropolis/tendril(loc)
+
+/mob/living/simple_animal/hostile/megafauna/bubblegum/drop_loot()
+	if(!enraged)
+		return ..()
+	var/crate_type = pick(loot)
+	var/obj/structure/closet/crate/C = new crate_type(loc)
+	new /obj/item/melee/spellblade/random(C)
+
+/obj/structure/closet/crate/necropolis/bubblegum/populate_contents()
+	new /obj/item/clothing/suit/space/hostile_environment(src)
+	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
+
+/obj/item/melee/spellblade/random
+	name = "decrepit spellblade"
+
+/obj/item/melee/spellblade/random/attack__legacy__attackchain(mob/living/target, mob/living/user, def_zone)
+	if(is_mining_level(user.z) || istype(get_area(user), /area/ruin/space/bubblegum_arena) || user.health <= 0)
+		return ..()
+
+	var/extra_force
+	var/extra_power
+	if(user.health >= 80)
+		extra_force = force/2
+		force -= extra_force
+		extra_power = power/2
+		power -= extra_power
+		. = ..()
+		force += extra_force
+		power += extra_power
+		return
+
+	extra_force = force/2 - force/2 * (80 - user.health) / 80
+	extra_power = power/2 - power/2 * (80 - user.health) / 80
+	force -= extra_force
+	power -= extra_power
+	. = ..()
+	force += extra_force
+	power += extra_power
+
+/obj/item/melee/spellblade/random/afterattack__legacy__attackchain(atom/target, mob/living/user, proximity, params)
+	if(is_mining_level(user.z) || istype(get_area(user), /area/ruin/space/bubblegum_arena) || user.health < 80 || iswizard(user))
+		return ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Пародирует прайму, делая шанс на выпадение лута с мегафауны не 100, а 75. При неудаче появится сундук с сокровищами Некрополя (как от тендрила).
Все хардмод версии фауны имеют 100% шанс на выпадение лута. 

Переносит спеллблейд в лут хардмод Бубльгума.
Вне Лаваленда спеллблейд с Бубльгума отныне имеет до 50% снижения урона в секторе станции, а также его активная способность не будет работать до тех пор, пока владелец не окажется в критическом состоянии/магом/будет иметь менее 80 здоровья. Сила спеллблейда Бубльгума тем выше, чем ниже здоровье владельца.

Активная способность спеллблейда Бубльгума работает даже на 100% здоровья, если владелец маг. Но урон всё ещё пропорционален здоровью.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Если игрок хочет стопроцентно получить заслуженную награду, то пусть накопает руды станции и сразится с усиленной версией, а иначе - rng.
Нёрф спеллблейда, имхо, заслуженный. Пришла пора поставить новые условия в спидране Бубльгума, чтобы его больше не убивали на 5 минуте раунда ради лучшего меча и брони, доступных обычному экипажу. Куча предметов Лаваленда теряют свою эффективность на станции (посохи, модсьюты, КА, крашер, ядра и т.д.) хотя бы частично. Вот и спеллблейд потеряет свою эффективность до тех пор, пока его владелец остаётся невредим. Подобно Бубльгуму, чем ниже уровень здоровья владельца меча, тем сильнее он становится (рейдж фаза Бубльгума тем дольше, чем ниже его здоровье). Находясь в критическом состоянии включается вторая фаза шахтёра и спеллблейд получает полную мощь даже в секторе станции, равно как и у мегафауны Лаваленда - после потери 50% хп, те получают новые приёмы, становятся сильнее.

Ограничение на использование способности в <80 хп создано для того, чтобы игрок не мог вечно бегать под 300 юнитами глюкозы вырезая всё и вся. Если ты не ранен, то и заклинание не будет работать, а урон меча составит 12.5 единиц.

Раз уж мы отказались от софткрита, то давайте пользоваться преимуществами 200хп кукол по полной! =)

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Много тестил, так как забыл про конфиг прайма. Жалею о потраченном времени.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Мегафауна Лаваленда теперь имеет шанс в 75% выдать привычный лут и 25% выдать сундук Некрополя. Хардмод мегафауна имеет шанс в 100% на выдачу привычного лута.
tweak: Спеллблейд перенесён в хардмод версию Бубльгума.
tweak: Спеллблейд Бубльгума вне Лаваленда теперь слабее, но становится сильнее по мере того, как его владелец получает урон.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
