### PR TITLE
Update engineering

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -24732,7 +24732,6 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_s_tesla_door_ext"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel{
@@ -38788,7 +38787,6 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_s_tesla_door_int"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -43752,7 +43750,6 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_n_tesla_door_int"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -92238,7 +92235,6 @@
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_n_tesla_door_ext"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel{

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -10145,7 +10145,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -11931,7 +11930,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aUX" = (
-/obj/effect/spawner/window/grilled,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/dronefabricator)
 "aUY" = (
@@ -15636,6 +15635,13 @@
 	icon_state = "grimy"
 	},
 /area/station/service/chapel/office)
+"bix" = (
+/obj/machinery/light/directional/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "biE" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
@@ -21065,7 +21071,7 @@
 	},
 /area/station/engineering/hallway)
 "bHZ" = (
-/obj/effect/spawner/window/grilled,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/emergency)
 "bIa" = (
@@ -23497,7 +23503,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10;
+	initialize_directions = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -23829,19 +23838,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "bUy" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_atmos_door_ext"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button{
-	autolink_id = "eng_atmos_btn_ext";
-	pixel_y = 24;
-	req_access = list(13)
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/engineering/transmission_laser)
 "bUE" = (
 /obj/item/flag/nt,
 /obj/structure/cable{
@@ -24312,6 +24317,7 @@
 /area/station/science/misc_lab)
 "bWT" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
+/obj/structure/sign/radiation/rad_area,
 /turf/simulated/wall,
 /area/station/maintenance/storage)
 "bWU" = (
@@ -24719,22 +24725,16 @@
 /turf/simulated/floor/plating,
 /area/station/supply/miningdock)
 "bYQ" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_s_tesla_door_ext"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/access_button{
-	autolink_id = "eng_s_tesla_btn_ext";
-	pixel_y = 24;
-	req_access = list(10,13)
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/external{
+	id_tag = "eng_s_tesla_door_ext"
+	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -26092,7 +26092,7 @@
 /area/station/medical/psych)
 "ceb" = (
 /obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
+	c_tag = "Gravity Generator Room East";
 	dir = 8
 	},
 /turf/simulated/floor/plasteel{
@@ -28765,7 +28765,6 @@
 	name = "SM Radiation Security Lock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -29859,15 +29858,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"cui" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/control)
 "cuj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -30251,7 +30241,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
 "cvB" = (
-/obj/effect/spawner/window/grilled,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/controlroom)
 "cvC" = (
@@ -30563,15 +30553,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"cxd" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkyellowfull"
-	},
-/area/station/engineering/control)
 "cxe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
@@ -32561,13 +32542,18 @@
 /turf/simulated/wall,
 /area/station/maintenance/aft)
 "cEy" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
+/obj/effect/turf_decal/miscellaneous/plumbing{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkred"
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -4
 	},
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "cEz" = (
 /obj/effect/turf_decal/delivery/hollow,
@@ -32619,14 +32605,15 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
 "cEM" = (
-/obj/structure/closet/walllocker/emerglocker/directional/north,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_n_tesla_vent"
+/obj/effect/turf_decal/miscellaneous/plumbing{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/end,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutralfull"
+/obj/machinery/shower{
+	pixel_y = 16
 	},
+/obj/effect/turf_decal/siding/yellow/end,
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "cES" = (
 /obj/structure/table,
@@ -35043,7 +35030,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -37485,22 +37472,22 @@
 	},
 /area/station/engineering/break_room)
 "cWW" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_atmos_door_int"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/obj/machinery/camera{
+	dir = 6;
+	network = list("Engineering","SS13");
+	c_tag = "Power Transmission Laser"
 	},
-/obj/machinery/access_button{
-	autolink_id = "eng_atmos_btn_int";
-	pixel_y = 24;
-	req_access = list(13)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "cWX" = (
 /obj/machinery/status_display/directional/south,
 /turf/simulated/floor/plasteel{
@@ -37531,6 +37518,12 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/access_button{
+	autolink_id = "eng_s_tesla_btn_ext";
+	req_access = list(10);
+	pixel_x = 24;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -37658,7 +37651,7 @@
 	},
 /area/station/engineering/equipmentstorage)
 "cXL" = (
-/obj/effect/spawner/window/grilled,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/equipmentstorage)
 "cXO" = (
@@ -37853,7 +37846,10 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "cYy" = (
@@ -37917,8 +37913,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -38060,13 +38055,16 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/utility)
 "cZg" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "cZh" = (
 /obj/machinery/field/generator{
@@ -38781,25 +38779,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "dbZ" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_s_tesla_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/airlock/external{
+	id_tag = "eng_s_tesla_door_int"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/access_button{
-	autolink_id = "eng_s_tesla_btn_int";
-	pixel_y = 24;
-	req_access = list(10,13)
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -38880,7 +38872,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -39145,12 +39137,6 @@
 "ddr" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
-"ddt" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "ddv" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -39175,7 +39161,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
 "ddE" = (
@@ -39389,10 +39374,7 @@
 	pixel_y = 32
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
@@ -39892,9 +39874,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "dgc" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "dgd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
@@ -39963,14 +39950,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
@@ -40261,10 +40251,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/supermatter_room)
-"dhL" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "dhM" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/spawner/random/maintenance,
@@ -40621,6 +40607,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "djg" = (
@@ -40692,7 +40681,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -41391,7 +41380,7 @@
 	},
 /area/station/engineering/atmos)
 "dmy" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -42402,6 +42391,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -42460,13 +42452,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "dqX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "drf" = (
@@ -42477,8 +42472,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/turret_protected/ai)
 "drh" = (
-/obj/effect/spawner/random/maintenance,
-/obj/structure/sink/kitchen/north,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "dro" = (
@@ -42921,6 +42917,9 @@
 "dts" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
@@ -43498,11 +43497,14 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/machinery/access_button{
+	autolink_id = "eng_s_tesla_btn_int";
+	req_access = list(10);
+	pixel_x = -24;
+	pixel_y = -6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
@@ -43744,22 +43746,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_n_tesla_door_int"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/access_button{
-	autolink_id = "eng_n_tesla_btn_int";
-	pixel_y = -24;
-	req_access = list(10,13)
-	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -43884,8 +43880,8 @@
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
 "dKa" = (
-/obj/effect/spawner/window/grilled,
 /obj/structure/disposalpipe/segment,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/emergency)
 "dKh" = (
@@ -44198,7 +44194,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "dQa" = (
@@ -44312,6 +44307,14 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/asmaint)
+"dTy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "dTF" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44853,6 +44856,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
+"edP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowcorners"
+	},
+/area/station/engineering/transmission_laser)
 "edQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45422,7 +45433,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
 "elE" = (
@@ -45544,6 +45554,17 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
+"eor" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/control)
 "eoP" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -46113,6 +46134,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/public/dorms)
+"eyA" = (
+/obj/effect/spawner/airlock/w_to_e,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/ai_transit_tube)
 "eyB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -47252,6 +47277,9 @@
 /area/station/hallway/secondary/exit)
 "eWH" = (
 /obj/structure/chair/stool,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -47329,17 +47357,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
-"eZi" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_s_tesla_vent";
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutralfull"
-	},
-/area/station/engineering/control)
 "eZj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood/fancy/oak,
@@ -47595,14 +47612,12 @@
 	ext_door_link_id = "eng_s_tesla_door_ext";
 	int_button_link_id = "eng_s_tesla_btn_int";
 	int_door_link_id = "eng_s_tesla_door_int";
-	pixel_y = 25;
-	vent_link_id = "eng_s_tesla_vent";
-	req_access = list(10,13)
+	pixel_y = 24;
+	req_access = list(10);
+	vent_link_id = "fpmaint_vent"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "darkred"
+	icon_state = "darkredfull"
 	},
 /area/station/engineering/control)
 "fdC" = (
@@ -47861,10 +47876,6 @@
 /obj/structure/closet/secure_closet/research_reagents,
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
-"fjE" = (
-/obj/effect/spawner/window/grilled,
-/turf/simulated/floor/plating,
-/area/station/engineering/hallway)
 "fjM" = (
 /obj/machinery/hydroponics/constructable{
 	desc = "These are connected with an irrigation tube. You see a little pipe connecting the trays.";
@@ -47926,6 +47937,14 @@
 	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/control)
+"fkp" = (
+/obj/machinery/alarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "fkC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/nightshifted/west,
@@ -48406,6 +48425,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/access_button{
+	autolink_id = "eng_n_tesla_btn_int";
+	req_access = list(10);
+	pixel_x = -24;
+	pixel_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -48650,6 +48675,18 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgery/secondary)
+"fyC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "fyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -51359,6 +51396,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"gwD" = (
+/obj/structure/sink/kitchen/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "gwH" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 4;
@@ -52044,12 +52085,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/station/command/office/hos)
-"gKF" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "gKL" = (
 /obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/cable{
@@ -53457,6 +53492,11 @@
 	icon_state = "darkred"
 	},
 /area/station/security/interrogation)
+"hie" = (
+/obj/effect/mapping_helpers/turfs/rust/maybe,
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "hir" = (
 /obj/item/candle,
 /obj/effect/decal/cleanable/dirt,
@@ -53718,6 +53758,12 @@
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass/no_creep,
 /area/station/public/dorms)
+"hnA" = (
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "hnB" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper{
@@ -54406,6 +54452,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"hAe" = (
+/obj/structure/closet/radiation,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "hAh" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/simulated/floor/grass,
@@ -54793,10 +54843,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
-"hGQ" = (
-/obj/structure/sign/poster/contraband/random/south,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "hGY" = (
 /obj/machinery/door/airlock/command/cap{
 	id_tag = "captainofficedoor"
@@ -55330,21 +55376,18 @@
 	},
 /area/station/maintenance/apmaint)
 "hRS" = (
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "eng_atmos_btn_ext";
-	ext_door_link_id = "eng_atmos_door_ext";
-	int_button_link_id = "eng_atmos_btn_int";
-	int_door_link_id = "eng_atmos_door_int";
-	pixel_y = 25;
-	vent_link_id = "eng_atmos_vent";
-	req_access = list(10,13)
+/obj/machinery/power/apc/directional/north,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_atmos_vent";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "hRY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -55727,6 +55770,12 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/access_button{
+	autolink_id = "eng_n_tesla_btn_ext";
+	req_access = list(10);
+	pixel_x = 24;
+	pixel_y = 6
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "hZZ" = (
@@ -56875,6 +56924,15 @@
 	icon_state = "dark"
 	},
 /area/station/service/bar)
+"izz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "izR" = (
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel{
@@ -57256,6 +57314,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"iHK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "iHT" = (
 /obj/structure/shelf/engineering,
 /obj/item/clothing/gloves/color/black{
@@ -57904,6 +57970,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"iVT" = (
+/obj/structure/sign/electricshock{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkyellowcorners"
+	},
+/area/station/engineering/transmission_laser)
 "iVU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -58171,6 +58249,21 @@
 	icon_state = "yellow"
 	},
 /area/station/maintenance/fsmaint)
+"jau" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/storage)
 "jaO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice/catwalk,
@@ -58305,16 +58398,18 @@
 	},
 /area/station/command/office/rd)
 "jeb" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -4
 	},
-/obj/structure/sign/vacuum/external{
-	pixel_x = -32
+/obj/effect/turf_decal/miscellaneous/plumbing{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "darkred"
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 1
 	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "jer" = (
 /obj/structure/cable{
@@ -59172,6 +59267,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room West";
+	dir = 4;
+	network = list("SS13","Engineering")
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkblue"
@@ -59514,6 +59614,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/stairs{
 	dir = 1
 	},
@@ -59616,6 +59719,14 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
+"jDk" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "jDn" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "qm"
@@ -59730,6 +59841,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/procedure/trainer_office)
+"jGB" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "jGG" = (
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
@@ -59744,10 +59860,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
-"jGR" = (
-/obj/item/candle,
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "jHG" = (
 /obj/structure/table,
 /obj/machinery/cooking/grill,
@@ -60525,16 +60637,11 @@
 	},
 /area/station/medical/reception)
 "jVD" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_s_tesla_vent";
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutralfull"
-	},
-/area/station/engineering/control)
+/obj/machinery/light/small/directional/north,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "jVE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -61026,7 +61133,7 @@
 	id = "Singularity";
 	name = "Containment Blast Doors"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -61514,6 +61621,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"krk" = (
+/obj/structure/sign/poster/random/east,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "krv" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -61753,16 +61867,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
-"kvn" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_s_tesla_vent";
-	dir = 8
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutralfull"
-	},
-/area/station/engineering/control)
 "kvz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -62327,7 +62431,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -62589,19 +62693,7 @@
 /area/station/supply/storage)
 "kLp" = (
 /obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_sm_vent";
-	dir = 8
-	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "eng_sm_btn_ext";
-	ext_door_link_id = "eng_sm_door_ext";
-	int_button_link_id = "eng_sm_btn_int";
-	int_door_link_id = "eng_sm_door_int";
-	pixel_y = 25;
-	vent_link_id = "eng_sm_vent";
-	req_access = list(13)
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/engineering/ai_transit_tube)
 "kLR" = (
@@ -63694,6 +63786,10 @@
 	icon_state = "brown"
 	},
 /area/station/supply/smith_office)
+"lgN" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "lgO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67569,6 +67665,14 @@
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/port)
+"mBx" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "mBE" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -67750,6 +67854,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"mEl" = (
+/obj/machinery/computer/arcade,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "mEs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -67947,6 +68055,14 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
+"mJr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "mJO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -69389,6 +69505,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"noc" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass,
+/turf/simulated/floor/catwalk,
+/area/station/engineering/transmission_laser)
 "nof" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -69778,7 +69909,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "nuM" = (
@@ -70532,6 +70663,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "nJf" = (
@@ -71055,7 +71189,10 @@
 /area/station/service/bar/atrium)
 "nTQ" = (
 /obj/machinery/light/small/directional/south,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "nTZ" = (
 /obj/structure/flora/ausbushes/palebush,
@@ -71950,20 +72087,6 @@
 	icon_state = "brown"
 	},
 /area/station/supply/storage)
-"ojt" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_sm_door_ext"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "eng_sm_btn_ext";
-	pixel_y = 24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plating,
-/area/station/engineering/ai_transit_tube)
 "ojz" = (
 /obj/structure/sign/poster/contraband/random/west,
 /obj/effect/decal/cleanable/dirt,
@@ -72021,22 +72144,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "okj" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_sm_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "eng_sm_btn_int";
-	pixel_y = 24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/engineering/ai_transit_tube)
+"okk" = (
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/control)
 "okB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -72496,13 +72617,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/xenobiology)
-"otr" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
 "otv" = (
 /obj/structure/mecha_wreckage/ripley,
 /obj/structure/sign/poster/contraband/random/north,
@@ -74163,6 +74277,11 @@
 /obj/structure/cult/archives,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"oXj" = (
+/obj/structure/sign/poster/contraband/random/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "oXo" = (
 /obj/structure/closet/crate/trashcart{
 	desc = "A heavy, metal laundrycart with wheels.";
@@ -74603,6 +74722,14 @@
 	},
 /turf/space,
 /area/station/engineering/solar/port)
+"pgc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/directional/west,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "pgD" = (
 /obj/structure/girder,
 /turf/simulated/floor/plasteel,
@@ -74612,18 +74739,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/incinerator)
-"pgT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutral";
-	dir = 9
-	},
-/area/station/engineering/control)
 "pgV" = (
 /obj/effect/spawner/random/barrier/obstruction,
 /turf/simulated/floor/plating,
@@ -75611,7 +75726,6 @@
 	name = "SM Radiation Security Lock"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -75622,6 +75736,23 @@
 	},
 /turf/simulated/floor/engine,
 /area/holodeck/alphadeck)
+"pxk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkyellowfull"
+	},
+/area/station/engineering/control)
 "pxv" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75731,6 +75862,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fsmaint)
+"pzK" = (
+/obj/effect/mapping_helpers/turfs/rust/maybe,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "pzN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -79521,6 +79656,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/tox,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"qRr" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "qRs" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table,
@@ -79705,19 +79844,6 @@
 	},
 /turf/space,
 /area/space/nearstation)
