### PR TITLE
[DNM] [TM] OD threshold for syndie nanites; limit syndie nanites for nukie medborg

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -127,10 +127,10 @@
 	to_chat(user, "<span class='notice'>Synthesizer is now producing [R.name].</span>")
 	choosen_reagent = selected_reagent
 
-/obj/item/reagent_containers/borghypo/examine(mob/user)
-	. = ..()
-	var/datum/reagent/get_reagent_name = GLOB.chemical_reagents_list[choosen_reagent]
-	. |= "<span class='notice'>It is currently dispensing [get_reagent_name.name]. Contains [total_reagents] units of various reagents.</span>" // We couldn't care less what actual reagent is in the container, just if there IS reagent in it
+///obj/item/reagent_containers/borghypo/examine(mob/user)
+//	. = ..()
+//	var/datum/reagent/get_reagent_name = GLOB.chemical_reagents_list[choosen_reagent]
+//	. |= "<span class='notice'>It is currently dispensing [get_reagent_name.name]. Contains [total_reagents] units of various reagents.</span>" // We couldn't care less what actual reagent is in the container, just if there IS reagent in it
 
 /obj/item/reagent_containers/borghypo/emag_act(mob/user)
 	if(!emagged)

--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -16,6 +16,8 @@
 #include "code/loot/megafauna.dm"
 #include "code/loot/pools.dm"
 #include "code/mobs/aliens/larva.dm"
+#include "code/reagents/medicine.dm"
+#include "code/reagents/reagent_containers.dm"
 #include "code/research_designs/equipment_designs.dm"
 #include "code/species/machine.dm"
 #include "code/species/skrell.dm"

--- a/modular_ss220/balance/code/reagents/medicine.dm
+++ b/modular_ss220/balance/code/reagents/medicine.dm
@@ -1,0 +1,8 @@
+/datum/reagent/medicine/syndicate_nanites
+	overdose_threshold = 50
+	harmless = FALSE
+
+/datum/reagent/medicine/syndicate_nanites/overdose_process(mob/living/M, severity)
+	var/update_flags = STATUS_UPDATE_NONE
+	update_flags |= M.adjustCloneLoss(1.5 * REAGENTS_EFFECT_MULTIPLIER, FALSE)
+	return list(0, update_flags)

