### PR TITLE
Увеличение кол-ва интеркомов на картах

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -832,10 +832,10 @@
 	},
 /obj/item/radio/intercom/custom{
 	dir = 8;
-	pixel_x = 36
+	pixel_x = 37
 	},
 /obj/item/radio/intercom/department/security{
-	pixel_x = 22;
+	pixel_x = 24;
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -3193,12 +3193,12 @@
 /obj/item/pen,
 /obj/machinery/requests_console/directional/south,
 /obj/item/radio/intercom/department/security{
-	pixel_x = -22;
+	pixel_x = -24;
 	dir = 4
 	},
 /obj/item/radio/intercom/custom{
 	dir = 4;
-	pixel_x = -36
+	pixel_x = -37
 	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -3780,7 +3780,7 @@
 /area/station/security/brig)
 "arC" = (
 /obj/item/radio/intercom/department/security{
-	pixel_y = 22
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -5470,10 +5470,10 @@
 "axQ" = (
 /obj/item/radio/intercom/custom{
 	dir = 1;
-	pixel_y = -36
+	pixel_y = -37
 	},
 /obj/item/radio/intercom/department/security{
-	pixel_y = -22;
+	pixel_y = -24;
 	dir = 1
 	},
 /obj/structure/table,
@@ -35365,6 +35365,7 @@
 	c_tag = "Engineering Lobby West";
 	network = list("SS13","Engineering")
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -48366,6 +48367,7 @@
 	c_tag = "Engineering Lobby East";
 	network = list("SS13","Engineering")
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -53887,7 +53889,7 @@
 	},
 /obj/item/radio/intercom/locked/prison{
 	name = "Prison Intercom (General)";
-	pixel_y = 22
+	pixel_y = 28
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -55468,7 +55470,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/item/radio/intercom/locked/prison{
 	name = "Prison Intercom (General)";
-	pixel_y = 24
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -58260,10 +58262,10 @@
 /area/station/security/prisonershuttle)
 "jeS" = (
 /obj/item/radio/intercom/department/security{
-	pixel_y = 22
+	pixel_y = 24
 	},
 /obj/item/radio/intercom/custom{
-	pixel_y = 36
+	pixel_y = 37
 	},
 /obj/structure/filingcabinet/security,
 /obj/machinery/light/small/directional/north,
@@ -80702,9 +80704,11 @@
 /obj/structure/filingcabinet,
 /obj/item/radio/intercom/private{
 	dir = 4;
-	pixel_x = -36
+	pixel_x = -37
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/item/radio/intercom/directional/west{
+	pixel_x = -24
+	},
 /turf/simulated/floor/carpet/royalblue,
 /area/station/command/office/captain)
 "ryo" = (
@@ -81544,7 +81548,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/locked/prison{
 	name = "Prison Intercom (General)";
-	pixel_y = 24
+	pixel_y = 28
 	},
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel{
@@ -94419,7 +94423,7 @@
 /obj/item/radio/intercom/locked/prison{
 	dir = 4;
 	name = "Prison Intercom (General)";
-	pixel_x = -22
+	pixel_x = -28
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -2510,6 +2510,7 @@
 /obj/item/reagent_containers/spray/pepper{
 	pixel_x = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -20159,6 +20160,7 @@
 /turf/simulated/floor/plating,
 /area/station/supply/sorting)
 "bDW" = (
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "blue"
@@ -21468,13 +21470,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "bJr" = (
-/obj/machinery/computer/guestpass{
-	pixel_y = 30
-	},
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/machinery/button/windowtint/west{
 	id = "rnd"
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "purple"
@@ -24477,6 +24477,7 @@
 /area/station/medical/sleeper)
 "bXP" = (
 /obj/machinery/door/firedoor,
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "whiteblue"
 	},
@@ -27505,6 +27506,7 @@
 	c_tag = "Medbay Hallway Center";
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -42320,6 +42322,13 @@
 	icon_state = "vault"
 	},
 /area/station/command/office/ce)
+"dqc" = (
+/obj/item/radio/intercom/directional/south,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/starboard/east)
 "dqk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -42739,6 +42748,7 @@
 "dsy" = (
 /obj/item/flag/sec,
 /obj/machinery/light_switch/south,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -43878,6 +43888,18 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/sleeper)
+"dJJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/medbay2)
 "dJW" = (
 /obj/machinery/atmospherics/unary/vent_pump/siphon/on{
 	autolink_id = "n2_out";
@@ -46477,6 +46499,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkblue"
 	},
@@ -50110,6 +50133,7 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -53104,9 +53128,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "hcb" = (
-/obj/item/radio/intercom,
-/turf/simulated/wall,
-/area/station/engineering/atmos)
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/station/hallway/primary/central/nw)
 "hcy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -57650,6 +57677,7 @@
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
 "iRV" = (
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "blue"
@@ -71970,6 +71998,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -72540,6 +72569,9 @@
 "oyO" = (
 /obj/item/stack/package_wrap,
 /obj/structure/table/glass,
+/obj/machinery/computer/guestpass{
+	pixel_y = 30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -80556,8 +80588,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"rvX" = (
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central/se)
 "rwb" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "yellow"
@@ -81942,6 +81982,13 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/engineering/ai_transit_tube)
+"rZA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port)
 "rZF" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -88215,6 +88262,13 @@
 	icon_state = "whitegreenfull"
 	},
 /area/station/medical/virology)
+"uqv" = (
+/obj/item/radio/intercom/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "uqy" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -93076,6 +93130,15 @@
 	icon_state = "darkpurple"
 	},
 /area/station/science/genetics)
+"wfP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitepurplecorner"
+	},
+/area/station/science/hallway)
 "wgs" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -95310,6 +95373,16 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"wZY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "wZZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -108310,7 +108383,7 @@ aaa
 aaa
 aaa
 aLd
-gGY
+uqv
 aMB
 aSd
 aSd
@@ -114205,7 +114278,7 @@ blV
 blV
 bls
 fMG
-fMG
+wZY
 bnu
 boW
 tde
@@ -119087,7 +119160,7 @@ aab
 beL
 bgA
 vJv
-oll
+rZA
 blQ
 cFP
 bnK
@@ -123463,7 +123536,7 @@ cdX
 bun
 bun
 gzl
-bun
+hcb
 bxi
 urU
 bzM
@@ -126629,7 +126702,7 @@ isi
 oWM
 osz
 ooa
-hcb
+nVh
 gCX
 cSd
 uCC
@@ -131696,7 +131769,7 @@ bCY
 bEw
 bFU
 nis
-bFU
+rvX
 bOz
 bFO
 bTG
@@ -134021,7 +134094,7 @@ caA
 cbv
 dZB
 bXP
-bXD
+caA
 caP
 bXD
 bQV
@@ -137619,7 +137692,7 @@ caA
 cbU
 dZB
 bXP
-bXD
+caA
 caP
 bXD
 ylO
@@ -138152,7 +138225,7 @@ dXp
 hYs
 cCR
 oiA
-avO
+dJJ
 bYv
 lHM
 bXI
@@ -141715,7 +141788,7 @@ bwv
 bwv
 bwv
 eiU
-cXh
+dqc
 bte
 cuQ
 djr
@@ -146872,7 +146945,7 @@ awK
 ctI
 wci
 keJ
-ggx
+wfP
 spl
 cgq
 ufq
@@ -146896,7 +146969,7 @@ ggx
 hug
 spl
 spl
-spl
+fTR
 rKV
 yku
 mCV

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -32096,6 +32096,7 @@
 	dir = 6;
 	network = list("SS13","RD")
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -33736,10 +33737,6 @@
 /area/station/science/robotics)
 "cIO" = (
 /obj/machinery/economy/vending/scidrobe,
-/obj/item/radio/intercom{
-	name = "south bump";
-	pixel_y = -28
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -28841,12 +28841,12 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/hop)
 "cnp" = (
-/obj/item/radio/intercom/directional/west,
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/primary/central/sw)
+/area/station/hallway/primary/port)
 "cnt" = (
 /obj/item/kirbyplants/large,
 /obj/machinery/light_switch/south,
@@ -68127,6 +68127,7 @@
 /area/station/maintenance/starboard2)
 "krc" = (
 /obj/machinery/optable,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -74625,6 +74626,7 @@
 	c_tag = "Central Ring Hallway West";
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -141811,7 +141813,7 @@ bOC
 bOC
 bSy
 oAE
-bWH
+cnp
 bYj
 bYj
 bYj
@@ -144394,7 +144396,7 @@ oUR
 oUR
 coE
 bwm
-cnp
+bwm
 bwm
 bwm
 muZ

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -558,7 +558,6 @@
 /area/shuttle/pod_4)
 "aff" = (
 /obj/structure/closet/emcloset,
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -7606,6 +7605,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_female)
 "aHR" = (
@@ -9941,6 +9941,7 @@
 /obj/machinery/camera{
 	c_tag = "Mining Access North"
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "brown"
@@ -9980,6 +9981,7 @@
 "aSb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "brown"
@@ -10139,6 +10141,7 @@
 	dir = 10;
 	initialize_directions = 10
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "aSM" = (
@@ -11172,6 +11175,7 @@
 /area/station/public/locker)
 "aXV" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "brown"
@@ -17189,6 +17193,7 @@
 	c_tag = "Cargo Dock SouthEast";
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "brown"
@@ -20910,6 +20915,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/tech_storage)
 "bKz" = (
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "arrival"
@@ -23462,12 +23468,10 @@
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
 "bSL" = (
-/obj/item/radio/intercom/private{
-	pixel_y = -28
-	},
 /obj/machinery/computer/borgupload{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
 "bSM" = (
@@ -32013,6 +32017,7 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -33774,6 +33779,7 @@
 /area/station/medical/reception)
 "cJl" = (
 /obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "green"
@@ -37662,6 +37668,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "purplecorner"
@@ -41004,6 +41011,7 @@
 	c_tag = "Research North Hallway";
 	network = list("Research","SS13")
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -41984,6 +41992,19 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/misc_lab)
+"due" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/bridge)
 "duf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -47322,6 +47343,13 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
+"dXg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/secondary/entry)
 "dXj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -50518,6 +50546,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/mechanic)
+"ePa" = (
+/obj/item/kirbyplants/large,
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/mineral/titanium/blue,
+/area/shuttle/arrival/station)
 "ePd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -55700,6 +55733,13 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/sleeper)
+"gzh" = (
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central/nw)
 "gzk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60011,6 +60051,7 @@
 /area/station/service/janitor)
 "hTj" = (
 /obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "green"
@@ -64904,6 +64945,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"jrS" = (
+/obj/item/radio/intercom/directional/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "red"
+	},
+/area/station/security/brig)
 "jrU" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -67084,6 +67131,13 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"kaA" = (
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "kaG" = (
 /obj/effect/turf_decal/siding/white,
 /turf/simulated/floor/plasteel/freezer,
@@ -75184,6 +75238,7 @@
 /area/station/maintenance/fore2)
 "mIc" = (
 /obj/item/flag/command,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "brown"
@@ -79827,6 +79882,7 @@
 /area/station/maintenance/starboard)
 "nYh" = (
 /obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "whitegreencorner"
@@ -83128,6 +83184,18 @@
 /obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/magistrate)
+"pbE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "pbQ" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/chair/sofa/pew/right{
@@ -84471,6 +84539,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_male)
 "pvZ" = (
@@ -86642,6 +86711,7 @@
 	c_tag = "Cargo Disposals Sorting";
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "brown"
@@ -89992,12 +90062,12 @@
 	},
 /area/station/engineering/atmos/control)
 "reW" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central/west)
 "rfd" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/interrogation/observation)
@@ -96370,6 +96440,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "tfF" = (
@@ -97618,6 +97689,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -102774,6 +102846,7 @@
 	},
 /obj/machinery/photocopier,
 /obj/machinery/newscaster/directional/north,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "red"
@@ -104531,6 +104604,14 @@
 	icon_state = "blue"
 	},
 /area/station/command/bridge/checkpoint/south)
+"vPw" = (
+/obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/fore)
 "vPO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -105423,6 +105504,7 @@
 	codes_txt = "patrol;next_patrol=hall9e";
 	location = "hall9d"
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutral"
 	},
