### PR TITLE
Fixes for underwindow cables and other stuff on Kerberos

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -11577,7 +11577,9 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/structure/sign/electricshock{
+	pixel_x = -32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutral"
@@ -29329,9 +29331,6 @@
 	},
 /area/station/hallway/primary/port)
 "cpX" = (
-/obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_y = 32
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -29341,6 +29340,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/newscaster/security_unit/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -29393,9 +29393,6 @@
 	},
 /area/station/hallway/secondary/bridge)
 "cqe" = (
-/obj/structure/sign/poster/official/nanotrasen_logo{
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29408,6 +29405,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -48234,6 +48232,9 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
+/obj/structure/sign/electricshock{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutral"
@@ -65430,6 +65431,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -77932,9 +77936,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "nBO" = (
-/obj/structure/sign/electricshock{
-	pixel_y = 32
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -77943,6 +77944,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -96629,9 +96633,6 @@
 	},
 /area/station/hallway/primary/central/nw)
 "tlB" = (
-/obj/structure/sign/electricshock{
-	pixel_y = 32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -96643,6 +96644,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/nanotrasen_logo{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -111555,6 +111559,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Перекладывает проводку под окнами на Керберосе и делает прочие штуки, о чем подробно расписано в коммитах.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Более вменяемая проводка на карте.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<details>
<summary> Много картинок </summary>

![изображение](https://github.com/user-attachments/assets/c1f077c4-0336-4cfb-b29d-a92622b952bd)

![изображение](https://github.com/user-attachments/assets/7f135400-4169-4dc4-b886-86302d879051)

![изображение](https://github.com/user-attachments/assets/88bf2b1e-9e67-40d6-920d-0eb4083c76be)

![изображение](https://github.com/user-attachments/assets/43ec215d-d883-4d9a-9359-928a2649485d)

![изображение](https://github.com/user-attachments/assets/ab781b17-e755-45bf-b43a-bb7bce0d4744)

![изображение](https://github.com/user-attachments/assets/eeb878b0-3fa6-4bae-ba3e-02d718c84757)

![изображение](https://github.com/user-attachments/assets/54624817-a6ed-4f65-80c5-5650f350ab43)

![изображение](https://github.com/user-attachments/assets/b9de5d7c-bdce-4d76-8fb1-4ef655369257)

</details>
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Протестировал на локальном сервере. Карта поменялась, нужные окна кусаются током, новая кнопка в офисе ГП работает.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Osetrokarasek
tweak: Керберос: переложена, добавлена и удалена проводка под окнами в различных отделах станции.
tweak: Керберос: ранее огражданенный вакантный офис стал чуть более гражданским.
del: Керберос: из офиса ГП убран один лишний автомат PTech.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Краткое описание от Sourcery

Рефакторинг и улучшение проводки и планировки офиса на карте Kerberos

Улучшения:
- Реорганизована проводка вокруг окон в различных отделах станции
- Улучшена планировка ранее пустовавшего офисного помещения

Мелкие задачи:
- Удалена лишняя машина PTech из офиса GP

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor and improve the wiring and office layout on the Kerberos map

Enhancements:
- Reorganized wiring around windows in various station departments
- Improved the layout of a previously vacant office space

Chores:
- Removed an extra PTech machine from the GP office

</details>