### PR TITLE
Suggest 516

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -8,8 +8,8 @@
 #define UPLOAD_LIMIT		10485760	//Restricts client uploads to the server to 10MB //Boosted this thing. What's the worst that can happen?
 #define MIN_CLIENT_VERSION	513		// Minimum byond major version required to play.
 									//I would just like the code ready should it ever need to be used.
-#define SUGGESTED_CLIENT_VERSION	514		// only integers (e.g: 513, 514) are useful here. This is the part BEFORE the ".", IE 513 out of 513.1542
-#define SUGGESTED_CLIENT_BUILD	1566		// only integers (e.g: 1542, 1543) are useful here. This is the part AFTER the ".", IE 1542 out of 513.1542
+#define SUGGESTED_CLIENT_VERSION	516		// only integers (e.g: 513, 514) are useful here. This is the part BEFORE the ".", IE 513 out of 513.1542
+#define SUGGESTED_CLIENT_BUILD	1660		// only integers (e.g: 1542, 1543) are useful here. This is the part AFTER the ".", IE 1542 out of 513.1542
 
 #define SSD_WARNING_TIMER 30 // cycles, not seconds, so 30=60s
 


### PR DESCRIPTION
## Что этот PR делает
При подключении к серверу с версией бьенда `<516.1660` в чате будет заметное сообщение о необходимости обновиться. Пока не можем зафорсить 516 - у многих технические проблемы, еще не все фиксы интерфейса применены.

## Changelog

:cl: Maxiemar
experiment: При подключении с BYOND версии 515 в чате будет отображаться сообщение о необходимости обновления.
/:cl:

## Обзор от Sourcery

Улучшения:
- Изменены константы версии клиента, чтобы предложить обновление до версии BYOND 516.1660

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Modify client version constants to suggest upgrading to BYOND version 516.1660

</details>