@@ -138378,7 +138460,7 @@ bty
 byF
 bty
 bfE
-bty
+kaA
 bty
 bGO
 bWz
@@ -141662,7 +141744,7 @@ aeb
 aeb
 ltw
 aeb
-reW
+aeb
 amB
 amL
 ant
@@ -142694,7 +142776,7 @@ abj
 aaa
 acC
 ant
-anP
+pbE
 adb
 aor
 aoR
@@ -144295,7 +144377,7 @@ eDP
 eDP
 bDR
 bDR
-wdz
+gzh
 liZ
 xTh
 pzY
@@ -144304,7 +144386,7 @@ oUR
 gXY
 oUR
 mKB
-oUR
+reW
 oUR
 xVw
 oUR
@@ -148333,7 +148415,7 @@ agD
 agE
 agT
 ahC
-ahV
+ePa
 ail
 ail
 ail
@@ -148421,7 +148503,7 @@ chm
 iUV
 cku
 iyc
-iyc
+due
 iyc
 fIB
 fwX
@@ -148879,7 +148961,7 @@ bhO
 aWq
 bhO
 bhO
-bsi
+vPw
 nME
 phe
 bhO
@@ -151676,7 +151758,7 @@ acC
 aec
 akb
 aeb
-aeb
+dXg
 aeb
 aeb
 aeb
