### PR TITLE
Another bubblegum fix

### DIFF
--- a/modular_ss220/balance/code/loot/megafauna.dm
+++ b/modular_ss220/balance/code/loot/megafauna.dm
@@ -15,11 +15,9 @@
 	if(length(loot))
 		new /obj/structure/closet/crate/necropolis/tendril(loc)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/drop_loot()
-	if(enraged)
-		loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged)
-		crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher)
-	return ..()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/round_2
+	loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged)
+	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher)
 
 /obj/structure/closet/crate/necropolis/bubblegum/populate_contents()
 	new /obj/item/clothing/suit/space/hostile_environment(src)
@@ -28,6 +26,9 @@
 /obj/structure/closet/crate/necropolis/bubblegum/enraged/populate_contents()
 	. = ..()
 	new /obj/item/melee/spellblade/random(src)
+
+/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher
+	name = "bloody bubblegum chest"
 
 /obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher/populate_contents()
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

опять фиксит выдачу двух лишних ящиков бубльгума, в этот раз без прока с `return ..()`, ошибок не повторяю.
финальный фикс, честно

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

меньше щиткода

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

ну раз уж мне подсказали как не страдать от рантаймов, то да, затестил. со старым кодом и правда 3 ящика в итоге было, два из которых полных, один обманный. теперь ящик один, всё хорошо.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->