### PR TITLE
Ignore stealth mode when counting active staff

### DIFF
--- a/code/modules/admin/misc_admin_procs.dm
+++ b/code/modules/admin/misc_admin_procs.dm
@@ -1007,9 +1007,11 @@ GLOBAL_VAR_INIT(gamma_ship_location, 1) // 0 = station , 1 = space
 		if(rank_mask && !check_rights_for(X, rank_mask))
 			result[2]++
 			continue
-		if(X.holder.fakekey)
-			result[2]++
-			continue
+		// SS220 EDIT START - ignore stealth mode when counting active staff
+		// if(X.holder.fakekey)
+		// 	result[2]++
+		// 	continue
+		// SS220 EDIT END
 		if(X.is_afk())
 			result[3]++
 			continue


### PR DESCRIPTION
## Что этот PR делает
Подсчет активных админов теперь включает админов в режиме стелса.

## Почему это хорошо для игры
Запрос администрации. Сообщение с пингом больше не будет отправляться в дискорд, если администрация на сервере на самом деле есть.

## Тестирование
Вышел в режим стелса, написал тикет - счетчик активных админов показал 1.

## Обзор от Sourcery

Исправления ошибок:
- Исправлена ошибка, из-за которой администраторы в режиме невидимости не учитывались как активные, что препятствовало отправке сообщения оповещения в Discord, когда администраторы фактически присутствовали на сервере.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where admins in stealth mode were not counted as active, preventing the alert message from being sent to Discord when admins were actually present on the server.

</details>