### PR TITLE
[DNM] [TM] No need to heal inactive players' bodies

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1767,7 +1767,7 @@
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)
 	for(var/mob/dead/observer/G in GLOB.dead_mob_list)
-		if(G.mind == src && G.mind.key == G.key && G.client)
+		if(G.mind == src && G.mind.key == G.key && (G in GLOB.player_list))
 			if(G.can_reenter_corpse || even_if_they_cant_reenter)
 				return G
 			break

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1767,10 +1767,15 @@
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)
 	for(var/mob/dead/observer/G in GLOB.dead_mob_list)
-		if(G.mind == src && G.mind.key == G.key && (G in GLOB.player_list))
+		if(G.mind == src && G.mind.key == G.key)
 			if(G.can_reenter_corpse || even_if_they_cant_reenter)
 				return G
 			break
+
+/datum/mind/proc/check_ghost_client()
+	var/mob/dead/observer/G = get_ghost()
+	if(G.client)
+		return TRUE
 
 /datum/mind/proc/grab_ghost(force)
 	var/mob/dead/observer/G = get_ghost(even_if_they_cant_reenter = force)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1767,7 +1767,7 @@
 
 /datum/mind/proc/get_ghost(even_if_they_cant_reenter)
 	for(var/mob/dead/observer/G in GLOB.dead_mob_list)
-		if(G.mind == src && G.mind.key == G.key)
+		if(G.mind == src && G.mind.key == G.key && G.client)
 			if(G.can_reenter_corpse || even_if_they_cant_reenter)
 				return G
 			break

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -209,10 +209,10 @@
 			revivable_state = "dead"
 		else if(ismachineperson(src) || (timeofdeath && is_revivable()))
 			revivable_state = "flatline"
-		else if(!mind)
-			revivable_state = "dead"
 		else if(get_ghost() || key)
 			revivable_state = "hassoul"
+		else if(!mind)
+			revivable_state = "dead"
 
 		holder.icon_state = "hud[revivable_state]"
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -205,12 +205,11 @@
 	// To the right of health bar
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/revivable_state = "dead"
-		if(!ghost_can_reenter()) // DNR or AntagHUD
-			revivable_state = "dead"
-		else if(ismachineperson(src) || (timeofdeath && is_revivable()))
-			revivable_state = "flatline"
-		else if(get_ghost() || key || mind)
-			revivable_state = "hassoul"
+		if(ghost_can_reenter()) // Not DNR or AntagHUD
+			if((ismachineperson(src) && get_ghost()) || (timeofdeath && is_revivable()))
+				revivable_state = "flatline"
+			else if(ismachineperson(src) || get_ghost()  || key)
+				revivable_state = "hassoul"
 
 		holder.icon_state = "hud[revivable_state]"
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -209,10 +209,8 @@
 			revivable_state = "dead"
 		else if(ismachineperson(src) || (timeofdeath && is_revivable()))
 			revivable_state = "flatline"
-		else if(get_ghost() || key)
+		else if(get_ghost() || key || mind)
 			revivable_state = "hassoul"
-		else if(!mind)
-			revivable_state = "dead"
 
 		holder.icon_state = "hud[revivable_state]"
 

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -206,9 +206,9 @@
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/revivable_state = "dead"
 		if(ghost_can_reenter()) // Not DNR or AntagHUD
-			if((ismachineperson(src) && get_ghost()) || (timeofdeath && is_revivable()))
+			if((ismachineperson(src)) && check_ghost_client() || (timeofdeath && is_revivable()))
 				revivable_state = "flatline"
-			else if(ismachineperson(src) || get_ghost()  || key)
+			else if(get_ghost() || key)
 				revivable_state = "hassoul"
 
 		holder.icon_state = "hud[revivable_state]"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -206,7 +206,7 @@
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/revivable_state = "dead"
 		if(ghost_can_reenter()) // Not DNR or AntagHUD
