### PR TITLE
Fix occupation window layout

### DIFF
--- a/code/modules/client/preference/character.dm
+++ b/code/modules/client/preference/character.dm
@@ -2032,7 +2032,7 @@
 	return(job_support_high || job_support_med || job_support_low || job_medsci_high || job_medsci_med || job_medsci_low || job_engsec_high || job_engsec_med || job_engsec_low)
 
 
-/datum/character_save/proc/SetChoices(mob/user, limit = 17, list/splitJobs = list("Head of Security", "Quartermaster"), widthPerColumn = 400, height = 700)
+/datum/character_save/proc/SetChoices(mob/user, limit = 18, list/splitJobs = list("Head of Security", "Quartermaster"), widthPerColumn = 500, height = 700) // SS220 EDIT - tweak limit and widthPerColumn
 	if(!SSjobs)
 		return
 

--- a/modular_ss220/jobs/code/jobs_character.dm
+++ b/modular_ss220/jobs/code/jobs_character.dm
@@ -25,10 +25,6 @@
 /datum/character_save
 	var/extra_jobs_check = FALSE
 
-// OFFICIAL parameters: 17 / HOS, Bart / 400 / 700
-/datum/character_save/SetChoices(mob/user, limit = 18, list/splitJobs = list("Head of Security", "Bartender"), widthPerColumn = 450, height = 700)
-	. = ..()
-
 /datum/character_save/proc/get_split_extra_jobs()
 	return list("Administrator", "Adjutant", "VIP Corporate Guest")
 


### PR DESCRIPTION
## Что этот PR делает
Чинит окно выбора роли.

## Почему это хорошо для игры
Весь интерфейс выровнен, не нужно скроллить.

## Тестирование
![Screenshot 2025-04-13 203350](https://github.com/user-attachments/assets/b61b58dd-3106-4dfc-b4e1-403c54f34356)

## Changelog

:cl: Maxiemar
fix: Исправлено окно выбора роли.
/:cl:

## Обзор от Sourcery

Настройка макета окна выбора занятия для улучшения читаемости и удобства использования пользовательского интерфейса.

Исправления ошибок:
- Исправлен макет окна занятия, чтобы предотвратить прокрутку и улучшить выравнивание интерфейса.

Улучшения:
- Изменены параметры окна выбора работы, чтобы увеличить ширину и настроить лимит заданий.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the occupation selection window layout to improve user interface readability and usability

Bug Fixes:
- Fix the occupation window layout to prevent scrolling and improve interface alignment

Enhancements:
- Modify the job selection window parameters to increase width and adjust the job limit

</details>