### PR TITLE
Fix music input for BYOND 516

### DIFF
--- a/code/modules/instruments/songs/_song_ui.dm
+++ b/code/modules/instruments/songs/_song_ui.dm
@@ -63,7 +63,7 @@
 			name = ""
 		if("import")
 			var/t = ""
-			t = tgui_input_text(usr, "Please paste the entire song, formatted:", parent.name, max_length = (MUSIC_MAXLINECHARS * MUSIC_MAXLINES), multiline = TRUE)
+			t = tgui_input_text(usr, "Please paste the entire song, formatted:", parent.name, max_length = 80000 /* SS220 EDIT - limit according to max URL length (80000) */, multiline = TRUE)
 			if(!in_range(parent, usr))
 				return
 			parse_song(t)

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -118,7 +118,7 @@
         }
 
         // Perform a standard call via location.href
-        if (url.length < 2048) {
+        if (url.length < 80000) { // SS220 EDIT - use Safari max URL length
           location.href = 'byond://' + url;
           return;
         }


### PR DESCRIPTION
## Что этот PR делает
Чинит ввод у музыкальных инструментов через изменение максимальной длины URL. Взял самое здоровое, что нашел в стандартах (Safari - 80к).

## Почему это хорошо для игры
Мы изображаем из себя культурное общество, нам нужна музыка.

## Тестирование
Сыграл Моргенштерн - ПОСОСИ на рояле.

## Changelog

:cl: Maxiemar
fix: Исправлен ввод длинных композиций в музыкальных инструментах. Текущее ограничение - 80к символов.
/:cl:
