### PR TITLE
Remove hidden safes from modular ruins

### DIFF
--- a/_maps/map_files220/RandomRuins/LavaRuins/old_outpost.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/old_outpost.dmm
@@ -44,7 +44,7 @@
 /turf/simulated/floor/plating/lavaland_air,
 /area/ruin/unpowered/misc_lavaruin)
 "cd" = (
-/obj/machinery/suit_storage_unit/lavaland,
+/obj/machinery/suit_storage_unit/lavaland/ruin,
 /obj/effect/mapping_helpers/machinery/damaged,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "brown";
@@ -62,7 +62,7 @@
 /turf/simulated/floor/plasteel/lavaland_air,
 /area/ruin/unpowered/misc_lavaruin)
 "dA" = (
-/obj/machinery/suit_storage_unit/lavaland,
+/obj/machinery/suit_storage_unit/lavaland/ruin,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "brown";
@@ -315,9 +315,8 @@
 /obj/item/reagent_containers/drinks/bottle/absinthe/premium,
 /obj/item/clothing/mask/cigarette/cigar,
 /obj/item/clothing/mask/cigarette/cigar,
-/turf/simulated/floor/plasteel/lavaland_air{
-	icon_state = "cautionfull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating/lavaland_air,
 /area/ruin/unpowered/misc_lavaruin)
 "qP" = (
 /obj/item/shard{
@@ -623,7 +622,7 @@
 	},
 /area/ruin/unpowered/misc_lavaruin)
 "IC" = (
-/obj/machinery/suit_storage_unit/lavaland,
+/obj/machinery/suit_storage_unit/lavaland/ruin,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "brown";

--- a/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -1010,9 +1010,6 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/structure/safe/floor,
-/obj/item/flash,
-/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
 /turf/simulated/floor/greengrid,
 /area/ruin/space/spacehotelv1/reception)
 "ix" = (
@@ -1076,9 +1073,11 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/spacehotelv1/kitchen)
 "jc" = (
-/obj/structure/closet,
+/obj/structure/safe,
 /obj/item/clothing/under/costume/maid,
 /obj/item/clothing/under/rank/civilian/barber,
+/obj/effect/spawner/random/pool/spaceloot/syndicate/mixed,
+/obj/item/flash,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/spacehotelv1/reception)
 "jd" = (
@@ -6464,10 +6463,6 @@
 /obj/item/folder/red{
 	pixel_x = 10;
 	pixel_y = 6
-	},
-/obj/item/t_scanner{
-	pixel_x = -10;
-	pixel_y = 2
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/spacehotelv1/reception)

--- a/modular_ss220/objects/_objects.dme
+++ b/modular_ss220/objects/_objects.dme
@@ -35,6 +35,7 @@
 #include "code/closets.dm"
 #include "code/coffin.dm"
 #include "code/computer.dm"
+#include "code/gps.dm"
 #include "code/mattress.dm"
 #include "code/miscellaneous.dm"
 #include "code/officetoys.dm"

--- a/modular_ss220/objects/code/gps.dm
+++ b/modular_ss220/objects/code/gps.dm
@@ -1,0 +1,2 @@
+/obj/item/gps/mining/ruin
+	tracking = FALSE

--- a/modular_ss220/objects/code/suit_storage_unit.dm
+++ b/modular_ss220/objects/code/suit_storage_unit.dm
@@ -4,3 +4,6 @@
 
 /obj/machinery/suit_storage_unit/security/space/safeguard
 	suit_type = /obj/item/mod/control/pre_equipped/safeguard
+
+/obj/machinery/suit_storage_unit/lavaland/ruin
+	storage_type = /obj/item/gps/mining/ruin


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Заменяет скрытые под плиткой пола сейфы на более видные, которые можно обнаружить не залезая в исходный код билда.

Выключает GPS в руине заброшенного аванпоста, чтобы его было не так легко найти по мете.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Игроки должны находить сейфы не после изучения каждой руины через код, а по ходу осмотра самой руины. На подобные сейфы должны быть хоть малейшие намёки, от кинутого рядом тирея с ломиком, вплоть до целой серии записок приводящих к сейфу (как в СССП).

Затронул лишь две руины, космо отель и заброшенный аванпост. Один сейф под полом есть ещё в руине Сьерры в космосе, но там есть все намёки на него.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

Диффбот крутая вещь!

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Зашёл на локалку, проверил, что сейфы видны и GPS в руине выключен.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

NPFC, пусть сами посетят руину и заметят сейф по ходу изучения.

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
