### PR TITLE
Fix Box and Meta stations' security consoles

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -826,8 +826,7 @@
 /area/station/security/warden)
 "aeV" = (
 /obj/machinery/computer/security{
-	dir = 8;
-	network = list("SS13","Research Outpost","Mining Outpost")
+	dir = 8
 	},
 /obj/item/radio/intercom/custom{
 	dir = 8;
@@ -3247,8 +3246,7 @@
 /area/station/security/warden)
 "apk" = (
 /obj/machinery/computer/security{
-	dir = 8;
-	network = list("SS13","Research Outpost","Mining Outpost")
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -3727,8 +3725,7 @@
 /area/station/security/lobby)
 "arl" = (
 /obj/machinery/computer/security{
-	dir = 4;
-	network = list("SS13","Research Outpost","Mining Outpost")
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -12167,9 +12164,7 @@
 /area/station/security/checkpoint/secondary)
 "aWf" = (
 /obj/structure/reagent_dispensers/peppertank/north,
-/obj/machinery/computer/security{
-	network = list("SS13","Research Outpost","Mining Outpost")
-	},
+/obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -17543,10 +17538,8 @@
 /obj/machinery/camera{
 	c_tag = "Bridge West"
 	},
-/obj/machinery/computer/security{
-	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
-	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
 	icon_state = "red"
 	},

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -14145,9 +14145,7 @@
 /area/station/security/checkpoint/secondary)
 "bix" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/computer/security{
-	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
-	},
+/obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "red"
@@ -28499,9 +28497,7 @@
 	},
 /area/station/security/checkpoint/secondary)
 "cfh" = (
-/obj/machinery/computer/security{
-	network = list("SS13","Research Outpost","Mining Outpost","Telecomms")
-	},
+/obj/machinery/computer/security,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkred"
@@ -53935,8 +53931,7 @@
 /area/station/security/detective)
 "jIs" = (
 /obj/machinery/computer/security{
-	dir = 8;
-	network = list("SS13","Research Outpost","Mining Outpost")
+	dir = 8
 	},
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plasteel{
@@ -69564,8 +69559,7 @@
 /area/station/security/main)
 "rsR" = (
 /obj/machinery/computer/security{
-	dir = 8;
-	network = list("SS13","Research Outpost","Mining Outpost")
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фиксит то, что некоторые консоли камер СБ не показывали каторгу в списке камер.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

[Каторга](https://github.com/ParadiseSS13/Paradise/pull/28595) в список камер была добавлена с оффов, но т.к. апдейтпафса не было - консоли не обновились.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Загрузил локалку, не нашёл камеры каторги в списке - понял, что выключил Лаваленд в конфиге.
Вернул Лаваленд в конфиг, залетел на мостик Киберады и глянул каторгу - работает.
![image](https://github.com/user-attachments/assets/1139c3ef-6bf4-4a2c-aa7b-cca987db316a)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Консоли камер СБ на Кибериаде и Цереброне теперь и правда показывают камеры каторги в списке.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