--- a/modular_ss220/balance/code/reagents/reagent_containers.dm
+++ b/modular_ss220/balance/code/reagents/reagent_containers.dm
@@ -1,0 +1,70 @@
+#define BORGHYPO_REFILL_VALUE 10
+#define SYNDICATE_NANITES_LIMIT 250 // прок..
+
+/obj/item/reagent_containers/borghypo
+	var/list/reagents_stored = list() // stores all reagents we have
+	var/list/reagents_produced = list() // stores all reagents we've produced
+
+/obj/item/reagent_containers/borghypo/Initialize(mapload)
+	. = ..()
+	refill_borghypo(loc, TRUE) // start with a full hypo
+
+/obj/item/reagent_containers/borghypo/process()
+	if(reagents_stored[choosen_reagent] >= maximum_reagents) // no need to refill
+		if(charge_tick)
+			charge_tick = 0
+		return
+	charge_tick++
+	if(charge_tick < recharge_time) // not ready to refill
+		return
+	charge_tick = 0
+	refill_borghypo(loc)
+
+/obj/item/reagent_containers/borghypo/refill_borghypo(mob/living/silicon/robot/user, roundstart = FALSE)
+	if(roundstart)
+		for(var/reagent as anything in reagent_ids)
+			reagents_stored[reagent] = maximum_reagents
+			reagents_produced[reagent] = maximum_reagents
+		return
+	if(!istype(user)) // in case if someone shitspawns it
+		return
+	if(choosen_reagent == "syndicate_nanites" && reagents_produced["syndicate_nanites"] >= SYNDICATE_NANITES_LIMIT && !user.admin_spawned) // allow adminbuse
+		to_chat(loc, span_warning("Nanite synthesizer is empty!"))
+		return
+	if(user.cell.use(charge_cost))
+		var/reagents_to_add = min(maximum_reagents - reagents_stored[choosen_reagent], BORGHYPO_REFILL_VALUE)
+		reagents_stored[choosen_reagent] += reagents_to_add
+		reagents_produced[choosen_reagent] += reagents_to_add
+
+// copypaste mostly
+/obj/item/reagent_containers/borghypo/interact_with_atom(atom/target, mob/living/user, list/modifiers)
+	if(ishuman(target))
+		var/mob/living/carbon/human/mob = target
+		if(reagents_stored[choosen_reagent] < 5)
+			to_chat(user, "<span class='warning'>The injector [reagents_stored[choosen_reagent] ? "lacks reagents" : "is empty"].</span>")
+			return ITEM_INTERACT_COMPLETE
+		if(!mob.can_inject(user, TRUE, user.zone_selected, penetrate_thick))
+			return ITEM_INTERACT_COMPLETE
+
+		to_chat(user, "<span class='notice'>You inject [mob] with the injector.</span>")
+		to_chat(mob, "<span class='notice'>You feel a tiny prick!</span>")
+		mob.reagents.add_reagent(choosen_reagent, 5)
+		reagents_stored[choosen_reagent] -= 5
+		user.changeNext_move(CLICK_CD_MELEE)
+		if(mob.reagents)
+			var/datum/reagent/injected = GLOB.chemical_reagents_list[choosen_reagent]
+			var/contained = injected.name
+			add_attack_logs(user, mob, "Injected with [name] containing [contained], transfered [5] units", injected.harmless ? ATKLOG_ALMOSTALL : null)
+			to_chat(user, "<span class='notice'>[5] units injected. [reagents_stored[choosen_reagent]] units remaining.</span>")
+		return ITEM_INTERACT_COMPLETE
+
+	if(isliving(target)) // ignore non-human mobs
+		return ITEM_INTERACT_COMPLETE
+
+/obj/item/reagent_containers/borghypo/examine(mob/user)
+	. = ..()
+	var/datum/reagent/get_reagent_name = GLOB.chemical_reagents_list[choosen_reagent]
+	. |= "<span class='notice'>It is currently dispensing [get_reagent_name.name]. Contains [reagents_stored[choosen_reagent]] units of various reagents.</span>" // We couldn't care less what actual reagent is in the container, just if there IS reagent in it
+
+#undef BORGHYPO_REFILL_VALUE
+#undef SYNDICATE_NANITES_LIMIT

--- a/modular_ss220/silicons/code/robot_items.dm
+++ b/modular_ss220/silicons/code/robot_items.dm
@@ -29,8 +29,8 @@
 
 /* Medical */
 /obj/item/reagent_containers/borghypo/basic/Initialize(mapload)
-	. = ..()
 	reagent_ids |= list("sal_acid", "charcoal")
+	return ..()
 
 /obj/item/reagent_containers/borghypo/basic/upgraded
 	name = "Upgraded Medical Hypospray"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет порог передоза для синди нанитов
Даёт ограничение медборгам ЯО в 250 нанитов на одного борга. Если борг не из аплинка - лимита не будет
Слегка рефакторит гипоспрей боргов, из-за чего он начинает тратить заряд при перезарядке

DNM TM ибо потом закину рефактор на оффы, а твик нанитов залью в отдельном ПРе. В текущем виде очень много лишнего в модуле понаписано

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

потому что нет интереса в том, чтобы залить в себя 300 юнитов нанитов и забыть о проблемах на весь раунд

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Затестил синди и обычного медборгов. Всё работает

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Восстанавливающие наниты теперь имеют порог передозировки в 50 юнитов. При передозировке наносится генетический урон.
tweak: Медборг ЯО теперь имеет лимит в 250 восстанавливающих нанитов на весь раунд.
tweak: Использование гипо медборга теперь имеет задержку между применениями.
tweak: Реагент в гипо медборга теперь перезаряжается только если является выбранным для синтеза.
fix: Перезарядка гипо медборга теперь и правда снижает заряд батареи киборга.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
