### PR TITLE
Fix runtime on Lance shuttle

### DIFF
--- a/modular_ss220/shuttles/code/lance_shuttle.dm
+++ b/modular_ss220/shuttles/code/lance_shuttle.dm
@@ -1,23 +1,12 @@
 /datum/map_template/shuttle/emergency/lance/preload()
 	message_admins("Preloading [name]!")
-	var/obj/docking_port/stationary/CCport
-	CCport = SSshuttle.getDock("emergency_away")
-	CCport.setDir(4)
+	var/obj/docking_port/stationary/CCport = SSshuttle.getDock("emergency_away")
 	CCport.forceMove(locate(105, 83, 1))
 	CCport.height = 50
 	CCport.dheight = 0
 	CCport.width = 19
 	CCport.dwidth = 9
-	var/obj/docking_port/stationary/CCtransit
-	CCtransit = SSshuttle.getDock("emergency_transit")
-	CCtransit.setDir(2)
-	CCtransit.forceMove(locate(179, 169, 1))
-	CCtransit.height = 50
-	CCtransit.dheight = 0
-	CCtransit.width = 19
-	CCtransit.dwidth = 9
-	var/obj/docking_port/stationary/syndicate
-	syndicate = SSshuttle.getDock("emergency_syndicate")
+	var/obj/docking_port/stationary/syndicate = SSshuttle.getDock("emergency_syndicate")
 	syndicate.setDir(8)
 	syndicate.forceMove(locate(91, 159, 1))
 	syndicate.height = 50


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Убирает мёртвый код с `emergency_transit`, приводящий к рантайму от `null.setDir`. Код был убран при мерге апстрима с lazyload шаттлами (где-то в начале марта)
Это _не_ фиксит #1865 (разве что частично), полноценный фикс на апстриме

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Рантаймы плохо

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

#29191

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

о нет

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