-"qVp" = (
-/obj/structure/closet/walllocker/firelocker/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutral";
-	dir = 10
-	},
-/area/station/engineering/control)
 "qVv" = (
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -79919,6 +80045,10 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/cryo)
+"qZB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "qZD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -80092,6 +80222,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/cmo)
+"rcB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "rcD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80155,6 +80293,9 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"rdk" = (
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "rdu" = (
 /obj/structure/shelf/engineering,
 /obj/item/clothing/suit/storage/hazardvest{
@@ -80540,11 +80681,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"rmk" = (
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "rmu" = (
-/obj/machinery/light/small/directional/east,
-/obj/effect/decal/remains/mouse,
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/engineering/transmission_laser)
 "rmH" = (
 /obj/structure/bed/mattress,
 /obj/effect/decal/cleanable/dirt,
@@ -80727,7 +80877,6 @@
 /turf/space,
 /area/station/maintenance/turbine)
 "rsI" = (
-/obj/structure/table,
 /obj/item/paper/gravity_gen,
 /obj/item/pen/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -80736,6 +80885,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkblue"
@@ -81617,7 +81767,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -81936,8 +82086,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "evamaint_vent";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -82235,6 +82388,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
 	},
@@ -82412,19 +82568,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
-"sdE" = (
-/obj/structure/closet/walllocker/emerglocker/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutral";
-	dir = 6
-	},
-/area/station/engineering/control)
 "sdP" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -82436,6 +82579,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"sdS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "sdX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -82745,6 +82896,7 @@
 /area/station/hallway/secondary/exit)
 "skh" = (
 /obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "ski" = (
@@ -83344,6 +83496,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"sui" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/transmission_laser,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/transmission_laser)
 "suo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -84289,13 +84451,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "evamaint_vent";
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkred"
+	icon_state = "darkredfull"
 	},
 /area/station/engineering/control)
 "sLp" = (
@@ -85675,6 +85837,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
+"tkU" = (
+/obj/structure/sign/radiation/rad_area,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "tkW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -85909,6 +86075,23 @@
 	icon_state = "white"
 	},
 /area/station/maintenance/aft)
+"tqb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/shelf/engineering,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/cable_coil{
+	color = "#FFFF00"
+	},
+/obj/item/multitool,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "tqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -86279,10 +86462,6 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
-"txJ" = (
-/obj/effect/spawner/window/grilled,
-/turf/simulated/floor/plating,
-/area/station/engineering/break_room)
 "txR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -87204,7 +87383,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "tRE" = (
