### PR TITLE
Update dynamic rulesets with ss220 protected roles

### DIFF
--- a/modular_ss220/jobs/code/jobs_gamemodes.dm
+++ b/modular_ss220/jobs/code/jobs_gamemodes.dm
@@ -1,44 +1,48 @@
 /datum/game_mode/changeling/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/game_mode/cult/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/game_mode/revolution/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/game_mode/traitor/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/game_mode/trifecta/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/game_mode/traitor/vampire/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/game_mode/vampire/pre_setup()
 	protected_jobs |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
+
+/datum/ruleset/roundstart_pre_setup()
+	protected_jobs |= GLOB.restricted_jobs_ss220
+	return ..()
 
 // antag mix scenarious
 /datum/antag_scenario/traitor/New()
 	protected_roles |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/antag_scenario/changeling/New()
 	protected_roles |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/antag_scenario/vampire/New()
 	protected_roles |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()
 
 /datum/antag_scenario/team/blood_brothers/New()
 	protected_roles |= GLOB.restricted_jobs_ss220
-	. = ..()
+	return ..()


### PR DESCRIPTION
## Что этот PR делает
Убирает донат и сб роли из сценариев парадизовского динамика.

## Почему это хорошо для игры
СБ не антаг.

## Тестирование
Нет.

## Changelog

:cl: Maxiemar
fix: СБ больше не становится антагонистом в режиме игры dynamic.
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Предотвращает превращение сотрудников службы безопасности в антагонистов в динамических игровых режимах.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevents Security Officers from becoming antagonists in dynamic game modes.

</details>