### PR TITLE
Fix antag hud icons at orbit

### DIFF
--- a/code/modules/asset_cache/assets/asset_job_icons.dm
+++ b/code/modules/asset_cache/assets/asset_job_icons.dm
@@ -3,7 +3,7 @@
 	name = "job_icons"
 
 /datum/asset/spritesheet/job_icons/create_spritesheets()
-	var/list/states = GLOB.joblist + "centcom" + "solgov" + "soviet" + "unknown" // "prisoner" already exists in GLOB.joblist - modular job
+	var/list/states = GLOB.joblist | "Prisoner" | "Centcom" | "Solgov" | "Soviet" | "Unknown"
 	var/default = 'icons/mob/hud/job_assets.dmi'
 	var/custom = 'modular_ss220/jobs/icons/job_assets.dmi'
 	for(var/state in states)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Чинит краш от дублирования наименований иконок
Тем самым теперь в орбите иконки должности отображаются правильно

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Фикс

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

Сейчас на лайве иконки в орбите сломаны (должна быть иконка клоуна, очевидно). Ассет лист крашится из-за того, что у нас модульная джобка Prisoner, а оффы её добавляют повторно. 

![image](https://github.com/user-attachments/assets/7dc3cb03-6b19-428e-bed3-91c016b580c3)

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

(иконка соответствует работке)

![image](https://github.com/user-attachments/assets/a394dfc3-c024-468b-9347-2df48e6dce62)

![image](https://github.com/user-attachments/assets/f2a244ed-f821-4831-9350-0220344f935d)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Исправлено неправильное отображение должностей в орбите (при использовании антаг худа).
imageadd: Добавлено отображение модульных (донат) должностей в орбите (всё так же при использовании антаг худа).
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Краткое описание от Sourcery

Исправления ошибок:
- Исправлена ошибка, приводящая к краху, вызванная дублированием названий иконок профессий при создании спрайтшита. Профессия "заключенный" добавлялась дважды, что вызывало конфликт. Это исправление удаляет дублирующуюся запись, устраняя сбой и обеспечивая правильное отображение значков профессий антагонистов в интерфейсе орбитального шаттла при использовании мода антагонистического HUD.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed a crash caused by duplicate job icon names when generating the spritesheet. The "prisoner" job was being added twice, causing a conflict. This fix removes the duplicate entry, resolving the crash and ensuring correct display of antagonist job icons in the orbiting shuttle interface when using the antagonist hud mod.

</details>