### PR TITLE
Докидываем недостающую кухонную утварь на Тету

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/oldstation.dmm
@@ -709,6 +709,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/reagent_containers/cooking/oven,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -2243,7 +2244,6 @@
 	},
 /area/ruin/ancientstation/kitchen)
 "gF" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/all_access/directional/north{
 	report_danger_level = 0
@@ -2273,16 +2273,17 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/cooking/stovetop,
+/obj/item/reagent_containers/cooking/pan{
+	pixel_x = 7;
+	pixel_y = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
 /area/ruin/ancientstation/kitchen)
 "gL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 10
-	},
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -2603,6 +2604,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/reagent_containers/cooking/deep_basket{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -4372,7 +4377,10 @@
 "pW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/item/reagent_containers/cooking/oven,
+/obj/item/reagent_containers/cooking/pot{
+	pixel_x = -1;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -6956,6 +6964,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cafeteria"
 	},
@@ -9073,7 +9085,7 @@ cS
 fL
 gs
 gE
-gG
+gL
 eo
 gG
 vJ
@@ -9217,8 +9229,8 @@ rn
 gs
 Iw
 gG
-VR
 gG
+VR
 gG
 hZ
 ha
@@ -9265,7 +9277,7 @@ fO
 gs
 gt
 gG
-sY
+gG
 gG
 gG
 ia
@@ -9313,8 +9325,8 @@ fS
 gs
 zp
 kx
-gL
 gG
+sY
 gG
 hY
 ha


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавляет недостающую кухонную утварь на Тету (старую станцию из гостролей), а именно: сковородку, кастрюлю и фритюрную корзинку. Также слегка меняет столы на кухне.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Тетовцы смогут налегке готовить себе еду из доступных ингредиентов.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
![изображение](https://github.com/user-attachments/assets/01b1640a-d32e-404e-a199-010bdd53433e)

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Протестировал на локальном сервере, карта поменялась, конфликтов не обнаружилось.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Osetrokarasek
tweak: Зайдя однажды в раунд за госта, я застал, как тетовцы давились сырыми яйцами, поскольку на их нищенской посудине не доложили такой банальной вещи, как сковорода. Ну и стало мне жаль бедняков, ну и решил я им эту несчастную сковородку додать... ну и сверху еще недостающей утвари докинуть по доброте душевной. Не благодарите.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Краткое описание от Sourcery

Добавлены кухонные принадлежности и изменены столы на станции Тета для улучшения возможностей приготовления пищи для членов экипажа.

Новые функции:
- Добавлено кухонное оборудование, включая сковороду, кастрюлю и корзину для фритюрницы на станцию ​​Тета.

Улучшения:
- Незначительно изменены кухонные столы для размещения нового кухонного оборудования.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add kitchen utensils and modify tables on the Teta station to improve cooking capabilities for crew members

New Features:
- Added kitchen equipment including a frying pan, pot, and deep fryer basket to the Teta station

Enhancements:
- Slightly modified kitchen tables to accommodate the new cooking equipment

</details>