### PR TITLE
[TM] Fix the atmos adjacent turfs search 

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -156,10 +156,9 @@ GLOBAL_LIST_INIT(diseases, subtypesof(/datum/disease))
 						C.ContractDisease(src)
 						break
 					var/direction = get_dir(current, target)
-					var/turf/next = get_step(current, direction)
-					if(!current.CanAtmosPass(direction) || !next.CanAtmosPass(turn(direction, 180)))
+					if(!current.CanAtmosPassBidirectional(direction))
 						break
-					current = next
+					current = get_step(current, direction)
 
 
 /datum/disease/proc/cure()

--- a/code/game/objects/effects/snowcloud.dm
+++ b/code/game/objects/effects/snowcloud.dm
@@ -104,7 +104,7 @@
 		playsound(loc, shovel.usesound, 50, TRUE)
 		if(do_after(user, 50 * shovel.toolspeed, target = src))
 			user.visible_message("<span class='notice'>[user] clears away [src]!</span>", "<span class='notice'>You clear away [src]!</span>")
-			qdel(src)	
+			qdel(src)
 		return ITEM_INTERACT_COMPLETE
 
 /obj/effect/snow/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume, global_overlay = TRUE)

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -260,7 +260,7 @@
 			break
 		if(T == previousturf)
 			continue	//so we don't burn the tile we be standin on
-		if(!T.CanAtmosPass(get_dir(T, previousturf)) || !previousturf.CanAtmosPass(get_dir(previousturf, T)))
+		if(!T.CanAtmosPassBidirectional(get_dir(T, previousturf)))
 			break
 		if(igniter)
 			igniter.ignite_turf(src, T)

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -237,7 +237,7 @@
 			if(!link)
 				continue
 			// Check if it wasn't already visited and if you can get to that turf
-			if(!closed[link] && T.CanAtmosPass(direction) && link.CanAtmosPass(turn(direction, 180)))
+			if(!closed[link] && T.CanAtmosPassBidirectional(direction))
 				var/dx = link.x - Ce.x
 				var/dy = link.y - Ce.y
 				var/target_dist = max((dist + 1 + sqrt(dx * dx + dy * dy)) / 2, dist)

--- a/code/modules/hallucinations/effects/major.dm
+++ b/code/modules/hallucinations/effects/major.dm
@@ -401,7 +401,7 @@
 		//Expand to each dir
 		for(var/direction in GLOB.cardinal)
 			var/turf/target_turf = get_step(source_turf, direction)
-			if(processed[target_turf] || !source_turf.CanAtmosPass(direction) || !target_turf.CanAtmosPass(turn(direction, 180)))
+			if(processed[target_turf] || !source_turf.CanAtmosPassBidirectional(direction))
 				continue
 			create_blob(target_turf)
 			expand_queue += target_turf

--- a/code/modules/hallucinations/effects/moderate.dm
+++ b/code/modules/hallucinations/effects/moderate.dm
@@ -286,7 +286,7 @@
 		// Expand to each dir
 		for(var/direction in GLOB.cardinal)
 			var/turf/target_turf = get_step(source_turf, direction)
-			if(processed[target_turf] || !source_turf.CanAtmosPass(direction) || !target_turf.CanAtmosPass(turn(direction, 180)))
+			if(processed[target_turf] || !source_turf.CanAtmosPassBidirectional(direction))
 				continue
 			create_plasma(target_turf)
 			expand_queue += target_turf

--- a/code/modules/power/generators/turbine.dm
+++ b/code/modules/power/generators/turbine.dm
@@ -275,7 +275,7 @@
 	if(compressor)
 		compressor.locate_machinery()
 
-/obj/machinery/power/turbine/CanAtmosPass(turf/T)
+/obj/machinery/power/turbine/CanAtmosPass(direction)
 	return !density
 
 /obj/machinery/power/turbine/process()


### PR DESCRIPTION
## Что этот PR делает
Исправляет поиск соседних турфов по логике атмоса, который сейчас некорректно обрабатывает турфы по диагонали.

## Почему это хорошо для игры
Это явно баг, потому что атмос такое не позволяет. Надо пофиксить.

https://youtu.be/SeBGNllTlBw?feature=shared&t=43

## Тестирование
Проверил на макете возле СМа, проверил распространение покрытия ксеноморфов. Там вообще немного кейсов, но пока ТМ для дозревания и потом на апстрим.

## Changelog

:cl: Maxiemar
fix: Воздух больше не всасывается скрабером по диагонали между плотными объектами и структурами.
/:cl:

## Обзор от Sourcery

Исправления ошибок:
- Исправлена проблема, из-за которой очистители воздуха забирали воздух по диагонали между плотными объектами и структурами.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where air scrubbers were drawing air diagonally between dense objects and structures.

</details>