@@ -87999,16 +88178,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/medbay)
-"udO" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_s_tesla_vent";
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutralfull"
-	},
-/area/station/engineering/control)
 "ueB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -88276,11 +88445,21 @@
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "ujG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "ujR" = (
 /turf/simulated/floor/plasteel{
 	dir = 10;
@@ -88516,7 +88695,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -89415,6 +89594,9 @@
 /area/station/engineering/control)
 "uES" = (
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/stairs/right,
 /area/station/engineering/control)
 "uEU" = (
@@ -89868,17 +90050,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "uOG" = (
-/obj/structure/rack,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/scanning_module{
-	pixel_x = 2;
-	pixel_y = 3
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/assembly/prox_sensor{
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkyellow"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/engineering/transmission_laser)
 "uOT" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery/hollow,
@@ -90247,6 +90427,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowfull"
@@ -90881,12 +91064,9 @@
 	ext_door_link_id = "eng_n_tesla_door_ext";
 	int_button_link_id = "eng_n_tesla_btn_int";
 	int_door_link_id = "eng_n_tesla_door_int";
-	pixel_y = -25;
-	vent_link_id = "eng_n_tesla_vent";
-	req_access = list(10,13)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
+	pixel_y = -24;
+	req_access = list(10);
+	vent_link_id = "fpmaint_vent"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -92032,19 +92212,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_n_tesla_door_ext"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/access_button{
-	autolink_id = "eng_n_tesla_btn_ext";
-	pixel_y = -24;
-	req_access = list(10,13)
-	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -93859,6 +94033,13 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/aft)
+"woc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/transmission_laser)
 "woj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -93880,18 +94061,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
-"wox" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutral";
-	dir = 5
-	},
-/area/station/engineering/control)
 "woA" = (
 /obj/machinery/shower{
 	dir = 8
@@ -94971,8 +95140,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/office)
 "wJg" = (
-/obj/effect/spawner/random/fungus/maybe,
-/turf/simulated/wall,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "wJn" = (
 /obj/structure/cable{
@@ -95346,17 +95517,18 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "wQI" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_n_tesla_vent"
-	},
 /obj/structure/sign/vacuum/external{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/end,
-/obj/structure/closet/walllocker/firelocker/north,
-/turf/simulated/floor/plasteel{
-	icon_state = "darkneutralfull"
+/obj/effect/turf_decal/miscellaneous/plumbing{
+	dir = 1
 	},
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/yellow/end,
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "wQK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -95405,7 +95577,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "wRz" = (
@@ -96642,6 +96813,13 @@
 /obj/structure/disaster_counter/supermatter,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
+"xot" = (
+/obj/item/candle{
+	pixel_y = 5
+	},
+/obj/effect/decal/remains/mouse,
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "xox" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/bed{
@@ -96875,6 +97053,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"xsH" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/transmission_laser)
 "xsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -98803,7 +98985,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /turf/simulated/floor/plasteel{
@@ -121195,14 +121377,14 @@ dsL
 cSU
 aab
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+rdk
+rdk
+rdk
+qRr
+rdk
+rdk
+rdk
+rdk
 aaa
 aaa
 aaa
@@ -121452,14 +121634,14 @@ dfA
 cSU
 aab
 aaa
-doE
-doE
-doE
-doE
-aaa
-aaa
-aaa
-aaa
+rdk
+tqb
+fkp
+woc
+pgc
+fyC
+rmk
+rdk
 aaa
 aaa
 aaa
@@ -121709,14 +121891,14 @@ tCH
 cSU
 aab
 aab
-dgc
+rdk
 bUy
-dgc
-doE
-aaa
-aaa
-aaa
-aaa
+jDk
+sui
+rcB
+iHK
+iVT
+rdk
 aaa
 aaa
 aaa
@@ -121966,14 +122148,14 @@ bWL
 cSU
 aab
 aab
-dgc
+rdk
 hRS
-dgc
-doE
-doE
-aaa
-aaa
-aaa
+mBx
+mJr
+jGB
+jGB
+izz
+xsH
 aaa
 aaa
 aaa
@@ -122223,14 +122405,14 @@ cSU
 cSU
 cSU
 cSU
-dgc
+rdk
 cWW
-dgc
-dgc
-doE
-aaa
-aaa
-aaa
+mBx
+iHK
+dTy
+sdS
+edP
+tkU
 aaa
 aaa
 aaa
@@ -122477,19 +122659,19 @@ qJO
 cSU
 bYQ
 cSU
-udO
-eZi
 cSU
-bQq
+gnB
+xot
+rdk
 ujG
 uOG
 dgc
-dcq
+bix
+krk
+hnA
+rdk
 aaa
-aab
-aab
-aab
-aab
+aaa
 aaa
 aaa
 aaa
@@ -122734,17 +122916,17 @@ cSU
 cSU
 fdz
 jeb
-pgT
-qVp
 cSU
-bQq
-ujG
+hea
+hea
+pzK
+noc
 rmu
-xvS
+hie
 dgS
 dgS
 dgS
-bSf
+dgS
 dgS
 dgS
 dgS
@@ -122991,13 +123173,13 @@ cTl
 cUu
 sLe
 cEy
-wox
-sdE
 cSU
+bQq
+bQq
 bWT
 cZg
 wJg
-dcq
+hAe
 dzg
 liX
 qKX
@@ -123248,13 +123430,13 @@ mfv
 cSU
 dbZ
 cSU
-kvn
-jVD
 cSU
-ddt
-gKF
-dhL
-otr
+jVD
+ddr
+bQq
+cZg
+wJg
+hAe
 dzg
 ncY
 irV
@@ -123504,13 +123686,13 @@ cfo
 cfo
 dDB
 bTa
+okk
 cSU
-cSU
-cSU
-cSU
-bQq
-ddr
-ddr
+gwD
+qZB
+qZB
+cZg
+wJg
 oSG
 dzg
 dpY
@@ -123759,15 +123941,15 @@ feH
 dmL
 dmL
 dmL
-cui
-cxd
+wDt
+dmL
+dmL
 cSU
-gnB
-jGR
-hea
+lgN
+mEl
 drh
-ddr
-ddr
+cZg
+wJg
 dzg
 dzg
 bOE
@@ -124019,10 +124201,10 @@ cSU
 cSU
 cSU
 cSU
-hea
-hea
-hea
+cSU
+qZB
 ddr
+qZB
 dgq
 nIX
 rix
@@ -124530,15 +124712,15 @@ sAe
 dkH
 rZd
 djb
-dcq
+cSU
 xCz
 sOi
 skh
 jAY
-bWT
+lgN
 ddr
 wzQ
-ddr
+oXj
 dzg
 mpV
 cQS
@@ -124782,9 +124964,9 @@ enk
 dqE
 uES
 dts
-dmL
-dfo
-bzm
+cfo
+pxk
+eor
 eWH
 nBq
 dar
@@ -124794,8 +124976,8 @@ dar
 dar
 dar
 dar
-wzQ
-hGQ
+jau
+sLy
 dgS
 dgS
 dgS
@@ -125052,7 +125234,7 @@ stu
 stu
 dar
 dev
-sLy
+xvS
 dcq
 lGD
 kak
@@ -125566,8 +125748,8 @@ pRq
 pRq
 dar
 iyc
-dcq
-dcq
+cZS
+cZS
 kmr
 cZS
 sRi
@@ -129137,7 +129319,7 @@ cPo
 cOf
 cPo
 rJp
-fjE
+uZx
 cUw
 wWf
 cHk
@@ -129908,15 +130090,15 @@ rdu
 qCi
 cQN
 cSq
-fjE
+uZx
 cUv
 cRP
 vaH
-fjE
+uZx
 cRe
 fqI
-fjE
-fjE
+uZx
+uZx
 vaH
 wZZ
 mmV
@@ -130174,7 +130356,7 @@ dej
 cNX
 cTf
 iHT
-fjE
+uZx
 bQt
 cZU
 cRR
@@ -130425,7 +130607,7 @@ aaa
 cOi
 csN
 cRS
-fjE
+uZx
 pNx
 cHT
 cNV
@@ -130682,7 +130864,7 @@ aab
 uZx
 cQP
 cRV
-fjE
+uZx
 cUs
 mgd
 dac
@@ -130945,7 +131127,7 @@ xdo
 dab
 mtc
 dbJ
-fjE
+uZx
 cQH
 hKe
 vBs
@@ -131194,7 +131376,7 @@ ubo
 bPH
 aaa
 cPs
-txJ
+cPP
 gMc
 cHQ
 cHQ
@@ -132230,7 +132412,7 @@ cHa
 iQt
 rzU
 dbL
-txJ
+cPP
 jZK
 dtv
 cOi
@@ -138660,7 +138842,7 @@ nvN
 rxp
 nvN
 okj
-nvN
+eyA
 dgT
 cWx
 dmz
@@ -139173,7 +139355,7 @@ pOt
 cxO
 doE
 nvN
-ojt
+okj
 nvN
 dhk
 rxp

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -24734,6 +24734,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -32551,7 +32552,9 @@
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 1
 	},
-/obj/structure/curtain/open/shower/engineering,
+/obj/structure/curtain/open/shower/engineering{
+	anchored = 1
+	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "cEz" = (
@@ -32611,7 +32614,9 @@
 	pixel_y = 16
 	},
 /obj/effect/turf_decal/siding/yellow/end,
-/obj/structure/curtain/open/shower/engineering,
+/obj/structure/curtain/open/shower/engineering{
+	anchored = 1
+	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "cES" = (
@@ -38792,6 +38797,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -43755,6 +43761,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -58409,7 +58416,9 @@
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 1
 	},
-/obj/structure/curtain/open/shower/engineering,
+/obj/structure/curtain/open/shower/engineering{
+	anchored = 1
+	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "jer" = (
@@ -74622,9 +74631,9 @@
 	autoclose = 0;
 	heat_proof = 1;
 	id_tag = "turbine_door_ext";
-	locked = 1;
 	superconductivity = 0
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "pcF" = (
@@ -95552,7 +95561,9 @@
 	pixel_y = 16
 	},
 /obj/effect/turf_decal/siding/yellow/end,
-/obj/structure/curtain/open/shower/engineering,
+/obj/structure/curtain/open/shower/engineering{
+	anchored = 1
+	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "wQK" = (
@@ -96913,9 +96924,9 @@
 	autoclose = 0;
 	heat_proof = 1;
 	id_tag = "turbine_door_int";
-	locked = 1;
 	superconductivity = 0
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "xqa" = (

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -33788,7 +33788,8 @@
 /obj/machinery/door_control/shutter/south{
 	desc = "A remote control-switch for the SM Radiation Security Shutters";
 	id = "engsm2";
-	name = "SM Door Radiation Shutters Control"
+	name = "SM Door Radiation Shutters Control";
+	req_access = list(10)
 	},
 /obj/item/clothing/gloves/color/black{
 	pixel_x = -6;
@@ -37161,6 +37162,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "cVM" = (
@@ -48568,7 +48570,7 @@
 	id = "smstorage";
 	name = "Supermatter Storage";
 	pixel_x = 24;
-	req_access = list(32)
+	req_access = list(10)
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -50461,7 +50463,8 @@
 /obj/machinery/door_control/shutter/north{
 	desc = "A remote control-switch for the SM Radiation Security Shutters";
 	id = "engsm2";
-	name = "SM Door Radiation Shutters Control"
+	name = "SM Door Radiation Shutters Control";
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -51901,7 +51904,8 @@
 /obj/machinery/door_control/shutter/south{
 	desc = "A remote control-switch for the SM Radiation Security Shutters";
 	id = "engsm2";
-	name = "SM Door Radiation Shutters Control"
+	name = "SM Door Radiation Shutters Control";
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
@@ -61131,7 +61135,8 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door_control/shutter/east{
 	id = "Singularity";
-	name = "Containment Blast Doors"
+	name = "Containment Blast Doors";
+	req_access = list(10)
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
@@ -65809,7 +65814,8 @@
 	desc = "A remote control-switch for the SM Radiation Security Shutters";
 	id = "engsm2";
 	name = "SM Door Radiation Shutters Control";
-	pixel_y = 5
+	pixel_y = 5;
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69328,7 +69334,8 @@
 /obj/machinery/ignition_switch{
 	id = "Turbine_igniter";
 	pixel_x = 8;
-	pixel_y = -38
+	pixel_y = -38;
+	req_access = list(24)
 	},
 /obj/machinery/computer/security/telescreen/turbine{
 	dir = 8;
@@ -69340,13 +69347,13 @@
 	name = "Turbine Vent Control";
 	pixel_x = -8;
 	pixel_y = -38;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /obj/machinery/door_control/shutter/south{
 	id = "auxincineratorvent";
 	name = "Auxiliary Vent Control";
 	pixel_x = -8;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -69354,6 +69361,16 @@
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
 	id = "incineratorturbine"
+	},
+/obj/machinery/airlock_controller/access_controller{
+	ext_button_link_id = "turbine_btn_ext";
+	ext_door_link_id = "turbine_door_ext";
+	int_button_link_id = "turbine_btn_int";
+	int_door_link_id = "turbine_door_int";
+	name = "Turbine Access Console";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access = list(24)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -74599,22 +74616,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "pcu" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	locked = 1;
-	superconductivity = 0
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/access_button/west{
-	autolink_id = "turbine_btn_int";
-	name = "Gas Turbine Airlock Control"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	locked = 1;
+	superconductivity = 0
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "pcF" = (
@@ -81156,6 +81169,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/access_button/west{
+	autolink_id = "turbine_btn_int";
+	name = "Gas Turbine Airlock Control";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access = list(24)
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "rzA" = (
@@ -81763,7 +81783,8 @@
 	},
 /obj/machinery/door_control/shutter/east{
 	id = "Singularity";
-	name = "Containment Blast Doors"
+	name = "Containment Blast Doors";
+	req_access = list(10)
 	},
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -84418,7 +84439,8 @@
 	},
 /obj/machinery/door_control/shutter/south{
 	id = "engsm";
-	name = "Radiation Shutters Control"
+	name = "Radiation Shutters Control";
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
@@ -93782,6 +93804,13 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/binary/valve,
+/obj/machinery/access_button/west{
+	autolink_id = "turbine_btn_ext";
+	name = "Gas Turbine Airlock Control";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access = list(24)
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "wiG" = (
@@ -96882,28 +96911,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
 	heat_proof = 1;
-	id_tag = "turbine_door_ext";
+	id_tag = "turbine_door_int";
 	locked = 1;
 	superconductivity = 0
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/airlock_controller/access_controller{
-	ext_button_link_id = "turbine_btn_ext";
-	ext_door_link_id = "turbine_door_ext";
-	int_button_link_id = "turbine_btn_int";
-	int_door_link_id = "turbine_door_int";
-	name = "Turbine Access Console";
-	pixel_x = 40;
-	pixel_y = 6
-	},
-/obj/machinery/access_button/west{
-	autolink_id = "turbine_btn_ext";
-	name = "Gas Turbine Airlock Control"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "xqa" = (

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -27895,7 +27895,7 @@
 	name = "Lobby Emergency Supply";
 	pixel_x = 24;
 	pixel_y = 8;
-	req_access = list(32)
+	req_access = list(11)
 	},
 /obj/machinery/door_control/normal/north{
 	desc = "A remote control-switch for the engineering lobby doors.";
@@ -27903,7 +27903,7 @@
 	name = "Lobby Entrance";
 	pixel_x = 24;
 	pixel_y = -8;
-	req_access = list(32)
+	req_access = list(11)
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -36150,7 +36150,7 @@
 	id = "engemergencyeva";
 	name = "Lobby Emergency Supply";
 	pixel_y = 6;
-	req_access = list(32)
+	req_access = list(11)
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
@@ -47616,7 +47616,7 @@
 	int_door_link_id = "eng_s_tesla_door_int";
 	pixel_y = 24;
 	req_access = list(10);
-	vent_link_id = "fpmaint_vent"
+	vent_link_id = "eng_s_vent"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
@@ -82109,7 +82109,7 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "evamaint_vent";
+	autolink_id = "eng_n_vent";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -84475,7 +84475,7 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "evamaint_vent";
+	autolink_id = "eng_s_vent";
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -91088,7 +91088,7 @@
 	int_door_link_id = "eng_n_tesla_door_int";
 	pixel_y = -24;
 	req_access = list(10);
-	vent_link_id = "fpmaint_vent"
+	vent_link_id = "eng_n_vent"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -25128,7 +25128,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZp" = (
-/obj/structure/curtain/open/shower/engineering,
+/obj/structure/curtain/open/shower/engineering{
+	anchored = 1
+	},
 /obj/effect/turf_decal/miscellaneous/plumbing{
 	dir = 1
 	},
@@ -32575,7 +32577,9 @@
 /obj/effect/turf_decal/miscellaneous/plumbing{
 	dir = 1
 	},
-/obj/structure/curtain/open/shower/engineering,
+/obj/structure/curtain/open/shower/engineering{
+	anchored = 1
+	},
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 1
 	},
@@ -64386,6 +64390,7 @@
 	id_tag = "enginen_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "jkP" = (
@@ -80245,9 +80250,9 @@
 	autoclose = 0;
 	heat_proof = 1;
 	id_tag = "turbine_door_int";
-	locked = 1;
 	superconductivity = 0
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "odQ" = (
@@ -89687,6 +89692,7 @@
 	id_tag = "enginen_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "qXy" = (
@@ -93548,6 +93554,7 @@
 	id_tag = "engines_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "siY" = (
@@ -104985,9 +104992,9 @@
 	autoclose = 0;
 	heat_proof = 1;
 	id_tag = "turbine_door_ext";
-	locked = 1;
 	superconductivity = 0
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "vRk" = (
@@ -106412,6 +106419,7 @@
 	id_tag = "engines_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "woQ" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -25632,7 +25632,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "evamaint_vent";
+	autolink_id = "enginen_vent";
 	dir = 4
 	},
 /obj/machinery/light/small/directional/south,
@@ -70600,6 +70600,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"liB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/closet/radiation,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/port)
 "liC" = (
 /obj/machinery/economy/vending/vulpix,
 /obj/effect/turf_decal/delivery,
@@ -70793,7 +70801,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "evamaint_vent";
+	autolink_id = "engines_vent";
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
@@ -106545,6 +106553,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "wrE" = (
@@ -128822,7 +128832,7 @@ cRD
 xCC
 cHA
 sPz
-dvl
+liB
 cJP
 cJV
 tTi
@@ -129079,7 +129089,7 @@ riO
 tJc
 cHA
 iRt
-dvl
+liB
 cJP
 pAC
 gqO

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -64382,7 +64382,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "enginen_door_ext"
 	},
@@ -80238,7 +80237,6 @@
 /area/station/maintenance/aft)
 "odb" = (
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -89685,7 +89683,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "enginen_door_int"
 	},
@@ -93547,7 +93544,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "engines_door_int"
 	},
@@ -100036,12 +100032,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonlockers)
 "ukQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -104987,7 +104977,6 @@
 /area/station/maintenance/starboard)
 "vRj" = (
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -106419,7 +106408,6 @@
 	name = "exterior access button";
 	req_access = list(10)
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "engines_door_ext"
 	},

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -64383,7 +64383,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "enginen_door_ext"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -89666,6 +89668,22 @@
 	},
 /turf/simulated/floor/engine/o2,
 /area/station/engineering/atmos)
+"qXa" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "enginen_door_int"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
 "qXy" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -93522,7 +93540,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "engines_door_int"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -106392,7 +106412,9 @@
 	req_access = list(10)
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "engines_door_ext"
+	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -134431,7 +134453,7 @@ bUm
 bGz
 bXU
 cdd
-siP
+qXa
 bXU
 ceV
 cic

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -412,9 +412,11 @@
 /obj/structure/sign/nosmoking_2{
 	pixel_x = 32
 	},
-/obj/machinery/computer/sm_monitor{
-	dir = 1
+/obj/machinery/computer/monitor{
+	dir = 1;
+	name = "Engineering Power Monitoring Console"
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "vault"
@@ -1126,9 +1128,13 @@
 /area/station/maintenance/old_kitchen)
 "aiV" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance,
-/turf/simulated/floor/plating,
+/obj/structure/sign/radiation/rad_area{
+	pixel_y = -32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "aiX" = (
 /obj/structure/chair{
@@ -2368,26 +2374,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/starboard)
-"apC" = (
-/obj/machinery/door/airlock/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	superconductivity = 0
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/access_button{
-	autolink_id = "turbine_btn_int";
-	name = "Gas Turbine Access Button";
-	pixel_y = 24
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/turf/simulated/floor/engine,
-/area/station/maintenance/turbine)
 "apF" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -6385,13 +6371,13 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door_control/bolt_control/west{
-	id = "smint"
+	id = "smint";
+	req_access = list(10)
 	},
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id_tag = "engsm"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "aDc" = (
@@ -8109,7 +8095,8 @@
 "aJs" = (
 /obj/machinery/door_control/shutter/north{
 	id = "engsm";
-	name = "Radiation Shutters Control"
+	name = "Radiation Shutters Control";
+	req_access = list(10)
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/structure/cable/yellow{
@@ -8285,7 +8272,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "aKa" = (
@@ -8596,7 +8582,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
@@ -9132,7 +9117,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "aOk" = (
@@ -9154,7 +9138,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "aOo" = (
@@ -12123,9 +12106,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "bcq" = (
@@ -16569,7 +16551,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "bvO" = (
@@ -17205,7 +17186,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
 "byy" = (
@@ -18304,8 +18284,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
 "bDe" = (
@@ -18844,7 +18823,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room/secondary)
 "bEK" = (
@@ -19443,6 +19422,9 @@
 "bGE" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 2
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -22526,6 +22508,13 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"bPX" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "bPY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -24623,6 +24612,18 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/paramedic)
+"bXq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "yellow"
+	},
+/area/station/engineering/transmission_laser)
 "bXy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -24797,11 +24798,9 @@
 /turf/simulated/wall,
 /area/station/maintenance/starboard2)
 "bXY" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/fire{
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "bYa" = (
@@ -24823,12 +24822,6 @@
 	icon_state = "dark"
 	},
 /area/station/turret_protected/aisat)
-"bYc" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
 "bYe" = (
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/plasteel{
@@ -25135,9 +25128,15 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZp" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
+/obj/structure/curtain/open/shower/engineering,
+/obj/effect/turf_decal/miscellaneous/plumbing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow/end,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "bZs" = (
 /obj/machinery/atmospherics/portable/canister/air,
@@ -25145,14 +25144,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
-"bZt" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
+"bZt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -25629,9 +25631,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "evamaint_vent";
+	dir = 4
 	},
+/obj/machinery/light/small/directional/south,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cbl" = (
@@ -26194,6 +26198,13 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/machinery/access_button/south{
+	autolink_id = "enginen_btn_int";
+	req_access = list(10);
+	name = "interior access button";
+	pixel_y = 6;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -27040,6 +27051,13 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/access_button/north{
+	autolink_id = "enginen_btn_ext";
+	name = "exterior access button";
+	req_access = list(10);
+	pixel_x = 24;
+	pixel_y = 6
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cgC" = (
@@ -27413,7 +27431,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cib" = (
@@ -28309,7 +28327,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "clp" = (
@@ -28330,7 +28348,7 @@
 /obj/machinery/door_control/shutter/east{
 	id = "Singularity";
 	name = "Containment Blast Doors";
-	req_access = list(32)
+	req_access = list(10)
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -30945,11 +30963,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cxF" = (
+/obj/effect/turf_decal/delivery,
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box{
+/obj/item/storage/firstaid/fire{
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cxG" = (
@@ -31784,12 +31802,18 @@
 /area/station/engineering/control)
 "cAD" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/status_display/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
+	},
+/obj/machinery/access_button/south{
+	autolink_id = "engines_btn_int";
+	name = "interior access button";
+	req_access = list(10);
+	pixel_y = -6;
+	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -32538,15 +32562,24 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cDz" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/turf_decal/delivery,
-/obj/structure/sign/vacuum{
-	pixel_x = -32
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -4
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/miscellaneous/plumbing{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/engineering,
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 1
+	},
+/turf/simulated/floor/noslip,
 /area/station/engineering/control)
 "cDD" = (
 /obj/effect/turf_decal/delivery,
@@ -32559,9 +32592,6 @@
 /obj/machinery/atmospherics/portable/canister/air,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/structure/sign/vacuum{
-	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -32720,7 +32750,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/classic/reversed,
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cEI" = (
@@ -33728,7 +33759,7 @@
 /area/station/maintenance/port)
 "cJP" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/station/service/cafeteria)
 "cJR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36681,16 +36712,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medmaint)
-"cWl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/spawner/random/storage,
-/obj/effect/spawner/random/engineering/toolbox,
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "neutral"
-	},
-/area/station/maintenance/port)
 "cWm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37173,9 +37194,17 @@
 	},
 /area/station/maintenance/medmaint)
 "cXX" = (
-/obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "cXY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37343,7 +37372,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "cYP" = (
@@ -38230,6 +38259,12 @@
 /obj/item/kirbyplants/large/dead,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/old_kitchen)
+"ddp" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "ddr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research,
@@ -40432,6 +40467,13 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/port)
+"doE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "neutral"
+	},
+/area/station/maintenance/port)
 "doJ" = (
 /obj/structure/disaster_counter/scichem{
 	pixel_y = 32
@@ -40556,9 +40598,19 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/robotics)
 "doV" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "doW" = (
 /obj/effect/landmark/start/cyborg,
@@ -41244,6 +41296,7 @@
 /obj/effect/decal/cleanable/dust,
 /obj/structure/sign/poster/random/west,
 /obj/effect/turf_decal/siding/wood/oak/end,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood/oak,
 /area/station/service/cafeteria)
 "drR" = (
@@ -42134,8 +42187,10 @@
 /area/station/science/lobby)
 "dvl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "dvo" = (
 /obj/machinery/r_n_d/circuit_imprinter,
@@ -43145,6 +43200,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -44293,7 +44351,6 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
-/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutral"
@@ -46857,28 +46914,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
-"dVU" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "enginen_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/machinery/access_button/south{
-	autolink_id = "enginen_btn_int";
-	req_access = list(10, 13);
-	name = "interior access button"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
 "dVX" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -48471,6 +48506,7 @@
 "elb" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "elg" = (
@@ -49726,6 +49762,21 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/public/vacant_office/secondary)
+"eEY" = (
+/obj/structure/shelf/engineering,
+/obj/item/clothing/glasses/welding,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/multitool,
+/obj/item/stack/cable_coil,
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "eFB" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -50072,9 +50123,10 @@
 	pixel_x = 6;
 	pixel_y = 6
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "eKx" = (
 /obj/structure/disposalpipe/segment{
@@ -52203,7 +52255,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/ai_transit_tube)
@@ -52340,6 +52391,9 @@
 	icon_state = "dark_large"
 	},
 /area/station/security/interrogation)
+"fvN" = (
+/turf/simulated/wall/r_wall,
+/area/station/service/cafeteria)
 "fwB" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -52797,13 +52851,6 @@
 /obj/machinery/plantgenes,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
-"fEo" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "enginen_vent"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
 "fEG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
@@ -53283,6 +53330,7 @@
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood/oak,
 /area/station/service/cafeteria)
 "fOp" = (
@@ -53385,6 +53433,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/supply/lobby)
+"fPE" = (
+/obj/structure/sign/poster/random/south,
+/obj/machinery/light_switch/west,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "fPF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53803,9 +53859,11 @@
 "fUZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/trash,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "fVI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -57585,6 +57643,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgery/primary)
+"hih" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "hiq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -58428,6 +58492,10 @@
 	icon_state = "darkpurple"
 	},
 /area/station/command/office/rd)
+"hyt" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "hyI" = (
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -58646,13 +58714,6 @@
 	icon_state = "purple"
 	},
 /area/station/maintenance/fsmaint)
-"hBj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
-/turf/simulated/floor/plasteel{
-	icon_state = "neutral"
-	},
-/area/station/maintenance/port)
 "hBk" = (
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/plasteel{
@@ -58997,6 +59058,18 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/morgue)
+"hGf" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "hGs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -59387,9 +59460,9 @@
 	ext_door_link_id = "enginen_door_ext";
 	int_button_link_id = "enginen_btn_int";
 	int_door_link_id = "enginen_door_int";
-	pixel_y = -25;
+	pixel_y = -24;
 	vent_link_id = "enginen_vent";
-	req_access = list(10,13)
+	req_access = list(10)
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -60259,6 +60332,13 @@
 /obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
+/obj/machinery/access_button{
+	autolink_id = "turbine_btn_ext";
+	name = "Gas Turbine Access Button";
+	req_access = list(24);
+	pixel_x = -24;
+	pixel_y = -8
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "ibp" = (
@@ -60811,6 +60891,11 @@
 /obj/effect/landmark/start/magistrate,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/magistrate)
+"ikn" = (
+/obj/effect/mapping_helpers/turfs/rust/maybe,
+/obj/structure/sign/electricshock,
+/turf/simulated/wall,
+/area/station/maintenance/port)
 "ikw" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Virology Work Zone"
@@ -62364,6 +62449,15 @@
 	icon_state = "dark"
 	},
 /area/station/service/bar/atrium)
+"iIw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution";
+	dir = 1
+	},
+/area/station/engineering/transmission_laser)
 "iIC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -62639,6 +62733,16 @@
 /obj/effect/firefly/green,
 /turf/simulated/floor/grass,
 /area/station/science/lobby)
+"iOj" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution";
+	dir = 1
+	},
+/area/station/engineering/transmission_laser)
 "iOp" = (
 /obj/effect/spawner/random/barrier/grille_often,
 /turf/simulated/floor/plating,
@@ -62711,16 +62815,11 @@
 /area/station/maintenance/dormitory_maintenance)
 "iPk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/vodka{
-	pixel_y = 32
-	},
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "iPy" = (
 /obj/structure/disposalpipe/segment{
@@ -62746,6 +62845,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/left,
 /obj/item/reagent_containers/drinks/bottle/vodka,
+/obj/structure/sign/poster/contraband/vodka{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "iQi" = (
@@ -62844,9 +62946,17 @@
 /area/station/engineering/hardsuitstorage)
 "iRt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/trash,
 /obj/machinery/light/small/directional/north,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "iRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -63605,6 +63715,15 @@
 	},
 /turf/simulated/floor/wood/cherry,
 /area/station/service/chapel/office)
+"jdX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution";
+	dir = 1
+	},
+/area/station/engineering/transmission_laser)
 "jep" = (
 /obj/structure/railing{
 	dir = 8
@@ -64258,22 +64377,14 @@
 /turf/simulated/floor/wood/cherry,
 /area/station/service/chapel/office)
 "jkM" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "enginen_door_ext"
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/machinery/access_button/north{
-	autolink_id = "enginen_btn_ext";
-	name = "exterior access button";
-	req_access = list(10,13)
-	},
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "jkP" = (
@@ -64328,7 +64439,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "jmD" = (
@@ -65542,14 +65652,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/old_kitchen)
-"jEI" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "engines_vent";
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/control)
 "jEZ" = (
 /obj/machinery/atmospherics/portable/canister/nitrogen,
 /obj/machinery/light/directional/north,
@@ -65630,8 +65732,16 @@
 	},
 /area/station/service/chapel/funeral)
 "jGT" = (
-/obj/effect/spawner/random/trash,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -66120,6 +66230,10 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/permabrig)
+"jOs" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/transmission_laser)
 "jOu" = (
 /obj/machinery/turretid/stun{
 	name = "AI Upload Turret Control";
@@ -66580,6 +66694,15 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/port)
+"jUA" = (
+/obj/machinery/light,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "jUG" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -66735,6 +66858,15 @@
 	},
 /turf/space,
 /area/space)
+"jXk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "jXC" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
@@ -66941,6 +67073,12 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"kaF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "kaG" = (
 /obj/effect/turf_decal/siding/white,
 /turf/simulated/floor/plasteel/freezer,
@@ -68147,6 +68285,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/legal/courtroom)
+"kvj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "kvm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -68486,7 +68630,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "kAK" = (
@@ -69236,13 +69379,11 @@
 /area/station/science/misc_lab)
 "kNF" = (
 /obj/machinery/status_display/directional/south,
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "Engineering Power Monitoring Console"
-	},
-/obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/computer/sm_monitor{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69688,6 +69829,16 @@
 	icon_state = "redbluefull"
 	},
 /area/station/maintenance/fore)
+"kVZ" = (
+/obj/machinery/alarm/directional/east,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "kWa" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -69721,6 +69872,10 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/carpet,
 /area/station/security/permabrig)
+"kWk" = (
+/obj/effect/mapping_helpers/turfs/rust/maybe,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "kWx" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -70372,9 +70527,6 @@
 	},
 /area/station/medical/virology)
 "lhJ" = (
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -70638,9 +70790,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "evamaint_vent";
+	dir = 4
 	},
+/obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "llR" = (
@@ -72952,6 +73106,13 @@
 	icon_state = "greenblue"
 	},
 /area/station/maintenance/abandoned_garden)
+"lUI" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "yellow"
+	},
+/area/station/engineering/transmission_laser)
 "lVg" = (
 /obj/docking_port/stationary{
 	dwidth = 8;
@@ -73390,6 +73551,15 @@
 	icon_state = "vault"
 	},
 /area/station/maintenance/port)
+"mdW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "mel" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -74529,7 +74699,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "mxB" = (
@@ -75490,24 +75659,26 @@
 	name = "Turbine Access Console";
 	pixel_x = 8;
 	pixel_y = -26;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /obj/machinery/ignition_switch{
 	id = "Incinerator";
 	pixel_x = 8;
-	pixel_y = -36
+	pixel_y = -36;
+	req_access = list(24)
 	},
 /obj/machinery/door_control/shutter{
 	id = "turbinevent";
 	name = "Turbine Vent Control";
 	pixel_x = -8;
 	pixel_y = -36;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /obj/machinery/door_control/shutter/south{
 	id = "auxincineratorvent";
 	name = "Auxiliary Vent Control";
-	pixel_x = -8
+	pixel_x = -8;
+	req_access = list(24)
 	},
 /obj/machinery/computer/turbine_computer{
 	dir = 1;
@@ -77037,6 +77208,10 @@
 /obj/effect/mapping_helpers/airlock/polarized,
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/public/vacant_office/secondary)
+"nnT" = (
+/obj/effect/spawner/random/fungus/maybe,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/port)
 "nnZ" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -79202,6 +79377,9 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "nRz" = (
@@ -79978,6 +80156,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"ock" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "ocr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -81953,6 +82141,10 @@
 	},
 /turf/simulated/floor/plasteel/dark/telecomms,
 /area/station/science/server/coldroom)
+"oKF" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "oKN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82414,6 +82606,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/science/research)
+"oRQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "oSb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -83496,6 +83697,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
+"pja" = (
+/obj/machinery/power/transmission_laser/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/station/engineering/transmission_laser)
 "pjk" = (
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
@@ -83547,6 +83762,9 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/storage/secondary)
+"pjT" = (
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "pka" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
@@ -84289,6 +84507,16 @@
 	icon_state = "dark_large"
 	},
 /area/station/security/armory/secure)
+"puc" = (
+/obj/machinery/power/apc/directional/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "pup" = (
 /obj/machinery/computer/card/minor/rd{
 	dir = 1
@@ -84628,6 +84856,7 @@
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood/oak,
 /area/station/service/cafeteria)
 "pAK" = (
@@ -85419,7 +85648,6 @@
 "pMy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa/right,
-/obj/effect/spawner/random/maintenance,
 /obj/structure/sign/poster/ripped{
 	pixel_y = 32
 	},
@@ -85914,6 +86142,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"pVT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/engineering{
+	pixel_x = -32
+	},
+/obj/effect/spawner/random/storage,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "pWb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -86225,6 +86463,9 @@
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "qbb" = (
@@ -86523,6 +86764,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"qgg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/transmission_laser)
 "qgl" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt,
@@ -86730,6 +86980,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/legal/magistrate)
+"qiI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "qjl" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -87160,6 +87425,22 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/medbay)
+"qqd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/port)
 "qqe" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -87239,9 +87520,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/ai_transit_tube)
 "qrT" = (
@@ -88309,7 +88590,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "qIl" = (
@@ -92060,6 +92341,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/patients_rooms)
+"rQX" = (
+/obj/machinery/camera{
+	c_tag = "Power Transmission Laser";
+	dir = 1;
+	network = list("Engineering","SS13")
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "rQZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -92871,8 +93162,8 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/mechanic)
 "sdr" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "sdI" = (
@@ -93206,9 +93497,6 @@
 	},
 /area/station/medical/morgue)
 "siP" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "engines_door_int"
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -93217,14 +93505,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/access_button/south{
-	autolink_id = "engines_btn_int";
-	name = "interior access button";
-	req_access = list(10,13)
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "siY" = (
@@ -93311,6 +93594,13 @@
 "skK" = (
 /turf/simulated/floor/engine,
 /area/station/maintenance/starboard2)
+"skS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/control)
 "skW" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood/oak,
@@ -93945,6 +94235,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"stL" = (
+/obj/structure/sign/radiation/rad_area,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "stW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -94433,9 +94727,10 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "sAA" = (
-/obj/effect/spawner/random/trash,
-/obj/effect/spawner/random/trash,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "sAG" = (
 /obj/structure/cable{
@@ -95119,6 +95414,21 @@
 /obj/machinery/firealarm/directional/north,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
+"sKL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "sKM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -95374,7 +95684,16 @@
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/port)
 "sPI" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
@@ -97102,6 +97421,10 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/locker)
+"trQ" = (
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "trS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -98706,6 +99029,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison/cell_block/a)
+"tVn" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "tVH" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -99661,6 +99991,21 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonlockers)
+"ukQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "ukR" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -99791,6 +100136,18 @@
 	},
 /turf/simulated/floor/plasteel/freezer,
 /area/station/security/permabrig)
+"umT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/port)
 "umY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -100607,6 +100964,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood/oak,
 /area/station/service/cafeteria)
 "uBS" = (
@@ -100814,6 +101172,15 @@
 /obj/machinery/light_switch/north,
 /turf/simulated/floor/wood/fancy,
 /area/station/public/sleep_female)
+"uGN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "yellow"
+	},
+/area/station/engineering/transmission_laser)
 "uGY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -101955,9 +102322,9 @@
 	ext_door_link_id = "engines_door_ext";
 	int_button_link_id = "engines_btn_int";
 	int_door_link_id = "engines_door_int";
-	pixel_y = 25;
+	pixel_y = 24;
 	vent_link_id = "engines_vent";
-	req_access = list(10,13)
+	req_access = list(10)
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -103596,10 +103963,17 @@
 /area/station/science/break_room)
 "vzZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -103641,6 +104015,11 @@
 "vBg" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/warden)
+"vBh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/status_display/directional/south,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
 "vBO" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -103980,7 +104359,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "vHE" = (
@@ -104564,23 +104942,19 @@
 	},
 /area/station/maintenance/starboard)
 "vRj" = (
-/obj/machinery/door/airlock/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_ext";
-	superconductivity = 0
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/access_button{
-	autolink_id = "turbine_btn_ext";
-	name = "Gas Turbine Access Button";
-	pixel_y = 24
-	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	locked = 1;
+	superconductivity = 0
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "vRk" = (
@@ -105123,6 +105497,18 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/medbay)
+"vYU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "caution";
+	dir = 1
+	},
+/area/station/engineering/transmission_laser)
 "vZE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -105617,6 +106003,12 @@
 	},
 /turf/simulated/floor/noslip,
 /area/station/engineering/controlroom)
+"whl" = (
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "whM" = (
 /obj/structure/safe/floor,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -105973,9 +106365,6 @@
 /turf/simulated/floor/light/blue,
 /area/station/maintenance/old_kitchen)
 "wou" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "engines_door_ext"
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -105984,11 +106373,11 @@
 /obj/machinery/access_button/north{
 	autolink_id = "engines_btn_ext";
 	name = "exterior access button";
-	req_access = list(10,13)
+	req_access = list(10)
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "woQ" = (
@@ -106114,6 +106503,12 @@
 	icon_state = "neutral"
 	},
 /area/station/public/pool)
+"wrg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/port)
 "wrE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm/directional/south,
@@ -108567,6 +108962,11 @@
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
 /area/station/maintenance/library)
+"xdr" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
+/area/station/engineering/transmission_laser)
 "xdE" = (
 /obj/machinery/shieldwallgen,
 /obj/structure/cable,
@@ -108910,6 +109310,10 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/restroom)
+"xkz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "xkE" = (
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -110270,6 +110674,19 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
+"xFW" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/space/nearstation)
 "xGf" = (
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor/plasteel{
@@ -110696,6 +111113,9 @@
 	icon_state = "brown"
 	},
 /area/station/supply/storage)
+"xLb" = (
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "xLg" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -111812,6 +112232,13 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/atmospherics/meter,
 /obj/machinery/light_switch/west,
+/obj/machinery/access_button{
+	autolink_id = "turbine_btn_int";
+	name = "Gas Turbine Access Button";
+	req_access = list(24);
+	pixel_y = -8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -111956,14 +112383,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
-"ygB" = (
-/obj/effect/spawner/random/trash,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "neutral"
-	},
-/area/station/maintenance/port)
 "ygI" = (
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "Secure Gate";
@@ -125289,7 +125708,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaZ
 aaa
 aaa
 aaa
@@ -125535,7 +125954,7 @@ aaa
 aaa
 aaa
 aaa
-aaZ
+aaa
 aaa
 aaa
 aaa
@@ -125790,13 +126209,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xLb
+xLb
+stL
+jOs
+trQ
+xLb
+xLb
 aaa
 aaa
 aaa
@@ -126047,13 +126466,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xLb
+eEY
+whl
+bPX
+whl
+fPE
+xLb
 aaa
 aaa
 aaa
@@ -126304,13 +126723,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xLb
+jdX
+kvj
+qgg
+hih
+xdr
+xLb
 aaa
 aaa
 aaa
@@ -126561,13 +126980,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xLb
+iOj
+uGN
+pjT
+lUI
+rQX
+xLb
 aaa
 aaa
 aaa
@@ -126818,13 +127237,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
+hyt
+vYU
+bXq
+kaF
+pja
+jUA
+hyt
 abj
 aaa
 aaa
@@ -127075,13 +127494,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abj
-abj
+xLb
+iIw
+xkz
+xkz
+oRQ
+hGf
+xLb
 pyi
 pyi
 pWq
@@ -127332,13 +127751,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-abj
-abj
-abj
-abj
-pyi
+xLb
+puc
+kVZ
+jXk
+qiI
+mdW
+xLb
 pyi
 cHo
 dXl
@@ -127589,13 +128008,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-dmq
-dmq
-riO
-cHA
-tJc
-pyi
+xLb
+xLb
+xLb
+kWk
+sKL
+ukQ
+xLb
 gkb
 dbg
 gJW
@@ -127849,10 +128268,10 @@ cRD
 cRD
 cRD
 xCC
-tJc
+ikn
 cXX
 aiV
-pyi
+fvN
 vlQ
 tTi
 dmU
@@ -128107,7 +128526,7 @@ cUQ
 vUu
 cIu
 elb
-dvl
+cXX
 dvl
 cJP
 ddc
@@ -128365,7 +128784,7 @@ cRD
 xCC
 cHA
 sPz
-dsr
+dvl
 cJP
 cJV
 tTi
@@ -128622,7 +129041,7 @@ riO
 tJc
 cHA
 iRt
-hBj
+dvl
 cJP
 pAC
 gqO
@@ -128878,9 +129297,9 @@ cie
 bXU
 pMy
 qfG
-oJn
+umT
 eKn
-pyi
+fvN
 xaR
 weu
 mOW
@@ -129135,9 +129554,9 @@ bXU
 jzw
 iPQ
 dIL
-dvl
+cXX
 fUZ
-pyi
+fvN
 dIb
 nBP
 fOe
@@ -129388,12 +129807,12 @@ gSE
 bXU
 cie
 cie
-cie
-bXU
+xFW
+tVn
 iPk
 sAA
-dvl
-tJc
+qqd
+wrg
 cJP
 rkV
 rkV
@@ -129627,7 +130046,7 @@ csr
 aaa
 bXU
 bXU
-cbb
+oKF
 abj
 aaa
 cmC
@@ -129645,13 +130064,13 @@ aaa
 cJd
 aaa
 abj
-cbb
+skS
 jzw
 riO
 lhJ
-ygB
-cMS
-cWl
+cXX
+nnT
+riO
 drn
 drn
 drn
@@ -129902,13 +130321,13 @@ cJe
 cOm
 aaa
 cbb
-cbb
+ddp
 cDx
 bXU
-tJc
+riO
 doV
-cMS
-czF
+nnT
+doE
 pWT
 lRD
 dpP
@@ -130160,9 +130579,9 @@ czw
 abj
 cCg
 cbb
-cDx
+ock
 bXU
-dhG
+pVT
 jGT
 luU
 drn
@@ -131387,7 +131806,7 @@ aLr
 aGY
 leZ
 jJU
-apC
+vRj
 huh
 leZ
 aZY
@@ -133738,7 +134157,7 @@ bRZ
 bUl
 dfU
 bXU
-fEo
+bZp
 cbi
 cdd
 ceU
@@ -133756,9 +134175,9 @@ cib
 cib
 cib
 dWi
-bXU
+cdd
 llJ
-jEI
+cDz
 jzw
 fzF
 dsr
@@ -133996,7 +134415,7 @@ bUm
 bGz
 bXU
 cdd
-dVU
+siP
 bXU
 ceV
 cic
@@ -134015,7 +134434,7 @@ cjP
 ceV
 bXU
 siP
-bXU
+cdd
 bXU
 vpq
 drn
@@ -134508,7 +134927,7 @@ bQk
 bSc
 bUo
 bWo
-bYc
+cDD
 bZt
 cbl
 cdf
@@ -134529,7 +134948,7 @@ nmg
 czk
 cAE
 cCm
-cdh
+vBh
 bXU
 vPi
 cXU

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -80226,6 +80226,22 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/aft)
+"odb" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_int";
+	locked = 1;
+	superconductivity = 0
+	},
+/turf/simulated/floor/engine,
+/area/station/maintenance/turbine)
 "odQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -131806,7 +131822,7 @@ aLr
 aGY
 leZ
 jJU
-vRj
+odb
 huh
 leZ
 aZY

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -44484,11 +44484,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/door/airlock/atmos/glass{
 	autoclose = 0;
-	id_tag = "atmossm_door_ext";
-	locked = 1
+	id_tag = "atmossm_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -48790,8 +48790,7 @@
 "gZP" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
-	id_tag = "enginesm_door_ext";
-	locked = 1
+	id_tag = "enginesm_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -48804,6 +48803,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -51696,8 +51696,7 @@
 "isB" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
-	id_tag = "enginesm_door_int";
-	locked = 1
+	id_tag = "enginesm_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -51710,6 +51709,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -53373,14 +53373,14 @@
 "jnF" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
-	id_tag = "enginesm_door_int";
-	locked = 1
+	id_tag = "enginesm_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -54687,11 +54687,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/door/airlock/atmos/glass{
 	autoclose = 0;
-	id_tag = "atmossm_door_int";
-	locked = 1
+	id_tag = "atmossm_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "jTK" = (
@@ -62681,11 +62681,11 @@
 /area/station/maintenance/fsmaint)
 "nEU" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "engine_door_int";
-	locked = 1
+	id_tag = "engine_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "nFf" = (
@@ -62717,11 +62717,11 @@
 /area/station/command/office/rd)
 "nFZ" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "engine_door_ext";
-	locked = 1
+	id_tag = "engine_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "nGj" = (
@@ -81285,14 +81285,14 @@
 "xxi" = (
 /obj/machinery/door/airlock/engineering/glass{
 	autoclose = 0;
-	id_tag = "enginesm_door_ext";
-	locked = 1
+	id_tag = "enginesm_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -531,7 +531,6 @@
 /area/station/maintenance/fore)
 "agj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -648,14 +647,6 @@
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/fire{
 	pixel_x = 32
-	},
-/obj/machinery/access_button{
-	layer = 3.1;
-	autolink_id = "turbine_btn_int";
-	name = "Gas Turbine Airlock Control";
-	pixel_x = -5;
-	pixel_y = -23;
-	req_access = list(24)
 	},
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/engine,
@@ -18070,6 +18061,14 @@
 	pixel_x = -8;
 	req_access = list(24)
 	},
+/obj/machinery/access_button{
+	layer = 3.1;
+	autolink_id = "turbine_btn_int";
+	name = "Gas Turbine Airlock Control";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access = list(24)
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "bum" = (
@@ -30520,7 +30519,6 @@
 /area/station/engineering/atmos/control)
 "cmF" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -31010,6 +31008,16 @@
 	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/airlock_controller/access_controller{
+	name = "Turbine Access Console";
+	pixel_x = 8;
+	pixel_y = -24;
+	ext_door_link_id = "turbine_door_ext";
+	int_door_link_id = "turbine_door_int";
+	ext_button_link_id = "turbine_btn_ext";
+	int_button_link_id = "turbine_btn_int";
+	req_access = list(24)
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "cov" = (
@@ -41311,25 +41319,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
 	heat_proof = 1;
-	id_tag = "turbine_door_ext";
+	id_tag = "turbine_door_int";
 	locked = 1;
 	superconductivity = 0
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/airlock_controller/access_controller{
-	name = "Turbine Access Console";
-	pixel_x = 40;
-	pixel_y = 8;
-	ext_door_link_id = "turbine_door_ext";
-	int_door_link_id = "turbine_door_int";
-	ext_button_link_id = "turbine_btn_ext";
-	int_button_link_id = "turbine_btn_int";
-	req_access = list(24)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "dmr" = (
@@ -42089,6 +42087,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/command/office/hos)
+"dHG" = (
+/obj/structure/closet/radiation,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "dHU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -52735,15 +52737,15 @@
 /obj/structure/sign/fire{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1
+	},
 /obj/machinery/access_button{
 	autolink_id = "turbine_btn_ext";
 	name = "Gas Turbine Airlock Control";
-	pixel_x = 5;
-	pixel_y = 23;
+	pixel_x = 8;
+	pixel_y = -24;
 	req_access = list(24)
-	},
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 1
 	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
@@ -52934,6 +52936,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/legal/courtroom)
+"iUw" = (
+/obj/effect/mapping_helpers/turfs/rust/probably,
+/obj/structure/sign/radiation/rad_area,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "iUC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57107,18 +57114,18 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "lee" = (
-/obj/machinery/door/airlock/public/glass{
-	autoclose = 0;
-	heat_proof = 1;
-	id_tag = "turbine_door_int";
-	locked = 1;
-	superconductivity = 0
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/machinery/door/airlock/public/glass{
+	autoclose = 0;
+	heat_proof = 1;
+	id_tag = "turbine_door_ext";
+	locked = 1;
+	superconductivity = 0
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "leh" = (
@@ -60012,8 +60019,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
 "mtB" = (
-/obj/structure/sign/radiation/rad_area,
-/turf/simulated/wall/r_wall,
+/obj/structure/closet/radiation,
+/obj/machinery/light/small/directional/south,
+/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "mtV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -61590,19 +61598,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/public/construction)
-"nfj" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/drinks/bottle/beer{
-	desc = "Takes you to a whole new level of thinking.";
-	name = "Meta-Cider"
-	},
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/catwalk,
-/area/station/maintenance/fsmaint)
 "nfk" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/binary/pump/on{
@@ -65282,6 +65277,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/closet,
+/obj/item/reagent_containers/drinks/bottle/beer{
+	desc = "Takes you to a whole new level of thinking.";
+	name = "Meta-Cider"
+	},
+/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "pfh" = (
@@ -77208,7 +77209,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 9
 	},
-/obj/machinery/light/small/directional/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -127837,7 +127837,7 @@ atX
 aul
 avM
 ayA
-nfj
+dKL
 hAn
 afY
 aCg
@@ -128096,7 +128096,7 @@ asU
 jlM
 dKL
 bfb
-cbc
+dHG
 aCg
 nZj
 nYI
@@ -128354,7 +128354,7 @@ kmb
 blA
 vmv
 mtB
-aaa
+aBZ
 aaa
 aef
 szY
@@ -128610,8 +128610,8 @@ uJn
 uJn
 vnQ
 vAN
-ksb
-aaa
+iUw
+aBZ
 aaa
 aef
 aef

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -41325,9 +41325,9 @@
 	autoclose = 0;
 	heat_proof = 1;
 	id_tag = "turbine_door_int";
-	locked = 1;
 	superconductivity = 0
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "dmr" = (
@@ -57123,9 +57123,9 @@
 	autoclose = 0;
 	heat_proof = 1;
 	id_tag = "turbine_door_ext";
-	locked = 1;
 	superconductivity = 0
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "leh" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -654,7 +654,8 @@
 	autolink_id = "turbine_btn_int";
 	name = "Gas Turbine Airlock Control";
 	pixel_x = -5;
-	pixel_y = -23
+	pixel_y = -23;
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/binary/pump/on,
 /turf/simulated/floor/engine,
@@ -2563,7 +2564,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -3083,10 +3084,16 @@
 /area/station/engineering/gravitygenerator)
 "avg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "avk" = (
 /obj/structure/cable/yellow{
@@ -3611,7 +3618,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "axe" = (
@@ -3919,9 +3926,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3947,7 +3951,7 @@
 "ayA" = (
 /obj/structure/sign/electricshock,
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/solar_maintenance/port)
 "ayB" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -4005,9 +4009,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
@@ -4105,7 +4106,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -4125,10 +4129,11 @@
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
@@ -4137,7 +4142,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "azs" = (
 /obj/structure/cable/yellow{
@@ -4146,12 +4151,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "azu" = (
@@ -4365,11 +4367,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/engineering{
+	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -4380,13 +4382,16 @@
 /area/station/public/sleep)
 "aAK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "aAM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4874,7 +4879,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/equipment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "aDc" = (
@@ -4913,6 +4918,9 @@
 /area/station/maintenance/fsmaint)
 "aDi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -5246,12 +5254,6 @@
 /area/station/maintenance/fsmaint)
 "aEy" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/classic/normal{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/construction{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "aEz" = (
@@ -6589,7 +6591,7 @@
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/tech_storage,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/equipment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hardsuitstorage)
 "aJT" = (
@@ -7841,7 +7843,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "aOd" = (
@@ -9759,7 +9761,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -11064,7 +11066,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/smes)
 "aZN" = (
@@ -11228,13 +11230,16 @@
 	},
 /area/station/public/locker)
 "bag" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "bai" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -11803,9 +11808,6 @@
 "bcd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/girder,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12926,7 +12928,16 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "bfc" = (
 /obj/structure/window/reinforced,
@@ -15155,7 +15166,10 @@
 /area/station/engineering/ai_transit_tube)
 "blA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "blB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15422,7 +15436,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery/hollow,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/equipment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "bmi" = (
@@ -18054,7 +18068,7 @@
 	id = "turbinevent";
 	name = "Turbine Vent Control";
 	pixel_x = -8;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -19250,6 +19264,7 @@
 /area/station/turret_protected/aisat/interior)
 "bxA" = (
 /obj/item/wrench,
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -23498,7 +23513,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/equipment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "bNh" = (
@@ -27800,6 +27815,12 @@
 	dir = 1;
 	name = "Atmos to Loop"
 	},
+/obj/machinery/access_button/west{
+	autolink_id = "atmossm_btn_int";
+	name = "Atmospherics Access Button";
+	req_access = list(24);
+	pixel_y = -24
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "ccz" = (
@@ -28053,7 +28074,7 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "cdw" = (
@@ -28155,7 +28176,7 @@
 	},
 /obj/machinery/door/airlock/atmos,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	dir = 10;
 	icon_state = "caution"
@@ -28724,7 +28745,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/atmos,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "cfR" = (
@@ -30963,7 +30984,8 @@
 /obj/machinery/ignition_switch{
 	id = "Turbine_igniter";
 	pixel_x = 8;
-	pixel_y = -36
+	pixel_y = -36;
+	req_access = list(24)
 	},
 /obj/machinery/computer/security/telescreen/turbine{
 	dir = 8;
@@ -30979,13 +31001,13 @@
 	name = "Turbine Vent Control";
 	pixel_x = -8;
 	pixel_y = -36;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /obj/machinery/door_control/shutter/south{
 	id = "auxincineratorvent";
 	name = "Auxiliary Vent Control";
 	pixel_x = -8;
-	req_access = list(12)
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
@@ -37233,6 +37255,12 @@
 	icon_state = "dark"
 	},
 /area/station/security/execution)
+"cNp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "cNs" = (
 /obj/structure/chair,
 /turf/simulated/floor/plasteel{
@@ -38373,12 +38401,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "cSy" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
-	},
-/turf/simulated/wall,
-/area/space/nearstation)
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "cSG" = (
 /obj/machinery/atmospherics/binary/valve,
 /obj/effect/turf_decal/stripes/line{
@@ -41148,6 +41173,18 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/exam_room)
+"dit" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fsmaint)
 "diG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -41218,6 +41255,23 @@
 	icon_state = "whiteblue"
 	},
 /area/station/security/permabrig)
+"dko" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/access_button{
+	autolink_id = "engine_btn_int";
+	name = "interior access button";
+	pixel_x = -24;
+	req_access = list(10);
+	pixel_y = -24
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "dkq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -41272,9 +41326,10 @@
 	ext_door_link_id = "turbine_door_ext";
 	int_door_link_id = "turbine_door_int";
 	ext_button_link_id = "turbine_btn_ext";
-	int_button_link_id = "turbine_btn_int"
+	int_button_link_id = "turbine_btn_int";
+	req_access = list(24)
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "dmr" = (
@@ -41562,7 +41617,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/wire_splicing/thirty,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "dtE" = (
 /turf/simulated/wall/r_wall,
@@ -41658,14 +41713,17 @@
 	},
 /area/station/medical/surgery/observation)
 "dxe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/directional/south,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "dxh" = (
 /obj/machinery/door/airlock/public/glass,
@@ -42092,8 +42150,10 @@
 /area/station/maintenance/maintcentral)
 "dKL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "dLg" = (
 /obj/item/rack_parts,
@@ -42130,6 +42190,16 @@
 	icon_state = "white"
 	},
 /area/station/science/lobby)
+"dNx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/east{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "dNU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42372,6 +42442,12 @@
 	c_tag = "Engineering - Central";
 	dir = 8
 	},
+/obj/machinery/access_button/west{
+	autolink_id = "enginesm_btn_ext";
+	name = "Supermatter Access Button";
+	pixel_x = 24;
+	req_access = list(10)
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "dTT" = (
@@ -42436,6 +42512,18 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
+"dVg" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fsmaint)
 "dVk" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -42515,6 +42603,14 @@
 /obj/machinery/atmospherics/meter,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
+"dXe" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "dXu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -42859,22 +42955,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	autolink_id = "atmossouth_vent"
-	},
 /obj/structure/sign/vacuum/external{
 	pixel_y = 32
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_x = 9;
-	pixel_y = -25;
-	vent_link_id = "atmossouth_vent";
-	ext_door_link_id = "atmossouth_door_ext";
-	int_door_link_id = "atmossouth_door_int";
-	ext_button_link_id = "atmossouth_btn_ext";
-	int_button_link_id = "atmossouth_btn_int"
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "efG" = (
@@ -43576,6 +43660,14 @@
 "ewk" = (
 /turf/simulated/floor/grass/no_creep,
 /area/station/medical/virology)
+"exb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "exm" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -43788,9 +43880,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44059,11 +44148,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"eKV" = (
-/obj/structure/lattice/catwalk,
-/obj/item/barcodescanner,
-/turf/space,
-/area/space/nearstation)
 "eKW" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -44276,6 +44360,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"eQG" = (
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "eRc" = (
 /obj/machinery/economy/vending/coffee,
 /turf/simulated/floor/plasteel{
@@ -44398,12 +44486,7 @@
 	locked = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button/east{
-	autolink_id = "atmossm_btn_ext";
-	name = "Atmospherics Access Button";
-	req_access = list(24)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -45325,13 +45408,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "fqO" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
@@ -45422,6 +45505,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -46744,21 +46830,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
-"fZt" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "atmossouth_door_ext";
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "atmossouth_btn_ext";
-	name = "exterior access button";
-	pixel_y = -24;
-	req_access = list(24,13)
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
 "fZU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -47075,7 +47146,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "ggM" = (
 /obj/structure/toilet{
@@ -47561,7 +47641,7 @@
 	superconductivity = 0
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "gvN" = (
@@ -47590,7 +47670,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/port)
 "gxC" = (
@@ -47958,6 +48038,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -48337,7 +48420,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/control)
 "gRF" = (
@@ -48552,13 +48635,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/machinery/airlock_controller/access_controller{
-	name = "Supermatter Access Console";
-	ext_door_link_id = "enginesm_door_ext";
-	int_door_link_id = "enginesm_door_int";
-	pixel_x = -22;
-	ext_button_link_id = "enginesm_btn_ext";
-	int_button_link_id = "enginesm_btn_int"
+/obj/machinery/access_button/east{
+	autolink_id = "enginesm_btn_int";
+	name = "Supermatter Access Button";
+	pixel_x = -24;
+	req_access = list(10)
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -48720,7 +48801,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -48877,7 +48958,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/directional/north,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "heJ" = (
 /obj/machinery/atmospherics/unary/outlet_injector/on{
@@ -48892,6 +48973,12 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/access_button/east{
+	autolink_id = "atmossm_btn_ext";
+	name = "Atmospherics Access Button";
+	req_access = list(24);
+	pixel_y = 24
 	},
 /turf/simulated/floor/plasteel{
 	dir = 9;
@@ -49240,6 +49327,18 @@
 	},
 /turf/simulated/floor/engine/co2,
 /area/station/engineering/atmos)
+"hnp" = (
+/obj/machinery/power/transmission_laser/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
 "hnq" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/rack,
@@ -49275,6 +49374,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/test_chamber)
+"hnH" = (
+/obj/effect/spawner/random/fungus/maybe,
+/turf/simulated/wall,
+/area/station/engineering/gravitygenerator)
 "hnI" = (
 /obj/structure/sink/directional/north,
 /obj/effect/turf_decal/delivery/hollow,
@@ -49403,10 +49506,10 @@
 	name = "Atmospherics Access";
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/construction{
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/atmos{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel,
@@ -49813,7 +49916,16 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "hAK" = (
 /obj/effect/spawner/random/trash,
@@ -51595,7 +51707,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -51620,6 +51732,9 @@
 /area/space/nearstation)
 "itu" = (
 /obj/machinery/alarm/directional/east,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -52393,6 +52508,17 @@
 	icon_state = "dark"
 	},
 /area/station/security/armory)
+"iKT" = (
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/shelf/engineering,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/multitool,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "iKV" = (
 /obj/machinery/door/airlock/mining,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -52475,7 +52601,10 @@
 "iLI" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -52610,7 +52739,8 @@
 	autolink_id = "turbine_btn_ext";
 	name = "Gas Turbine Airlock Control";
 	pixel_x = 5;
-	pixel_y = 23
+	pixel_y = 23;
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1
@@ -53170,6 +53300,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"jlz" = (
+/obj/effect/spawner/airlock/w_to_e,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos/distribution)
 "jlL" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Danger: Conveyor Access";
@@ -53180,6 +53314,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
+"jlM" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/solar_maintenance/port)
 "jma" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -53235,14 +53373,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/access_button/east{
-	autolink_id = "enginesm_btn_int";
-	name = "Supermatter Access Button";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(10,24)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -53790,6 +53921,10 @@
 /obj/structure/sign/cargo,
 /turf/simulated/wall,
 /area/station/supply/lobby)
+"jFb" = (
+/obj/effect/spawner/random/fungus/maybe,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/gravitygenerator)
 "jFi" = (
 /obj/machinery/alarm/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -54549,12 +54684,7 @@
 	locked = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button/west{
-	autolink_id = "atmossm_btn_int";
-	name = "Atmospherics Access Button";
-	req_access = list(24)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "jTK" = (
@@ -55370,7 +55500,7 @@
 "ksb" = (
 /obj/effect/mapping_helpers/turfs/rust/probably,
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/fsmaint)
+/area/station/engineering/transmission_laser)
 "ksf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -56988,7 +57118,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "leh" = (
@@ -57547,7 +57677,7 @@
 	pixel_y = 24;
 	ext_button_link_id = "engine_btn_ext";
 	int_button_link_id = "engine_btn_int";
-	req_access = list(10,13)
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
@@ -58795,12 +58925,10 @@
 "lRH" = (
 /obj/effect/spawner/random/trash,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "lRK" = (
@@ -59166,6 +59294,9 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"mcl" = (
+/turf/simulated/wall,
+/area/station/engineering/gravitygenerator)
 "mcp" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
@@ -59439,6 +59570,20 @@
 	icon_state = "darkblue"
 	},
 /area/station/command/office/cmo)
+"mhG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
 "mhS" = (
 /obj/structure/sign/poster/official/random/north,
 /turf/simulated/floor/plasteel{
@@ -59491,6 +59636,15 @@
 /obj/effect/turf_decal/delivery/hollow,
 /obj/structure/plasticflaps{
 	opacity = 1
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/supply/mule_bot{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/windoor/access/any/engineering/general{
+	dir = 8
+	},
+/obj/machinery/door/window/classic/normal{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -59857,6 +60011,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"mtB" = (
+/obj/structure/sign/radiation/rad_area,
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/fsmaint)
 "mtV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -60196,7 +60354,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "mCX" = (
@@ -60862,6 +61020,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/science/break_room)
+"mVs" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
 "mVu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60869,6 +61033,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/port)
 "mVB" = (
@@ -61042,7 +61207,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "mYh" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -61228,7 +61396,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "nbO" = (
 /obj/effect/spawner/airlock/s_to_n,
@@ -61265,19 +61433,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	pixel_x = 9;
-	pixel_y = 25;
-	vent_link_id = "aiaccess_vent";
-	ext_door_link_id = "aiaccess_door_ext";
-	int_door_link_id = "aiaccess_door_int";
-	ext_button_link_id = "aiaccess_btn_ext";
-	int_button_link_id = "aiaccess_btn_int"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8;
-	autolink_id = "aiaccess_vent"
-	},
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -61441,7 +61598,10 @@
 	},
 /obj/effect/spawner/random/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "nfk" = (
 /obj/machinery/light/directional/north,
@@ -61845,6 +62005,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
+"nou" = (
+/obj/effect/spawner/random/fungus/maybe,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/control)
 "noy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -62013,6 +62177,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -62523,13 +62690,7 @@
 	locked = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "engine_btn_int";
-	name = "interior access button";
-	pixel_x = -24;
-	req_access = list(10,13)
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "nFf" = (
@@ -62565,13 +62726,7 @@
 	locked = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "engine_btn_ext";
-	name = "interior access button";
-	pixel_y = 24;
-	req_access = list(10,13)
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "nGj" = (
@@ -62584,6 +62739,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"nGo" = (
+/obj/structure/sign/radiation/rad_area,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "nGt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63812,6 +63971,14 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/station/science/robotics/chargebay)
+"osy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
 "otp" = (
 /obj/structure/table,
 /obj/structure/sign/poster/official/random/south,
@@ -63985,6 +64152,16 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/station/supply/storage)
+"oAE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "oBh" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -64492,6 +64669,10 @@
 /obj/machinery/economy/atm/directional/west,
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
+"oPq" = (
+/obj/effect/spawner/airlock/w_to_e,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "oPO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/atmospherics/meter{
@@ -65093,9 +65274,16 @@
 	superconductivity = 0
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
+"peI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "pfh" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery";
@@ -65139,7 +65327,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "pgs" = (
@@ -65235,11 +65423,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "piB" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -65742,13 +65930,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "pxj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "pxr" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -65819,16 +66010,19 @@
 	},
 /area/station/medical/medbay)
 "pAO" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "pAU" = (
 /obj/structure/cable/yellow{
@@ -66780,6 +66974,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"pXh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/camera{
+	dir = 4;
+	c_tag = "Power Transmission Laser";
+	network = list("Engineering","SS13")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/directional/west,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "pXH" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -67270,28 +67480,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medmaint)
-"qkC" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "aiaccess_door_ext";
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "transittube";
-	name = "Transit Tube Blast Door"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "aiaccess_btn_ext";
-	name = "exterior access button";
-	pixel_y = 24;
-	req_access = list(75,13)
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/ai_transit_tube)
 "qkD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -68093,6 +68281,16 @@
 	icon_state = "red"
 	},
 /area/station/security/permabrig)
+"qGp" = (
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "qIg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -68759,48 +68957,14 @@
 /turf/simulated/floor/grass/no_creep,
 /area/station/security/permabrig)
 "qZz" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "aiaccess_door_int";
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "transittube";
 	name = "Transit Tube Blast Door"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "aiaccess_btn_int";
-	name = "interior access button";
-	pixel_y = 24;
-	req_access = list(75,13)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
 /area/station/engineering/ai_transit_tube)
-"rab" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airlock_controller/access_controller{
-	name = "Atmos Supermatter Access Console";
-	ext_door_link_id = "atmossm_door_ext";
-	int_door_link_id = "atmossm_door_int";
-	pixel_y = -24;
-	ext_button_link_id = "atmossm_btn_ext";
-	int_button_link_id = "atmossm_btn_int"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
 "rak" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -69306,6 +69470,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "rmg" = (
@@ -69471,6 +69638,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "rqW" = (
@@ -69499,6 +69667,16 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"rrk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "rrq" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -69736,7 +69914,7 @@
 /area/station/science/toxins/launch)
 "rxV" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/food_trash,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -70532,6 +70710,16 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
+"rQy" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "rRp" = (
 /obj/structure/closet/secure_closet/brig,
 /turf/simulated/floor/plasteel{
@@ -71278,21 +71466,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "snf" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "atmossouth_door_int";
-	locked = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "atmossouth_btn_int";
-	name = "interior access button";
-	pixel_y = -24;
-	req_access = list(13)
-	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "snq" = (
@@ -71640,6 +71813,11 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft)
+"sxF" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light_switch/east,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "sxL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -71822,6 +72000,10 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard)
+"sEo" = (
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "sEI" = (
 /obj/machinery/atmospherics/trinary/filter,
 /turf/simulated/floor/plasteel,
@@ -72652,6 +72834,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"sXa" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/access_button{
+	autolink_id = "engine_btn_ext";
+	name = "interior access button";
+	pixel_y = 24;
+	req_access = list(10)
+	},
+/turf/space,
+/area/space/nearstation)
 "sXJ" = (
 /obj/machinery/light/small/directional/south,
 /turf/simulated/floor/plasteel{
@@ -73292,6 +73484,10 @@
 	icon_state = "redfull"
 	},
 /area/station/security/permabrig)
+"tmr" = (
+/obj/structure/sign/securearea,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/transmission_laser)
 "tmt" = (
 /obj/machinery/disposal,
 /obj/effect/turf_decal/delivery/hollow,
@@ -73528,6 +73724,10 @@
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"ttp" = (
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/transmission_laser)
 "ttA" = (
 /obj/structure/rack,
 /obj/item/hand_labeler,
@@ -75147,6 +75347,13 @@
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"uoR" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/wall/r_wall,
+/area/space/nearstation)
 "upE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -75730,9 +75937,8 @@
 	},
 /area/station/engineering/equipmentstorage)
 "uJn" = (
-/obj/effect/spawner/airlock/w_to_e,
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/fsmaint)
+/area/station/engineering/transmission_laser)
 "uJs" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -76100,7 +76306,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -76688,6 +76895,12 @@
 	icon_state = "brown"
 	},
 /area/station/hallway/primary/central)
+"vcS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fsmaint)
 "vcW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9;
@@ -76968,6 +77181,23 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/science/misc_lab)
+"vkY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
+"vlq" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "vlP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -76979,7 +77209,16 @@
 	dir = 9
 	},
 /obj/machinery/light/small/directional/south,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/catwalk,
 /area/station/maintenance/fsmaint)
 "vmA" = (
 /obj/machinery/door/airlock/security{
@@ -77051,10 +77290,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "vnQ" = (
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "vob" = (
 /turf/simulated/wall,
 /area/station/medical/storage)
@@ -77559,12 +77802,20 @@
 	},
 /area/station/medical/exam_room)
 "vAN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "vAP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -77710,6 +77961,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/security/processing)
+"vEH" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/machinery/airlock_controller/access_controller{
+	name = "Atmos Supermatter Access Console";
+	ext_door_link_id = "atmossm_door_ext";
+	int_door_link_id = "atmossm_door_int";
+	pixel_y = 24;
+	ext_button_link_id = "atmossm_btn_ext";
+	int_button_link_id = "atmossm_btn_int";
+	req_access = list(24)
+	},
+/turf/simulated/floor/noslip,
+/area/station/engineering/control)
 "vFz" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
@@ -78734,7 +79000,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "wkL" = (
@@ -78827,6 +79096,11 @@
 	icon_state = "white"
 	},
 /area/station/security/permabrig)
+"wol" = (
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
 "wos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80144,7 +80418,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -80234,6 +80508,15 @@
 "xbT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/machinery/airlock_controller/access_controller{
+	name = "Supermatter Access Console";
+	ext_door_link_id = "enginesm_door_ext";
+	int_door_link_id = "enginesm_door_int";
+	pixel_x = 24;
+	ext_button_link_id = "enginesm_btn_ext";
+	int_button_link_id = "enginesm_btn_int";
+	req_access = list(10)
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80780,6 +81063,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
+"xpY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "darkgrey"
+	},
+/area/station/engineering/transmission_laser)
 "xqS" = (
 /obj/machinery/door/window/classic/reversed{
 	name = "Danger: Conveyor Access";
@@ -81001,14 +81292,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/access_button/west{
-	autolink_id = "enginesm_btn_ext";
-	name = "Supermatter Access Button";
-	pixel_x = 0;
-	pixel_y = 24;
-	req_access = list(10,24)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -81461,6 +81745,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
+"xHT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "xIe" = (
 /obj/machinery/flasher{
 	id = "justiceflash";
@@ -81887,14 +82186,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_north)
 "xQV" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/sign/vacuum/external{
-	pixel_y = 32
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/engineering/transmission_laser)
 "xRE" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -82028,6 +82328,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -124194,8 +124495,8 @@ aLl
 asN
 aud
 paT
-aLl
-aIo
+mcl
+hnH
 azs
 aBZ
 aEy
@@ -124447,14 +124748,14 @@ amk
 amk
 oVx
 amk
-aBZ
-aBZ
-aBZ
-aBZ
-aBZ
+amk
+amk
+amk
+amk
+amk
 ayN
 ayI
-amk
+aCg
 aCd
 aEE
 aIA
@@ -124965,10 +125266,10 @@ aGt
 nHi
 avR
 avF
-aBZ
+amk
 ayQ
 azn
-amk
+aCg
 aCf
 aDw
 ccH
@@ -125222,10 +125523,10 @@ ccM
 asQ
 avV
 avI
-aBZ
-aBZ
+amk
+amk
 pAO
-aBZ
+aCg
 btR
 aEn
 llU
@@ -125479,10 +125780,10 @@ cAI
 aEo
 nnI
 avH
-aBZ
+amk
 sOy
 aAK
-aBZ
+aCg
 aFZ
 aHg
 iOr
@@ -125736,10 +126037,10 @@ arw
 nHi
 awn
 awU
-aBZ
+amk
 hFY
 bag
-aBZ
+aCg
 dxF
 aHg
 iOr
@@ -125757,9 +126058,9 @@ knc
 aXs
 tjY
 bao
-rab
+bbC
 aCg
-drL
+vEH
 hFO
 eTy
 hfb
@@ -125993,10 +126294,10 @@ amk
 amk
 rMO
 avf
-cbc
+jFb
 aBT
 dxe
-aBZ
+aCg
 aCD
 ksf
 aSn
@@ -126250,11 +126551,11 @@ aaa
 oVx
 amk
 amk
-aBZ
+amk
 nbN
 pxj
-cbc
-aBZ
+nou
+aCg
 nYI
 nYI
 nYI
@@ -126509,8 +126810,8 @@ aaa
 aaa
 edZ
 dsq
-wJQ
-avA
+dit
+vcS
 iLI
 aDi
 gHz
@@ -126528,7 +126829,7 @@ aOe
 tVw
 gpj
 tAn
-bbC
+dko
 nEU
 mdN
 mLC
@@ -126545,7 +126846,7 @@ bxx
 bly
 auq
 qZz
-iRu
+jlz
 fmo
 iHO
 bqT
@@ -126764,11 +127065,11 @@ dPW
 asU
 ans
 ans
-aBZ
+ans
 azr
 avg
-dAH
-aBZ
+peI
+aCg
 qto
 bsw
 mtV
@@ -127021,11 +127322,11 @@ nEz
 hbr
 auj
 arT
-aBZ
+ans
 heC
-avA
-avA
-aBZ
+dVg
+apL
+aCg
 iJz
 enh
 vZU
@@ -127058,7 +127359,7 @@ jKS
 aXO
 aXO
 auq
-qkC
+qZz
 iRu
 ciD
 dkG
@@ -127282,7 +127583,7 @@ gxm
 mXQ
 ggF
 tsq
-aBZ
+aCg
 kLs
 lcc
 vZU
@@ -127301,7 +127602,7 @@ kGw
 dea
 oXB
 aCg
-aef
+sXa
 aef
 aef
 aef
@@ -127539,7 +127840,7 @@ ayA
 nfj
 hAn
 afY
-aBZ
+aCg
 bJW
 fmP
 aFY
@@ -127792,11 +128093,11 @@ dPW
 ans
 ans
 asU
-aBZ
+jlM
 dKL
 bfb
 cbc
-aBZ
+aCg
 nZj
 nYI
 nYI
@@ -127852,7 +128153,7 @@ bCM
 abq
 bCM
 snf
-bCM
+oPq
 bCM
 aaa
 abq
@@ -128052,7 +128353,7 @@ bOn
 kmb
 blA
 vmv
-aBZ
+mtB
 aaa
 aaa
 aef
@@ -128303,10 +128604,10 @@ aaa
 aaa
 aaa
 aaa
-aef
-aaa
-aaa
-ksb
+uJn
+uJn
+uJn
+uJn
 vnQ
 vAN
 ksb
@@ -128365,7 +128666,7 @@ cbl
 bCM
 abq
 bCM
-fZt
+snf
 bCM
 clH
 cmP
@@ -128560,12 +128861,12 @@ aaa
 aaa
 aaa
 aaa
-aef
-aaa
-aaa
-aLl
-gbM
-avA
+tmr
+oAE
+exb
+pXh
+rrk
+xHT
 uJn
 abq
 abq
@@ -128817,13 +129118,13 @@ aaa
 aaa
 aaa
 aaa
-aef
-aef
-aef
-aef
-aLl
+uJn
+qGp
+vkY
+osy
+hnp
 xQV
-aBZ
+uJn
 aaa
 aaa
 aaa
@@ -129074,12 +129375,12 @@ aaa
 aaa
 aaa
 aaa
-eKV
-aaa
-aaa
-aef
-aLl
-avA
+uJn
+vlq
+xpY
+wol
+mVs
+dXe
 ksb
 aaa
 aaa
@@ -129331,13 +129632,13 @@ aaa
 aaa
 aaa
 aaa
-aef
-aaa
-aaa
-aef
-aef
-aef
-aBZ
+uJn
+dNx
+iKT
+mhG
+cNp
+rQy
+uJn
 aaa
 aaa
 aaa
@@ -129588,13 +129889,13 @@ aaa
 aaa
 aaa
 aaa
-ajo
-abq
-abq
+uJn
+sEo
+sEo
 cSy
-abq
-aef
-abq
+sEo
+sxF
+uJn
 abq
 aaa
 abq
@@ -129845,13 +130146,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uJn
+uJn
+nGo
+ttp
+eQG
+uJn
+uJn
 mZb
 bre
 bre
@@ -130106,9 +130407,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+abq
+abq
+uoR
 mZb
 mZb
 bre
@@ -130365,7 +130666,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+abq
 aaa
 mZb
 mZb


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Делает инженерный отдел чуть лучше:
Добавляет ПТЛ на все карты
Чинит неправильные/отсутствующие доступы в пределах отдела
Добавляет душ для буферной зоны Сингулярности
Фиксит невозможность дотянуться до аптечки на Керберосе
Где возможно - добавляет аирлок хелперы
Добавляет камеру в комнату гравгена на Кибериаде - теперь в ней нет слепых зон
Убирает радкостюмы из комнаты турбины на Мете - турбина не излучает радиации...
Добавляет стекло в аирлоки ведущие к зоне содержания Теслы/Сингулярности
Эээээ, может ещё что-то, но я забыл

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

ПТЛ добавили лет пять назад, а у нас его всё нет. Доступы должны соответствовать действительности. Стандартизация - гуд

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

MDB

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

компилируется, побегал, потыкал кнопки, запустил ПТЛ на Кибериаде - работает. You can trust me!

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: Power Transmission Laser добавлен на все станции.
fix: Исправлены неверные доступы в пределах инженерного отдела на всех станциях.
fix: До аптечки от ожогов на Керберосе теперь можно дотянуться.
tweak: Незначительные правки в маппинге инженерного отдела на всех картах.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Обновление инфраструктуры инженерного отдела на нескольких картах станций

Новые функции:
- Добавлен лазер передачи энергии (PTL) на все карты станций

Исправления ошибок:
- Исправлены права доступа в инженерном отделе
- Исправлена доступность аптечки для лечения ожогов на станции Kerberos

Улучшения:
- Стандартизация планировки инженерного отдела на разных картах станций

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update engineering department infrastructure across multiple station maps

New Features:
- Add Power Transmission Laser (PTL) to all station maps

Bug Fixes:
- Correct access permissions within the engineering department
- Fix reachability to burn treatment medical kit on Kerberos station

Enhancements:
- Standardize engineering department layout across different station maps

</details>

## Краткое описание от Sourcery

Обновление и стандартизация инфраструктуры инженерного отдела на нескольких картах станций.

Новые возможности:
- Добавлен лазер передачи энергии (PTL) на все карты станций.

Исправления ошибок:
- Исправлены права доступа в инженерном отделе.
- Исправлена доступность аптечки для лечения ожогов на станции Kerberos.
- Удалены радиационные костюмы из турбинного зала на станции Meta.

Улучшения:
- Добавлена камера в комнату гравигенератора на Cyberia для устранения слепых зон.
- Добавлены помощники для шлюзов, где это возможно.
- Добавлено стекло к шлюзам, ведущим в зоны содержания Tesla/Singularity.
- Добавлен душ в буферную зону Singularity.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update and standardize the engineering department infrastructure across multiple station maps

New Features:
- Add Power Transmission Laser (PTL) to all station maps

Bug Fixes:
- Correct access permissions within the engineering department
- Fix reachability to burn treatment medical kit on Kerberos station
- Remove radiation suits from turbine room on Meta station

Enhancements:
- Add camera to gravgen room on Cyberia to eliminate blind spots
- Add airlock helpers where possible
- Add glass to airlocks leading to Tesla/Singularity containment zones
- Add shower to Singularity buffer zone

</details>