### PR TITLE
Fix 3 cameras around AI core on Cyberiad

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -64941,7 +64941,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "AI Satellite Exterior South";
+	c_tag = "AI Core North";
 	network = list("SS13","MiniSat")
 	},
 /turf/simulated/floor/plasteel{
@@ -70146,7 +70146,7 @@
 /area/station/security/permabrig)
 "nFg" = (
 /obj/machinery/camera{
-	c_tag = "Mini Satellite Teleporter";
+	c_tag = "AI Core South";
 	dir = 1;
 	network = list("SS13","MiniSat")
 	},
@@ -90401,7 +90401,7 @@
 	pixel_x = 9
 	},
 /obj/machinery/camera{
-	c_tag = "AI Satellite Exterior South";
+	c_tag = "AI Core";
 	network = list("SS13","MiniSat")
 	},
 /obj/machinery/turretid/lethal{


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Задаёт уникальные `c_tag` трём камерам в районе ядра ИИ, позволяя тем появиться на консолях камер СБ (и им подобным).

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Bugfix.

Они всегда были рабочими, но полгода назад, после какого-то мержа апстрима, забыли поменять их теги и всё сломалось - было несколько камер с одинаковыми `c_tag` и в консоль для камер добавлялась лишь последняя с подобным тегом, остальные не учитывались.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

![image](https://github.com/user-attachments/assets/d421db3f-13cd-412a-b001-ef2c8f12bb08)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Три камеры вокруг ядра ИИ на Кибериаде вновь можно просматривать с консоли камер СБ.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
