### PR TITLE
NT* improvements

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -13655,16 +13655,6 @@
 	icon_state = "darkredfull"
 	},
 /area/centcom/ss220/command)
-"icT" = (
-/obj/structure/sink/directional/east,
-/obj/structure/mirror{
-	pixel_x = -30
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/syndicate_mothership)
 "idU" = (
 /obj/structure/railing/cap/normal,
 /turf/simulated/floor/indestructible/grass/no_creep,
@@ -22939,11 +22929,11 @@
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/bar)
 "nFN" = (
-/obj/structure/mirror{
-	pixel_x = -30
-	},
 /obj/structure/sink/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/mirror/magic/nuclear{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -51516,7 +51506,7 @@ gOQ
 gOQ
 fnU
 eSY
-icT
+nFN
 oPQ
 nFN
 eXO

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -11,6 +11,7 @@
 	var/projectile_delay = 0
 	var/projectiles
 	var/projectile_energy_cost
+	var/suppressed
 
 /obj/item/mecha_parts/mecha_equipment/weapon/can_attach(obj/mecha/combat/M as obj)
 	if(..())
@@ -58,7 +59,12 @@
 		chassis.use_power(energy_drain)
 		projectiles--
 		A.fire()
-		playsound(chassis, fire_sound, 50, 1)
+		// SS220 EDIT START
+		if(suppressed)
+			playsound(chassis, fire_sound, 10, TRUE, ignore_walls = FALSE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
+		else
+			playsound(chassis, fire_sound, 50, 1)
+		// SS220 EDIT END
 
 		sleep(max(0, projectile_delay))
 	set_ready_state(0)

--- a/modular_ss220/maps220/code/objects.dm
+++ b/modular_ss220/maps220/code/objects.dm
@@ -141,12 +141,21 @@
 
 // Mecha equipment
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/syndi
-	name = "\improper AC 2 \"Special\""
-	desc = "C-20r inside!"
-	equip_cooldown = 8
-	projectile = /obj/item/projectile/bullet/midbullet2
-	fire_sound = 'sound/weapons/gunshots/gunshot_smg.ogg'
+	name = "\improper SA-9 \"Tacit\""
+	equip_cooldown = 0.8 SECONDS
+	projectile = /obj/item/projectile/bullet/midbullet
+	projectile_delay = 1.5
 	projectile_energy_cost = 14
+	suppressed = TRUE
+	fire_sound = 'sound/weapons/gunshots/gunshot_silenced.ogg'
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/syndie
+	name = "SA ISR \"Interitus\""
+	equip_cooldown = 8 SECONDS // greater cooldown for high damage
+	energy_drain = 500 // 2000 total
+	projectile = /obj/item/projectile/ion
+	projectiles_per_shot = 4
+	variance = 20 // kinda accurate
 
 /* Caves awaymission */
 /obj/item/clothing/gloves/ring/immortality_ring

--- a/modular_ss220/maps220/code/objects.dm
+++ b/modular_ss220/maps220/code/objects.dm
@@ -142,9 +142,10 @@
 // Mecha equipment
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/syndi
 	name = "\improper SA-9 \"Tacit\""
-	equip_cooldown = 0.8 SECONDS
+	equip_cooldown = 0.75 SECONDS
 	projectile = /obj/item/projectile/bullet/midbullet
-	projectile_delay = 1.5
+	projectiles_per_shot = 2
+	projectile_delay = 1.2
 	projectile_energy_cost = 14
 	suppressed = TRUE
 	fire_sound = 'sound/weapons/gunshots/gunshot_silenced.ogg'

--- a/modular_ss220/objects/code/mecha/combat.dm
+++ b/modular_ss220/objects/code/mecha/combat.dm
@@ -15,7 +15,7 @@
 	deflect_chance = 20
 	leg_overload_coeff = 100
 	max_temperature = 35000
-	armor = list(melee = 40, bullet = 40, laser = 50, energy = 35, bomb = 20, rad = 20, fire = 100, acid = 100)
+	armor = list(MELEE = 40, BULLET = 40, LASER = 50, ENERGY = 35, BOMB = 20, RAD = 20, FIRE = INFINITY, ACID = INFINITY)
 	operation_req_access = list(ERT_TYPE_AMBER)
 	max_equip = 5
 	wreckage = /obj/structure/mecha_wreckage/gygax/gygax_nt
@@ -63,14 +63,18 @@
 /// Rover
 /obj/mecha/combat/durand/rover
 	name = "Ровер"
-	desc = "Боевой мех, разработанный Синдикатом на основе Durand Mk. II путем удаления ненужных вещей и добавления некоторых своих технологий. Гораздо лучше защищен от любых опасностей, связанных с Нанотрейзен."
+	desc = "Боевой мех, разработанный Синдикатом на основе Durand Mk. II путем удаления ненужных вещей и добавления некоторых своих технологий. \
+		Гораздо лучше защищен от любых опасностей, связанных с Нанотрейзен. Ценой за такую защиту стала сильно пострадавшая мобильность."
 	icon = 'modular_ss220/objects/icons/mecha.dmi'
 	icon_state = "darkdurand"
 	initial_icon = "darkdurand"
-	armor = list(melee = 30, bullet = 40, laser = 50, energy = 50, bomb = 20, rad = 50, fire = 100, acid = 100)
+	armor = list(MELEE = 50, BULLET = 75, LASER = 25, ENERGY = 25, BOMB = 20, RAD = 50, FIRE = INFINITY, ACID = INFINITY)
 	operation_req_access = list(ACCESS_SYNDICATE)
-	max_equip = 4
-	internal_damage_threshold = 35
+	step_in = 6 // slowest mech in game
+	max_equip = 5
+	max_integrity = 425
+	max_temperature = 40000
+	internal_damage_threshold = 25
 	wreckage = /obj/structure/mecha_wreckage/durand/rover
 	starting_voice = /obj/item/mecha_modkit/voice/syndicate
 	destruction_sleep_duration = 2 SECONDS
@@ -87,11 +91,13 @@
 	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/syndi
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/repair_droid
+	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/syndie
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster
+	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay(src)
 	ME.attach(src)
-	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
+	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
+	ME.attach(src)
+	ME = new /obj/item/mecha_parts/mecha_equipment/thrusters
 	ME.attach(src)
 
 /obj/mecha/combat/durand/rover/loaded/add_cell()

--- a/modular_ss220/uplink_items/_uplink_items.dme
+++ b/modular_ss220/uplink_items/_uplink_items.dme
@@ -1,2 +1,3 @@
 #include "_uplink_items.dm"
 #include "code/uplink_general.dm"
+#include "code/uplink_nuclear.dm"

--- a/modular_ss220/uplink_items/code/uplink_general.dm
+++ b/modular_ss220/uplink_items/code/uplink_general.dm
@@ -6,3 +6,6 @@
 	reference = "SHAD"
 	item = /obj/item/flashlight/shadowlight
 	cost = 20
+
+/datum/uplink_item/dangerous/chainsaw
+	excludefrom = list()

--- a/modular_ss220/uplink_items/code/uplink_nuclear.dm
+++ b/modular_ss220/uplink_items/code/uplink_nuclear.dm
@@ -1,0 +1,8 @@
+/datum/uplink_item/support/rover
+	name = "Rover Exosuit"
+	desc = "Более полезная версия Дюранда, предоставляющая наивысшую прочность экзокостюма. \
+			Не лучший выбор для активного наступления, но отлично подойдёт тем, кто не уверен в своих напарниках. \
+			Вооружён лёгким штурмовым пулемётом \"Tacit\" и тяжёлым ионным дробовиком \"Interitus\" от Scarborough Arms."
+	reference = "RE"
+	item = /obj/mecha/combat/durand/rover/loaded
+	cost = 450 // 338 on discount


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Слегка переделал Ровер.
Добавляет нюкерам: магические зеркала, позволяющие менять расу (как на оффах) и ТТС куклы; Ровер в аплинк; бензопилу Синдиката в аплинк.

Ровер - усиленная версия Дюранда. 
Пулемёт, стреляющий очередями из двух пуль калибра .45, быстрой перезарядкой между очередями, сниженной стоимостью энергии за выстрел и глушителем (!!).
Усиленная версия ионного дробовика - четыре ионных проджектайла (у ионки в оружейной СБ один проджектайл за выстрел) за выстрел, но с перезарядкой между выстрелами в 8 секунд (у обычной ионки 4 секунды). Сильно повышает боевой потенциал на ближне-средних дистанциях против других мехов (Арес из гамма оружейной, например).

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Ну зеркало есть на оффах, почему бы и сюда его не добавить, вроде проблем нет?

Больше разнообразия - хорошо, а этот пр повышает количество мехов для нюкеров в полтора раза.
За свои повышенные характеристики он заплатил самой низкой скоростью передвижения - он крайне немобилен и его легко застать врасплох, преследовать, но его суть в том, чтобы железно стоять в позиции. Своеобразный челлендж для нюкера, который вынужден идти в наступление, но способен взять защитный экзокостюм. Если ставка сыграет и он займёт роль обороняющегося, а экипаж перейдёт в наступление - мех покажет себя с крайне сильной стороны (ну ещё надо чтобы пилот был не глупым).

Какие-то статы могут быть слишком, я его, понятное дело, не тестил на 80 членах экипажа, так что либо надо на стадии ревью их подправить, либо после мержа посмотреть раунды с ним.
За один выстрел ионного дробовика наносит КПБ порядка 150 урона (при условии, что все 4 проджектайла попали), но у нюкеров и так полно гиб пушек, не думаю, что ионка сделает в этом плане большую разницу.

Бензопилу убрали с инициативы оффов по причине "каждый раунд берут бензопилу". Ну, каждый раунд ещё элитки берут, по такой логике можно и элитки убрать. Бред, в общем-то.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Загрузил локалку, поменял расу в зеркале, купил пилу, купил Ровер, пострелял с него - ищью не замечено.
На локалке в зеркале отображаются вообще все расы (големы, скелеты и т.д.), но такое даже в логове мага есть, так что наверняка локалка ищью, на лайве должно быть нормально.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: Добавлены M.A.G.I.C зеркала для ЯО - они позволяют сменить расу и TTS оперативника. Располагаются в уборной СЦК.
add: Добавлен боевой экзокостюм Ровер в аплинк ЯО. Стоимость - 450 ТК (338 по скидке). Является продвинутым аналогом Дюранда и контрмерой Аресу (и всей синтетике в целом).
add: ЯО вернули бензопилу в аплинк.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->


<sub>*NT - Nuclear Team</sub>