### PR TITLE
Updated the rest of the old Mining Satchels of Holding textures.

### DIFF
--- a/modular_ss220/aesthetics/satchels/code/satchels.dm
+++ b/modular_ss220/aesthetics/satchels/code/satchels.dm
@@ -1,6 +1,8 @@
 /obj/item/storage/bag/ore/holding
 	icon = 'modular_ss220/aesthetics/satchels/icons/satchels.dmi'
+
 /obj/item/storage/bag/ore/cyborg/holding
 	icon = 'modular_ss220/aesthetics/satchels/icons/satchels.dmi'
+
 /obj/item/storage/bag/expedition/robust
 	icon = 'modular_ss220/aesthetics/satchels/icons/satchels.dmi'


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Обновляет все остальные текстуры БС рудной сумки, такие как:
- "Robust treasure satchel" (рудная сумка исследователей),
- "Cyborg mining satchel of holding" (сумка киборгов).

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

В предыдущий раз я поленился обновить ВСЕ старые спрайты этой сумки, исправляюсь.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

![image](https://github.com/user-attachments/assets/db97d5b3-a027-496d-a12f-590184653c93)
![image](https://github.com/user-attachments/assets/daac596e-3631-4d03-8a80-aae5b0936a60)


<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Зашел на локалку, проверил что все на месте, изображения выше.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Karol1ng
imageadd: Теперь блюспейс версии рудной сумки у киборгов и сумки под сокровища исследователей тоже имеют обновленный спрайт.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Обновление текстур для шахтерских сумок, используемых киборгами и исследователями экспедиций.

Новые возможности:
- Обновлены исходники иконок для нескольких вариантов шахтерских сумок для использования нового набора текстур.

Улучшения:
- Улучшена визуальная согласованность предметов шахтерских сумок для разных типов игроков.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update textures for mining satchels used by cyborgs and expedition researchers

New Features:
- Updated icon sources for multiple mining satchel variants to use a new texture set

Enhancements:
- Improved visual consistency for mining satchel items across different player types

</details>