### PR TITLE
[🐌] Fix runtime for mice

### DIFF
--- a/modular_ss220/mobs/code/simple_animal/friendly/mouse.dm
+++ b/modular_ss220/mobs/code/simple_animal/friendly/mouse.dm
@@ -184,7 +184,7 @@
 
 	if(istype(F, /obj/item/food/sliced/cheesewedge) || istype(F, /obj/item/food/sliceable/cheesewheel))
 		Druggy(2 SECONDS)
-		emote(pick("дёргается","быстро вертит хвостиком","издаёт продолжительный писк"))
+		custom_emote(EMOTE_VISIBLE, pick("дёргается","быстро вертит хвостиком","издаёт продолжительный писк"))
 
 	if(nutriment > bitesize)
 		F.reagents.remove_reagent("nutriment", bitesize, TRUE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

фиксит рантайм при попытке выдать эмоут на мышке

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

🐌

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

![🐌](https://github.com/user-attachments/assets/cf19fb95-c755-42ed-b9b1-8a3751068d2c)

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Мышь, при поедании сыра, теперь корректно отображает своё впечатление всем вокруг.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
