### PR TITLE
Adds nuclear disk as exeption for harddel

### DIFF
--- a/code/controllers/subsystem/SSgarbage.dm
+++ b/code/controllers/subsystem/SSgarbage.dm
@@ -26,7 +26,7 @@ SUBSYSTEM_DEF(garbage)
 
 	//Queue
 	var/list/queues
-	var/static/list/types_to_HARD_DELETE = list(/client, /obj/item/disk/nuclear) // SS220 EDIT - disable hard del (performance tweak)
+	var/static/list/hard_del_enjoyers = list(/client, /obj/item/disk/nuclear) // SS220 EDIT - disable hard del (performance tweak)
 
 	#ifdef REFERENCE_TRACKING
 	var/list/reference_find_on_fail = list()
@@ -256,7 +256,7 @@ SUBSYSTEM_DEF(garbage)
 #ifdef GAME_TESTS
 	del(D)
 #else
-	if(is_type_in_list(D, types_to_HARD_DELETE))
+	if(is_type_in_list(D, hard_del_enjoyers))
 		del(D)
 #endif
 	// SS220 EDIT END


### PR DESCRIPTION
## Что этот PR делает
Добавляет ядерный диск в исключения, чтобы его можно было удалить. 

## Почему это хорошо для игры

Пинпоинтер будет работать, после удаления диска.

## Тестирование

Пинпоинтер работает корректно, диск удалился. 

## Changelog

:cl:
fix: Пинпоинтер снова корректно отслеживает диск, если тот был перемещён при попытке перехода на другой z-уровень.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Этот pull request исправляет проблему, из-за которой целеуказатель (pinpointer) некорректно отслеживал ядерный диск после его перемещения, позволяя корректно удалять ядерный диск.

Исправления ошибок:
- Исправлена проблема, из-за которой целеуказатель (pinpointer) некорректно отслеживал ядерный диск после его перемещения.

Улучшения:
- Обеспечена возможность корректного удаления ядерного диска.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request fixes an issue where the pinpointer would not correctly track the nuclear disk after it was moved, by allowing the nuclear disk to be properly deleted.

Bug Fixes:
- Fixes an issue where the pinpointer would not correctly track the nuclear disk after it was moved.

Enhancements:
- Allows the nuclear disk to be properly deleted.

</details>