### PR TITLE
[Fix] Blacksmith wiring + Lobby button at Engineering (Cyberiad)

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -33829,7 +33829,7 @@
 "cJo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/engineering/glass{
-	id = "englobby"
+	id_tag = "englobby"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/poddoor{
@@ -46900,10 +46900,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
@@ -98635,6 +98632,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

- Фиксит проводку у офиса кузнеца на Кибериаде, дабы выглядело красивше и не приходилось доделывать в раунде инженерам. 
- Фиксит кнопку в лобби инженерного отдела, дабы можно было пропускать людей не выходя в коридор из КПП.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Явная недоработка, надо фиксить.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Зашел на локалку, потыкал кнопку лобби инженерии, - дверь открывалась/закрывалась. Проверил мультитулом подачу энергии к кузнецу - АПЦ заряжался.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Бригада электриков с АКН "Трурль" нашла неполадки в проводке около офиса кузнеца на Кибериаде и устранила их.
fix: Кнопка открытия главных шлюзов в КПП инженерии на Кибериаде магическим образом починилась.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Исправление электропроводки и функциональности кнопки в холле в инженерной зоне станции Кибериада

Исправления ошибок:
- Исправлена электропроводка возле офиса Кузнеца для улучшения функциональности
- Отремонтирована кнопка в холле в инженерной зоне, чтобы обеспечить доступ к двери без выхода в коридор

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix electrical wiring and lobby button functionality in the Engineering area of the Cyberiad station

Bug Fixes:
- Corrected electrical wiring near the Blacksmith's office to improve functionality
- Repaired the lobby button in Engineering to allow door access without exiting to the corridor

</details>