### PR TITLE
Adds downside for pump up + fixes oversight for slimepeople using mephedrone

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drugs.dm
+++ b/code/modules/reagents/chemistry/reagents/drugs.dm
@@ -260,11 +260,21 @@
 
 /datum/reagent/pump_up/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
+	var/recent_consumption = holder.cycle_used[type] // SS220 EDIT
 	update_flags |= M.adjustStaminaLoss(-21) // one cycle to get out of stam crit ~2 second
 	M.AdjustParalysis(-2 SECONDS)
 	M.AdjustStunned(-2 SECONDS)
 	M.AdjustWeakened(-2 SECONDS)
 	M.AdjustKnockDown(-2 SECONDS)
+	// SS220 EDIT START
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/datum/organ/heart/datum_heart = H.get_int_organ_datum(ORGAN_DATUM_HEART)
+		if(datum_heart)
+			var/heart_damage = 0.05 + 0.75 / 100 * recent_consumption // 0.05 at 1st cycle, 0.8 at 100th. Death in 120 (127 for slime people) cycles without treatment
+			var/obj/item/organ/internal/heart/our_heart = datum_heart.linked_organ
+			our_heart.receive_damage(heart_damage, TRUE)
+	// SS220 EDIT END
 	return ..() | update_flags
 
 /datum/reagent/pump_up/overdose_process(mob/living/M, severity)

--- a/code/modules/reagents/chemistry/reagents/medicine.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine.dm
@@ -143,7 +143,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/heal_modifier = 0.4
-		if(M.reagents.has_reagent("mephedrone"))
+		if(M.reagents.has_reagent("mephedrone") || M.reagents.has_reagent("pump_up")) // SS220 EDIT
 			heal_modifier -= 0.3 //This lowers the healing to 0.1. As such, you need time off the drug to heal heart damage, but can be on the drug endlessly when not oding IF you keep your supply going.
 
 		//Mitocholide is hard enough to get, it's probably fair to make this all internal organs
@@ -1087,7 +1087,12 @@
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/M)
 	var/update_flags = STATUS_UPDATE_NONE
-	update_flags |= M.adjustBrainLoss(-3, FALSE)
+	// SS220 EDIT START
+	var/heal_modifier = 3
+	if(isslimeperson(M) && (M.reagents.has_reagent("mephedrone") || M.reagents.has_reagent("pump_up"))) // so these 2 drugs deal more brain damage than we can heal using mannitol
+		heal_modifier = 0.1 // sadge
+	update_flags |= M.adjustBrainLoss(-heal_modifier, FALSE)
+	// SS220 EDIT END
 	return ..() | update_flags
 
 /datum/reagent/medicine/mutadone

--- a/code/modules/reagents/chemistry/reagents_datum.dm
+++ b/code/modules/reagents/chemistry/reagents_datum.dm
@@ -38,6 +38,8 @@
 	var/taste_description = "metaphorical salt"
 	/// how quickly the addiction threshold var decays
 	var/addiction_decay_rate = 0.01
+	// SS220 EDIT - how quickly the used cycle var decays - 0.5 means 33% uptime
+	var/cycle_decay_rate = 0.5
 
 	// Which department's (if any) reagent goals this is eligible for.
 	// Must match the values used by request consoles.
@@ -141,6 +143,7 @@
 	if(!addiction_chance)
 		return
 	M.reagents.addiction_threshold_accumulated[type] += consumption_rate
+	M.reagents.cycle_used[type]++ // SS220 EDIT
 	if(is_type_in_list(src, M.reagents.addiction_list))
 		return
 	var/current_threshold_accumulated = M.reagents.addiction_threshold_accumulated[type]

--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -33,6 +33,7 @@
 	var/temperature_max = 10000
 	var/list/datum/reagent/addiction_list = list()
 	var/list/addiction_threshold_accumulated = list()
+	var/list/cycle_used = list() // SS220 EDIT
 	var/flags
 
 /datum/reagents/New(maximum = 100, temperature_minimum, temperature_maximum)
@@ -305,6 +306,14 @@
 		addiction_threshold_accumulated[R] -= initial(R.addiction_decay_rate) // Otherwise very slowly deplete the buildup (defaults to 0.01)
 		if(addiction_threshold_accumulated[R] <= 0)
 			addiction_threshold_accumulated -= R
+	// SS220 EDIT START
+	for(var/datum/reagent/R as anything in cycle_used)
+		if(has_reagent(initial(R.id)))
+			continue
+		cycle_used[R] -= initial(R.cycle_decay_rate)
+		if(cycle_used[R] <= 0)
+			cycle_used -= R
+	// SS220 EDIT END
 
 	// a bitfield filled in by each reagent's `on_mob_life` to find out which states to update
 	var/update_flags = STATUS_UPDATE_NONE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет негативное свойство для памп апа, наиболее полезного и, до сих пор, не имевшего минусов кустарного наркотика. Теперь он медленно убивает сердце. Изначальный урон 0.05, для полной смерти при такой скорости понадобится 1200 циклов. Однако урон скалируется с каждым циклом проведённым в организме и эффект медленно спадает при отсутствии (аналог метамфетамина, нельзя закинуться один раз на X юнитов и забыть о проблемах - гарантированно умрёшь). Если использовать его в малых дозах и с перерывами, никакой смерти, очевидно, не произойдёт.

Добавляет исключение для манитола у слаймолюдей, если у тех в крови есть насос или мефедрон - он будет лечить `0.1` урон мозгу вместо `3`. Без этого слаймолюди полностью игнорируют негативные свойства от этих наркотиков при использовании манитола.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Не модульно - полезность под вопросом.

Памп ап является адреналом за 0 ТК без баффа к скорости передвижения. Он выводит из стаминакрита _каждый_ цикл, из-за чего задержать пользователя памп апа нелетально невозможно. Весьма раковый геймплей, когда игрок просто берёт 5 пачек сигарет, делает в них насос и курит на протяжении двух часов без негативных эффектов, буквально получая иммунитет к оглушениям. 

У кустарного наркотика должен быть какой-то даунсайд эффект, ведь это даже не тщательно выверенный наркотик создаваемый исключительно при помощи хим диспенсера - он собирается на коленке при помощи кофейного стаканчика и шприца с эпинефрином.

Прикольно, когда игроку нужно что-то делать в зависимости от ситуации. Попал в передрягу - использовал инъектор с наркотиком, получив преимущество на n-ный период времени. 

Не прикольно, когда игрок может просто курить одни и те же сигареты на протяжении двух часов для получения серьёзного игрового преимущества (билд основан на стаминауроне) и не получать от этого негативных последствий.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Хуман умрёт через 120 циклов (более 4 минут) пользования, без использования митоколида.
![image](https://github.com/user-attachments/assets/a1b0bb93-83b7-4d76-823b-7d614938e26f)

Слаймомен умрёт через 127 циклов пользования, без использования манитола.
![image](https://github.com/user-attachments/assets/8691adc3-ef83-4a26-811e-f5d375a262db)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Памп ап теперь наносит урон сердцу. Урон тем выше, чем дольше пользуется наркотиком носитель. Без лечения, смерть для человека гарантирована через 4-5 минут безостановочного использования. Слаймомены продержутся на 15 секунд дольше.
tweak: Слаймомены больше не могут перебить урон от мефедрона по ядру при помощи манитола.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
