### PR TITLE
Give Engineering Robots an ATMOS Holofan

### DIFF
--- a/modular_ss220/silicons/code/robot_modules.dm
+++ b/modular_ss220/silicons/code/robot_modules.dm
@@ -13,6 +13,7 @@
 		/obj/item/inflatable/cyborg,
 		/obj/item/inflatable/cyborg/door,
 		/obj/item/gps/cyborg,
+		/obj/item/holosign_creator/atmos,
 		)
 
 /obj/item/robot_module/medical/Initialize(mapload)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавляет в инвентарь инженерных боргов ATMOS-голофан.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Без голофана функционал боргов представляется урезанным. Стены и двери из PR #499 всё ещё будут использоваться, поскольку их пополнение легче и дешевле пополнения РЦД.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
![image](https://github.com/user-attachments/assets/e8167823-1c0b-43e1-af2f-5c25c32cd405)

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Запустил локалку, проверил что голофан есть и работает.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: После долгих консультаций с ИИ на ЦК, стажёр-робототехник нашёл ATMOS-голофан и примотал его синей изолентой к инженерным боргам.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
