### PR TITLE
Fix Colossus' projectiles

### DIFF
--- a/modular_ss220/balance/code/items/projectiles.dm
+++ b/modular_ss220/balance/code/items/projectiles.dm
@@ -1,6 +1,6 @@
 /obj/item/projectile
 	///If TRUE, hit mobs even if they're on the floor and not our target
-	var/hit_prone_targets = FALSE
+	var/hit_prone_targets = TRUE
 
 /atom/handle_ricochet(obj/item/projectile/ricocheting_projectile)
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фиксит снаряды Колосса, ну и вообще любого моба - теперь они попадают по лежачим до тех пор, пока лежачий карбон находится в сознании или является непосредственно конечной целью снаряда.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Фикс. Подводных камней быть не может.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

i ded
![image](https://github.com/user-attachments/assets/2eeddf3f-8543-4dae-a078-1a5da19e05f6)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Снаряды Колосса вновь способны попадать по лежачим игрокам.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
