### PR TITLE
Микрофикс невозможного стола в инженерии Кербероса

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -24797,11 +24797,7 @@
 /turf/simulated/wall,
 /area/station/maintenance/starboard2)
 "bXY" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire{
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/delivery,
+/obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "bYa" = (
@@ -25140,11 +25136,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "bZs" = (
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/machinery/atmospherics/unary/portables_connector,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "bZt" = (
@@ -25695,7 +25691,6 @@
 	},
 /area/station/medical/reception)
 "cbu" = (
-/obj/item/kirbyplants/large,
 /obj/machinery/camera{
 	c_tag = "Engine Room North";
 	network = list("Engineering","SS13")
@@ -28557,11 +28552,11 @@
 "cmO" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard{
-	pixel_x = -6;
+	pixel_x = -7;
 	pixel_y = 4
 	},
 /obj/item/toy/figure/crew/engineer{
-	pixel_x = -6;
+	pixel_x = -8;
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/delivery/hollow,
@@ -30946,10 +30941,8 @@
 /area/station/engineering/control)
 "cxF" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/firstaid/fire,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cxG" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет стол в инженерном отделе Кербероса, до которого невозможно дотянуться (а также до аптечки на нем), просто... удаляя его. А аптечка перемещена на место коробки пончиков на столике рядом.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Ликвидирован один бестолковый стол, почему нет?
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
До:

![изображение](https://github.com/user-attachments/assets/5d9ed00c-1e0c-48ec-a2d6-43385a476cea)

После:

![изображение](https://github.com/user-attachments/assets/5b976f9d-e02c-4f59-b3d7-dd3e97e1caf9)

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

![изображение](https://github.com/user-attachments/assets/cdcb5d18-669f-467b-b3b1-2bfe73707687)

Запустил на локальном сервере, все отлично.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Osetrokarasek
del: Керберос: в инженерном отделе был разобран и вынесен по частям невозможный стол.
del: Керберос: конфискована одна из коробок пончиков некогда принадлежавшая инженерному отделу.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Удалена недоступная таблица в инженерном отделе Kerberos и перемещена аптечка

Исправления ошибок:
- Исправлена проблема с недоступной таблицей в инженерном отделе путем ее удаления.

Рутинные задачи:
- Перемещена аптечка из недоступной таблицы к ближайшей коробке с пончиками.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove an inaccessible table in the Kerberos engineering department and relocate the medical kit

Bug Fixes:
- Fixed an issue with an unreachable table in the engineering department by removing it

Chores:
- Relocated a medical kit from the inaccessible table to a nearby donut box table

</details>