@@ -153561,7 +153643,7 @@ xwQ
 ciV
 xwQ
 xwQ
-xwQ
+iru
 aER
 eZo
 lDQ
@@ -163816,7 +163898,7 @@ osD
 hWM
 smr
 raT
-off
+jrS
 vBg
 lSQ
 bvh

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -3236,6 +3236,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "avI" = (
@@ -59112,6 +59113,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
+"mbS" = (
+/obj/item/radio/intercom/directional/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "mcd" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -67502,6 +67510,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "cautioncorner"
@@ -74057,9 +74066,6 @@
 /obj/item/kirbyplants/large/plant14,
 /obj/machinery/light_switch/west{
 	pixel_y = 6
-	},
-/obj/item/radio/intercom/directional/west{
-	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -124341,7 +124347,7 @@ iet
 fDS
 ftQ
 sSj
-qJz
+mbS
 qJz
 ims
 qQw
@@ -124598,7 +124604,7 @@ hSu
 kEv
 mDR
 vug
-hHE
+bCN
 hHE
 hHE
 bNg

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -2286,6 +2286,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/flag/mime,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -4211,7 +4212,7 @@
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "azC" = (
 /obj/item/radio/intercom/department/security{
-	pixel_y = 22
+	pixel_y = 28
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -5556,6 +5557,7 @@
 "aFZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "aGb" = (
@@ -7483,6 +7485,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "aMS" = (
@@ -11278,6 +11281,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "greenblue"
@@ -15651,16 +15655,13 @@
 /area/station/procedure/trainer_office)
 "bmR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/radio/intercom{
-	name = "east bump";
-	pixel_x = 28
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
 	},
 /obj/structure/janitorialcart,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "bmT" = (
@@ -15675,9 +15676,7 @@
 	pixel_y = -4
 	},
 /obj/item/camera,
-/obj/item/radio/intercom/private{
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
 "bmV" = (
@@ -17411,9 +17410,7 @@
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
 /obj/item/flash,
-/obj/item/radio/intercom/department/security{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "red"
@@ -18858,9 +18855,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/item/radio/intercom/private{
-	pixel_x = -28
-	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/wood,
 /area/station/command/office/captain)
 "bwn" = (
@@ -23312,6 +23307,7 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "arrival"
@@ -28437,7 +28433,7 @@
 "ceU" = (
 /obj/structure/chair,
 /obj/item/radio/intercom/locked/confessional{
-	pixel_x = -22;
+	pixel_x = -28;
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -31818,7 +31814,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/locked/confessional{
-	pixel_x = 22;
+	pixel_x = 28;
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -32162,7 +32158,7 @@
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/turbine)
 "ctw" = (
-/obj/machinery/light_switch/west,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -32729,6 +32725,7 @@
 /area/station/hallway/primary/aft)
 "cvJ" = (
 /obj/item/kirbyplants/large/alien/alien6,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgreycheck"
 	},
@@ -35514,6 +35511,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/geneticist,
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "white"
 	},
@@ -36784,6 +36782,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkblue"
@@ -42132,6 +42131,13 @@
 	icon_state = "white"
 	},
 /area/station/medical/medbay)
+"dMf" = (
+/obj/item/radio/intercom/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/station/security/permabrig)
 "dMK" = (
 /obj/machinery/atmospherics/binary/valve/open,
 /turf/simulated/floor/plating,
@@ -47243,13 +47249,10 @@
 	},
 /area/station/security/brig)
 "gmn" = (
-/obj/item/radio/intercom/locked/prison{
-	name = "Prison Intercom (General)";
-	pixel_y = 25
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "black"
@@ -52766,7 +52769,7 @@
 /area/station/engineering/controlroom)
 "iTG" = (
 /obj/item/radio/intercom/department/security{
-	pixel_y = -22;
+	pixel_y = -28;
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -54684,9 +54687,7 @@
 	req_access = list(74)
 	},
 /obj/item/clothing/head/helmet/skull/yorick,
-/obj/item/radio/intercom/department/security{
-	pixel_y = 22
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "jXo" = (
@@ -58296,6 +58297,7 @@
 "lHl" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "redcorner"
@@ -61108,9 +61110,7 @@
 /area/space/nearstation)
 "mZe" = (
 /obj/machinery/r_n_d/protolathe,
-/obj/machinery/computer/guestpass{
-	pixel_y = 30
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -62601,6 +62601,7 @@
 /area/station/engineering/break_room)
 "nIi" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},
@@ -63038,14 +63039,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "nVX" = (
-/obj/item/radio/intercom/directional/west,
-/obj/item/radio/intercom/department/security{
-	pixel_x = -34;
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "red"
@@ -63605,8 +63602,10 @@
 /turf/space,
 /area/space/nearstation)
 "onF" = (
-/obj/item/radio/intercom/directional/north,
 /obj/machinery/papershredder,
+/obj/machinery/computer/guestpass{
+	pixel_y = 30
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -69331,9 +69330,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
 "rpt" = (
-/obj/item/radio/intercom/directional/west,
+/obj/item/radio/intercom/directional/west{
+	pixel_x = -24
+	},
 /obj/item/radio/intercom/department/security{
-	pixel_x = -34;
+	pixel_x = -37;
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -69559,7 +69560,7 @@
 /area/station/science/storage)
 "ruH" = (
 /obj/item/radio/intercom/department/security{
-	pixel_x = 22;
+	pixel_x = 28;
 	dir = 8
 	},
 /obj/machinery/flasher/portable,
@@ -75601,15 +75602,12 @@
 	},
 /area/station/security/brig)
 "uGn" = (
-/obj/item/radio/intercom/locked/prison{
-	name = "Prison Intercom (General)";
-	pixel_x = -25
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "cautioncorner"
 	},
-/area/station/security/permabrig)
+/area/station/hallway/primary/starboard)
 "uGy" = (
 /obj/item/bodybag,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -77790,9 +77788,11 @@
 "vKy" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/officetoys,
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/directional/east{
+	pixel_x = 24
+	},
 /obj/item/radio/intercom/department/security{
-	pixel_x = 34;
+	pixel_x = 37;
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
@@ -80411,7 +80411,7 @@
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/locked/prison{
 	name = "Prison Intercom (General)";
-	pixel_y = 25
+	pixel_y = 28
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -103471,7 +103471,7 @@ smH
 udK
 udK
 udK
-mKI
+dMf
 iqe
 udK
 odW
@@ -103727,7 +103727,7 @@ rqq
 obJ
 oaX
 oaX
-uGn
+oaX
 fCF
 eyZ
 rLO
@@ -118427,7 +118427,7 @@ aaa
 aaa
 aaa
 blo
-bnr
+uGn
 hfi
 bqA
 blC


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавлено больше интеркомов на всех станциях, в места, которые непокрыты ими + в отдельных зонах, где их нет.
Визуально исправлено расположение интеркомов (повернуты не в ту сторону, выходят за край стены, наслоение друг на друга).
Интеркомы на стойке РНД приближены ближе к точке выхода для удобной коммуникации.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Добавляет больше точек связи игрокам на станции
Оптимизирует карту в связи с отключением общей волны
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
![изображение](https://github.com/user-attachments/assets/7a07e19d-d26e-4d05-9f4e-2e4576529dc0)
<img width="1895" alt="cera up" src="https://github.com/user-attachments/assets/0c16b77f-04dc-4997-8cc8-f9930848ac85" />
<img width="1910" alt="cera down'" src="https://github.com/user-attachments/assets/b906f436-1e17-47df-b4e6-d09d4da2f7e6" />
<img width="1916" alt="cyber up" src="https://github.com/user-attachments/assets/d2f539ed-d3a7-4152-9e91-a27c3265ceba" />
<img width="1910" alt="cyber down" src="https://github.com/user-attachments/assets/50ffc196-f9ef-4a11-a124-c30751cb4069" />

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Проверил запуск большинства интеркомов + места изменений позиций других приборов (терминал временных доступов, выключатель)
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: Добавлено больше интеркомов на всех станциях
tweak: Интеркомы в РНД перемещы ближе к стойке
fix: Поправлено "кривое" расположение интеркомов на станции
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Summary by Sourcery

Увеличьте количество интеркомов на всех станциях для улучшения покрытия связи и скорректируйте их размещение для лучшего визуального выравнивания.

Новые функции:
- Добавлено больше интеркомов на всех станциях для покрытия ранее неохваченных областей и конкретных зон, где их не хватало.

Улучшения:
- Скорректировано визуальное размещение интеркомов для исправления проблем с ориентацией и предотвращения наложения на стены.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase the number of intercoms on all stations to improve communication coverage and adjust their placement for better visual alignment.

New Features:
- Added more intercoms across all stations to cover previously uncovered areas and specific zones lacking them.

Enhancements:
- Adjusted the visual placement of intercoms to correct orientation issues and prevent overlap with walls.

</details>