-			if((ismachineperson(src)) && check_ghost_client() || (timeofdeath && is_revivable()))
+			if((ismachineperson(src) && check_ghost_client()) || (!ismachineperson(src) && timeofdeath && is_revivable()))
 				revivable_state = "flatline"
 			else if(get_ghost() || key)
 				revivable_state = "hassoul"

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -206,7 +206,7 @@
 	if(stat == DEAD || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		var/revivable_state = "dead"
 		if(ghost_can_reenter()) // Not DNR or AntagHUD
-			if((ismachineperson(src) && check_ghost_client()) || (!ismachineperson(src) && timeofdeath && is_revivable()))
+			if((ismachineperson(src) && client) || (!ismachineperson(src) && timeofdeath && is_revivable()))
 				revivable_state = "flatline"
 			else if(get_ghost() || key)
 				revivable_state = "hassoul"

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -252,9 +252,11 @@
 		if(suiciding)
 			msg += "<span class='warning'>[p_they(TRUE)] appear[p_s()] to have committed suicide... there is no hope of recovery.</span>\n"
 		if(!just_sleeping)
-			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive; there are no signs of life"
+			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive"
 			if(get_int_organ(/obj/item/organ/internal/brain) && !key)
 				if(!check_ghost_client())
+					msg += "; there are no signs of life"
+				if(!get_ghost())
 					msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"
 

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -254,7 +254,7 @@
 		if(!just_sleeping)
 			msg += "<span class='deadsay'>[p_they(TRUE)] [p_are()] limp and unresponsive; there are no signs of life"
 			if(get_int_organ(/obj/item/organ/internal/brain) && !key)
-				if(!get_ghost())
+				if(!check_ghost_client())
 					msg += " and [p_their()] soul has departed"
 			msg += "...</span>\n"
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1092,6 +1092,10 @@ GLOBAL_LIST_INIT(slot_equipment_priority, list( \
 	if(mind)
 		return mind.get_ghost(even_if_they_cant_reenter)
 
+/mob/proc/check_ghost_client()
+	if(mind)
+		return mind.check_ghost_client()
+
 /mob/proc/grab_ghost(force)
 	if(mind)
 		return mind.grab_ghost(force = force)

--- a/code/modules/surgery/organs/brain.dm
+++ b/code/modules/surgery/organs/brain.dm
@@ -61,7 +61,7 @@
 		. += "You can feel a bright spark of life in this one!"
 		return
 	if(brainmob?.mind)
-		if(brainmob.get_ghost())
+		if(brainmob.check_ghost_client())
 			. += "You can feel the small spark of life still left in this one."
 			return
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет условие при осмотре тела, мозга и подобных действий, что игрок должен быть в сети, иначе его покажет как "неактивного".

Мозг вышедшего с сервера будет показан как
> This one seems particularly lifeless. Perhaps it will regain some of its luster later..

А его тело
> He is limp and unresponsive; there are no signs of life and his soul has departed...

При этом на иконки медхуда это не повлияет (черепок или серая линия), то есть медики спокойно отличат игрока с ДНР или сменой тела (заролял мидраунд антажку и отцепился от изначального тела) от игрока, который просто вышел с сервера.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Рефактор кода осмотра тела произошёл осенью, и раньше он работал именно так - если игрок не в сети, то его показывало как "без души" и медикам не приходилось его лечить. Теперь приходится, ведь клиент не учитывается.

Медикам не придётся тратить время на тех, кто давно покинул сервер и играть не собирается.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Ну локалка запустилась, вроде ничего не сломал, но в одного тестировать подобное не очень удобно. Надеюсь на ТМ, потом на апстрим закину, если всё работает как надо.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Тела без активности мозга вновь помечаются соответственно, больше не придётся тратить время на лечение кататоников.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Исправления ошибок:
- Исправлена ошибка, из-за которой медицинский персонал тратил время на лечение тел отключенных игроков.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where medical staff would waste time healing bodies of disconnected players.

</details>