### PR TITLE
Remove hierophant and elite tumor from lavaland guaranteed ruins list

### DIFF
--- a/modular_ss220/maps220/code/RandomRuins/lavaland/lavaland_ruins.dm
+++ b/modular_ss220/maps220/code/RandomRuins/lavaland/lavaland_ruins.dm
@@ -54,3 +54,9 @@
 
 /datum/map_template/ruin/lavaland/legiongate/get_cost()
 	return 0
+
+/datum/map_template/ruin/lavaland/hierophant
+	always_place = FALSE
+
+/datum/map_template/ruin/lavaland/tumor
+	always_place = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Убирает руину с Иерофантом и элитой Лаваленда из списка гарантированных руин Лаваленда

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Гарантированные руины Лаваленда это: спавнеры (нейтральных) гост ролей, аванпост и главный босс Лаваленда - Легион. Иерофант и элита не являются неотъемлемыми частями Лазиса, а потому я не вижу причин чтобы они были гарантированы и всякий раз снижали общий бюджет руин ради себя. По моему мнению, Иерофант не стоит в одном ряду с Легионом чтобы являться гарантированной мегафауной планеты. А элита.. ну это буквально тендрил, ничего особенного в ней нет для спавна каждый раунд вместо какой-то другой интересной руины, коих в последнее время стало очень даже много

Рандом - круто. А гарант спавн они получили лет 6+ назад, когда их только ввели и руин было мало

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

(аванпоста нет ибо у меня старый конфиг без него)
![image](https://github.com/user-attachments/assets/451cec4f-ad6d-49ea-a1e9-1870b793bd80)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Спавн руин Иерофанта и Элиты Лаваленда более не является гарантированным.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
