### PR TITLE
Fix bubblegum crate spawner

### DIFF
--- a/modular_ss220/balance/code/loot/megafauna.dm
+++ b/modular_ss220/balance/code/loot/megafauna.dm
@@ -16,15 +16,22 @@
 		new /obj/structure/closet/crate/necropolis/tendril(loc)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/drop_loot()
-	if(!enraged)
-		return ..()
-	var/crate_type = pick(loot)
-	var/obj/structure/closet/crate/C = new crate_type(loc)
-	new /obj/item/melee/spellblade/random(C)
+	if(enraged)
+		loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged)
+		crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher)
+	return ..()
 
 /obj/structure/closet/crate/necropolis/bubblegum/populate_contents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
 	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
+
+/obj/structure/closet/crate/necropolis/bubblegum/enraged/populate_contents()
+	. = ..()
+	new /obj/item/melee/spellblade/random(src)
+
+/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher/populate_contents()
+	. = ..()
+	new /obj/item/crusher_trophy/demon_claws(src)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination
 	loot_chance = 100


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

фиксит отсутствие места для спавна ящика, ну или его спавн в нулевом пространстве, что-то из этого, я так и не понял.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

фикс

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

вызвал проки drop_loot на локалке, дюпа лута нет, лут корректный, но не могу нормально затестить из-за рантаймов от статус эффектов хардмод бубльгума.

![image](https://github.com/user-attachments/assets/373ca2c4-b4a0-4dc3-b39b-e3dcefc3f41e)


<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Хардмод Бубльгум теперь корректно спавнит свой ящик.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
