### PR TITLE
Trade Shuttle Tweak

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -371,13 +371,8 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/general)
 "alD" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/civilian,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "navyblue"
-	},
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "alK" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -427,11 +422,7 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
 "anB" = (
-/obj/item/flag/solgov,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/catwalk,
 /area/shuttle/trade/sol)
 "anH" = (
 /obj/structure/table/tray,
@@ -857,8 +848,11 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "avr" = (
-/turf/simulated/wall/mineral/titanium,
-/area/space/nearstation/centcom)
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "avt" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/effect/mapping_helpers/light,
@@ -2244,10 +2238,12 @@
 	},
 /area/syndicate_mothership/jail)
 "bdG" = (
-/obj/structure/rack,
-/obj/item/storage/box/crewvend,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 9;
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "bed" = (
@@ -2274,9 +2270,9 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "beM" = (
+/obj/effect/turf_decal/delivery/white,
 /turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "beO" = (
@@ -2311,10 +2307,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
-"bfU" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "bfW" = (
 /turf/simulated/floor/mineral/plastitanium{
 	color = "#fff894";
@@ -3200,8 +3192,9 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "bwv" = (
-/obj/machinery/light/spot/directional/south,
-/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "bwG" = (
@@ -3723,8 +3716,10 @@
 	},
 /area/ghost_bar/indoor)
 "bJE" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/fancy/oak,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "bJI" = (
 /obj/structure/table/wood,
@@ -4185,7 +4180,7 @@
 /area/centcom/ss220/bar)
 "bSn" = (
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "bSp" = (
@@ -4296,6 +4291,14 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
+"bUc" = (
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "bUd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -5803,10 +5806,13 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "cCP" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/closet/walllocker/emerglocker/directional/east,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/machinery/light/small/directional/east,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "cCU" = (
 /turf/simulated/floor/beach/away/water{
@@ -6551,6 +6557,20 @@
 	icon_state = "darkbluealt"
 	},
 /area/centcom/ss220/admin3)
+"cUS" = (
+/obj/item/reagent_containers/drinks/bottle/whiskey,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/lighter/zippo/engraved,
+/obj/item/lighter/zippo/engraved,
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluecorners"
+	},
+/area/shuttle/trade/sol)
 "cUU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -7776,14 +7796,12 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "dtV" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/paper_bin{
-	pixel_y = 3
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "traderwinshut"
 	},
-/obj/item/pen/fancy{
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/royalblue,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "dub" = (
 /obj/structure/window/reinforced{
@@ -7834,12 +7852,11 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "dvw" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 10
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dvG" = (
 /obj/machinery/computer/arcade/battle,
@@ -7898,12 +7915,6 @@
 /obj/item/bedsheet/blue,
 /turf/simulated/floor/carpet/blue,
 /area/ghost_bar/indoor)
-"dxj" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "dxQ" = (
 /obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/plasteel/dark,
@@ -9427,6 +9438,12 @@
 	name = "vox floor"
 	},
 /area/vox_base)
+"eeJ" = (
+/obj/effect/turf_decal/siding/wood/oak/end{
+	dir = 8
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "eeQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10061,8 +10078,10 @@
 	},
 /area/tdome/tdomeadmin)
 "esY" = (
+/obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 9;
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "etc" = (
@@ -10570,6 +10589,14 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
+"eEG" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "eEH" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkredaltstrip"
@@ -11581,10 +11608,8 @@
 	},
 /area/ghost_bar/indoor)
 "eYC" = (
-/obj/effect/turf_decal/delivery/white,
 /turf/simulated/floor/plasteel/dark{
-	dir = 10;
-	icon_state = "navyblue"
+	icon_state = "navybluefull"
 	},
 /area/shuttle/trade/sol)
 "eYF" = (
@@ -12708,6 +12733,16 @@
 /obj/item/gun/syringe/rapidsyringe,
 /turf/simulated/floor/wood/oak,
 /area/admin)
+"fsE" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "fsG" = (
 /obj/structure/table/glass,
 /obj/item/folder/red{
@@ -12744,12 +12779,10 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "ftp" = (
-/obj/item/flag/solgov,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
-	},
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "fts" = (
 /obj/item/flag/nt,
@@ -13409,8 +13442,7 @@
 /area/centcom/ss220/medbay)
 "fHx" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/traders/medical,
-/obj/structure/closet,
+/obj/effect/landmark/spawner/tradergearminor,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -13759,19 +13791,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/general)
-"fQO" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 15
-	},
-/obj/item/painter,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/toy/crayon/spraycan,
-/obj/structure/shelf,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "fQY" = (
 /obj/machinery/economy/vending/cigarette/syndicate/free,
 /turf/simulated/floor/wood/oak,
@@ -15193,10 +15212,12 @@
 	},
 /area/ninja/holding)
 "gBF" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 4
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/spawner/random/traders/medical,
+/obj/structure/closet,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "gBI" = (
 /obj/effect/turf_decal/siding/wood/oak/corner{
@@ -15848,13 +15869,6 @@
 /obj/effect/spawner/random/ccfood/dessert,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/bar)
-"gPp" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "gPu" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/mapping_helpers/light,
@@ -17089,6 +17103,14 @@
 	icon_state = "dark_large"
 	},
 /area/centcom/ss220/bar)
+"hqg" = (
+/obj/item/flag/solgov,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "hqz" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/effect/turf_decal/box/white,
@@ -18059,7 +18081,7 @@
 /area/centcom/ss220/admin3)
 "hKx" = (
 /turf/simulated/floor/plasteel/dark{
-	dir = 1;
+	dir = 5;
 	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
@@ -21222,6 +21244,18 @@
 	},
 /turf/simulated/floor/wood/fancy,
 /area/ghost_bar/outdoor)
+"iZf" = (
+/obj/structure/rack,
+/obj/item/eftpos{
+	pixel_x = -6
+	},
+/obj/item/storage/box/crewvend{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "iZn" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -22411,14 +22445,6 @@
 	icon_state = "dark_herringbone"
 	},
 /area/centcom/ss220/command)
-"jDq" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "jDz" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 4;
@@ -23951,10 +23977,6 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
 "kne" = (
-/obj/structure/rack,
-/obj/item/storage/bag/money{
-	pixel_y = 8
-	},
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -24137,13 +24159,14 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "kqx" = (
-/obj/structure/closet,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/traders/engineering,
-/obj/effect/spawner/random/oil/maybe,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/paper_bin{
+	pixel_y = 3
 	},
+/obj/item/pen/fancy{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "kqN" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -26365,9 +26388,10 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/park)
 "lmP" = (
-/obj/structure/chair/comfy/shuttle/dark{
-	dir = 8
-	},
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/engineering,
+/obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -27958,6 +27982,13 @@
 /obj/structure/chair/comfy/red,
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
+"lUj" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "lUm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sunnybush,
@@ -28362,6 +28393,13 @@
 	icon_state = "brownoldfull"
 	},
 /area/syndicate_mothership/jail)
+"mdh" = (
+/obj/effect/spawner/random/traders/large_item,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "mdm" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/indestructible
@@ -30388,13 +30426,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
-"naO" = (
-/obj/machinery/light/small/directional/west,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "darkbrown"
-	},
-/area/shuttle/trade/sol)
 "naQ" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -30652,6 +30683,19 @@
 /obj/structure/table/glass/reinforced/titanium,
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/general)
+"ngi" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/painter,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/toy/crayon/spraycan,
+/obj/structure/shelf,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "ngG" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/effect/turf_decal/box/white,
@@ -31289,6 +31333,12 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership)
+"nwo" = (
+/obj/item/flag/solgov,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "nwt" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/turf_decal/delivery/white,
@@ -31838,7 +31888,7 @@
 "nHZ" = (
 /obj/item/flag/solgov,
 /obj/effect/turf_decal/siding/wood/oak{
-	dir = 10
+	dir = 9
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
@@ -34002,9 +34052,12 @@
 	},
 /area/ghost_bar/indoor)
 "oIQ" = (
-/obj/item/flag/solgov,
+/obj/structure/rack,
+/obj/item/storage/bag/money{
+	pixel_y = 8
+	},
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "oJf" = (
@@ -35179,13 +35232,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/ss220/jail)
-"phG" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/landmark/spawner/tradergearminor,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "phM" = (
 /obj/structure/table/glass/reinforced/titanium,
 /obj/item/kirbyplants/large{
@@ -36802,20 +36848,12 @@
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
 "pVD" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/obj/machinery/economy/vending/cigarette/beach,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
-"pWc" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2
-	},
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
+	dir = 4;
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "pWf" = (
@@ -36959,6 +36997,12 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
+"pZI" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "pZL" = (
 /obj/structure/closet/crate/trashcart{
 	name = "Специальная доставка с ЦК"
@@ -37220,6 +37264,12 @@
 	name = "vox floor"
 	},
 /area/vox_base)
+"qgo" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "qgz" = (
 /obj/item/flag/syndi,
 /obj/structure/curtain/black{
@@ -38628,6 +38678,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/syndicate_mothership)
+"qPp" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/obj/machinery/economy/vending/cigarette/beach,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "qPs" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/medal/silver{
@@ -38673,12 +38730,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
-"qQk" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
-	},
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "qQI" = (
 /obj/structure/table/glass,
 /obj/item/food/applepie,
@@ -39469,13 +39520,8 @@
 	},
 /area/ghost_bar/indoor)
 "rhr" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/minerals,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "darkbrown"
-	},
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "rhs" = (
 /obj/item/tank/internals/emergency_oxygen/nitrogen{
@@ -39869,12 +39915,6 @@
 	},
 /turf/simulated/floor/wood/parquet,
 /area/centcom/ss220/admin2)
-"rpQ" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 5;
-	icon_state = "darkbrown"
-	},
-/area/shuttle/trade/sol)
 "rpU" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -40968,15 +41008,6 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
-"rKz" = (
-/obj/structure/closet/walllocker/emerglocker/directional/east,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/machinery/light/small/directional/east,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "rKA" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo3"
@@ -43646,14 +43677,8 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "sOd" = (
-/obj/structure/chair/comfy/corp{
-	dir = 8
-	},
-/obj/structure/chair/comfy/corp{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
+/turf/simulated/wall/mineral/titanium,
+/area/space/nearstation/centcom)
 "sOo" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
@@ -43894,8 +43919,8 @@
 /area/centcom/ss220/bar)
 "sSB" = (
 /turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "navyblue"
+	dir = 1;
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "sTi" = (
@@ -46864,6 +46889,14 @@
 /obj/item/bedsheet/yellow,
 /turf/simulated/floor/wood,
 /area/ghost_bar/indoor)
+"upE" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "upJ" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1
@@ -47079,11 +47112,13 @@
 	},
 /area/syndicate_mothership/outside)
 "uuh" = (
-/obj/effect/spawner/random/traders/large_item,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/structure/chair/comfy/corp{
+	dir = 8
 	},
+/obj/structure/chair/comfy/corp{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "uus" = (
 /obj/item/flag/nt,
@@ -47166,9 +47201,12 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "uxC" = (
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "traderwinshut"
 	},
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "uxD" = (
 /obj/effect/turf_decal/siding/wood/oak{
@@ -48930,8 +48968,13 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/space/nearstation/centcom)
 "vlY" = (
-/turf/simulated/floor/catwalk,
-/area/shuttle/trade/sol)
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "traderwinshut"
+	},
+/turf/simulated/floor/plating,
+/area/space/nearstation/centcom)
 "vmm" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/beach/away/water{
@@ -49132,14 +49175,6 @@
 /obj/structure/flora/tree/jungle,
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
-"vrn" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/donksoft,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "vru" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/oak,
@@ -49529,8 +49564,11 @@
 /area/syndicate_mothership)
 "vwx" = (
 /obj/effect/turf_decal/delivery/white,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 10;
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "vwI" = (
@@ -49844,20 +49882,6 @@
 "vCF" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/park)
-"vCP" = (
-/obj/item/reagent_containers/drinks/bottle/whiskey,
-/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/item/clothing/mask/cigarette/cigar/havana,
-/obj/item/clothing/mask/cigarette/cigar/havana,
-/obj/item/lighter/zippo/engraved,
-/obj/item/lighter/zippo/engraved,
-/obj/structure/closet/cabinet,
-/obj/effect/turf_decal/delivery/white,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluecorners"
-	},
-/area/shuttle/trade/sol)
 "vCS" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
@@ -50582,12 +50606,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
-"vSB" = (
-/obj/effect/turf_decal/siding/wood/oak/end{
-	dir = 8
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "vSF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51014,6 +51032,15 @@
 /obj/structure/table/glass/reinforced/titanium,
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/admin2)
+"wfd" = (
+/obj/machinery/light/spot/directional/south,
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/machinery/door_control/shutter/south{
+	id = "traderwinshut";
+	req_access = list(160)
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "wfs" = (
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/plasteel/dark{
@@ -53026,9 +53053,13 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/ss220/general)
 "wWd" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
-/area/space/nearstation/centcom)
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "wWg" = (
 /obj/machinery/door/poddoor{
 	id_tag = "SIT_ready";
@@ -55014,7 +55045,6 @@
 "xOB" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/closet,
-/obj/item/stack/tile/disco_light/thirty,
 /obj/effect/spawner/random/traders/service,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
@@ -94002,7 +94032,7 @@ adJ
 mYc
 cOi
 ltM
-lEE
+uxC
 ltM
 ltM
 qGf
@@ -94257,20 +94287,20 @@ adJ
 adJ
 adJ
 mYc
-avr
+sOd
 umj
-vSB
-uxC
-dvw
-beM
-lmP
-lmP
-uxC
+eeJ
+bSn
+eEG
+pZI
+wWd
+wWd
+bSn
 xOL
-vlY
-vlY
+anB
+anB
 umj
-avr
+sOd
 mYc
 iTR
 iTR
@@ -94514,20 +94544,20 @@ adJ
 adJ
 adJ
 mYc
-wWd
-jDq
+vlY
+bUc
 lqX
-vCP
+cUS
 ltM
 dyG
-sSB
-sSB
+avr
+avr
 msS
 ltM
 kry
-rKz
-fQO
-avr
+cCP
+ngi
+sOd
 mYc
 iTR
 iTR
@@ -94771,14 +94801,14 @@ adJ
 adJ
 adJ
 mYc
-lEE
+dtV
 sQY
-bwv
+wfd
 umj
 ltM
 ltM
-bSn
-pWc
+eYC
+fsE
 ltM
 ltM
 ltM
@@ -95028,18 +95058,18 @@ adJ
 adJ
 adJ
 mYc
-lEE
+dtV
 dvR
 kBd
 ltM
-alD
+bdG
 ima
 ima
 ima
 ima
-eYC
+vwx
 ltM
-naO
+esY
 dOd
 ltM
 mYc
@@ -95290,13 +95320,13 @@ ltM
 ltM
 ltM
 jKW
-esY
-phG
+kne
 fHx
-esY
+gBF
+kne
 fYD
 ltM
-hKx
+sSB
 qnb
 lEE
 mYc
@@ -95543,18 +95573,18 @@ adJ
 adJ
 mYc
 ltM
-pVD
+qPp
 uxD
-cCP
+ftp
 kcV
-esY
+kne
 mtL
 rBy
-esY
+kne
 bka
-cCP
-hKx
-vrn
+ftp
+sSB
+upE
 lEE
 mYc
 iTR
@@ -95800,18 +95830,18 @@ adJ
 adJ
 mYc
 ltM
-gPp
-bfU
+lUj
+rhr
 ltM
-ftp
-esY
-xOB
-vwx
-esY
-oIQ
-ltM
-hKx
+hqg
 kne
+xOB
+beM
+kne
+nwo
+ltM
+sSB
+oIQ
 ltM
 mYc
 iTR
@@ -96058,17 +96088,17 @@ adJ
 mYc
 lEE
 vMa
-bfU
+rhr
 ltM
 hbo
 nVU
-sSB
-sSB
+avr
+avr
 nVU
 muG
 ltM
-hKx
-bdG
+sSB
+iZf
 ltM
 mYc
 iTR
@@ -96314,7 +96344,7 @@ adJ
 adJ
 mYc
 lEE
-dtV
+kqx
 izZ
 ltM
 ltM
@@ -96325,7 +96355,7 @@ xQo
 ltM
 ltM
 ogy
-kqx
+lmP
 lEE
 mYc
 iTR
@@ -96571,18 +96601,18 @@ adJ
 adJ
 mYc
 lEE
-sOd
-bfU
-ltM
-anB
-lkV
-aQD
-aQD
-lkV
-nHZ
-ltM
-hKx
 uuh
+rhr
+ltM
+nHZ
+lkV
+aQD
+aQD
+lkV
+dvw
+ltM
+sSB
+mdh
 lEE
 mYc
 mYc
@@ -96829,17 +96859,17 @@ adJ
 mYc
 ltM
 oeK
-qQk
-qNq
-dxj
-sHv
-sHv
-sHv
-sHv
 bJE
+qNq
+qgo
+sHv
+sHv
+sHv
+sHv
+alD
 gTY
-rpQ
-rhr
+hKx
+pVD
 ltM
 xPv
 hOY
@@ -97347,8 +97377,8 @@ bFH
 ltM
 xAm
 ske
-gBF
-gBF
+bwv
+bwv
 fAB
 aAt
 ltM

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -371,10 +371,11 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/general)
 "alD" = (
-/obj/item/flag/solgov,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
 /turf/simulated/floor/plasteel/dark{
-	dir = 1;
+	dir = 9;
 	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
@@ -426,10 +427,11 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
 "anB" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plating,
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "anH" = (
 /obj/structure/table/tray,
@@ -855,11 +857,8 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "avr" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
+/turf/simulated/wall/mineral/titanium,
+/area/space/nearstation/centcom)
 "avt" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/effect/mapping_helpers/light,
@@ -2245,8 +2244,11 @@
 	},
 /area/syndicate_mothership/jail)
 "bdG" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/fancy/oak,
+/obj/structure/rack,
+/obj/item/storage/box/crewvend,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "bed" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -2272,10 +2274,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "beM" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "beO" = (
 /obj/structure/light_fake/spot{
@@ -2309,6 +2311,10 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
+"bfU" = (
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "bfW" = (
 /turf/simulated/floor/mineral/plastitanium{
 	color = "#fff894";
@@ -3194,11 +3200,9 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "bwv" = (
-/obj/effect/turf_decal/delivery/white,
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "navyblue"
-	},
+/obj/machinery/light/spot/directional/south,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "bwG" = (
 /obj/structure/showcase,
@@ -3719,10 +3723,8 @@
 	},
 /area/ghost_bar/indoor)
 "bJE" = (
-/obj/structure/chair/comfy/corp{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/royalblue,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "bJI" = (
 /obj/structure/table/wood,
@@ -4183,7 +4185,7 @@
 /area/centcom/ss220/bar)
 "bSn" = (
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	icon_state = "navybluefull"
 	},
 /area/shuttle/trade/sol)
 "bSp" = (
@@ -5801,21 +5803,10 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "cCP" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/shuttle/engine/platform{
-	layer = 2.9;
-	dir = 4
-	},
-/obj/structure/shuttle/engine/heater{
-	icon_state = "heater2x2_side";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless,
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "cCU" = (
 /turf/simulated/floor/beach/away/water{
@@ -7785,11 +7776,14 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "dtV" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/obj/effect/turf_decal/siding/wood/oak/corner{
-	dir = 1
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/paper_bin{
+	pixel_y = 3
 	},
-/turf/simulated/floor/wood/fancy/oak,
+/obj/item/pen/fancy{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "dub" = (
 /obj/structure/window/reinforced{
@@ -7840,9 +7834,11 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "dvw" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /turf/simulated/floor/plasteel/dark{
-	dir = 5;
-	icon_state = "darkbrown"
+	icon_state = "navybluefull"
 	},
 /area/shuttle/trade/sol)
 "dvG" = (
@@ -7902,6 +7898,12 @@
 /obj/item/bedsheet/blue,
 /turf/simulated/floor/carpet/blue,
 /area/ghost_bar/indoor)
+"dxj" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "dxQ" = (
 /obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/plasteel/dark,
@@ -8798,13 +8800,6 @@
 	icon_state = "darkgreen"
 	},
 /area/centcom/ss220/admin3)
-"dNq" = (
-/obj/machinery/light/small/directional/west,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "darkbrown"
-	},
-/area/shuttle/trade/sol)
 "dNJ" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/gavelblock{
@@ -10066,14 +10061,9 @@
 	},
 /area/tdome/tdomeadmin)
 "esY" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/flashlight/lamp{
-	pixel_y = 5
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "etc" = (
 /obj/structure/mirror{
@@ -10124,14 +10114,6 @@
 /obj/item/flag/species/vox,
 /turf/simulated/floor/plating/nitrogen,
 /area/vox_base)
-"etQ" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "etS" = (
 /obj/effect/decal/nanotrasen_logo_circle{
 	icon_state = "ntlogo_sec";
@@ -11599,7 +11581,9 @@
 	},
 /area/ghost_bar/indoor)
 "eYC" = (
+/obj/effect/turf_decal/delivery/white,
 /turf/simulated/floor/plasteel/dark{
+	dir = 10;
 	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
@@ -12760,7 +12744,12 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "ftp" = (
-/turf/simulated/floor/catwalk,
+/obj/item/flag/solgov,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "fts" = (
 /obj/item/flag/nt,
@@ -13420,7 +13409,8 @@
 /area/centcom/ss220/medbay)
 "fHx" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/landmark/spawner/tradergearminor,
+/obj/effect/spawner/random/traders/medical,
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -13769,6 +13759,19 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/general)
+"fQO" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/painter,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/toy/crayon/spraycan,
+/obj/structure/shelf,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "fQY" = (
 /obj/machinery/economy/vending/cigarette/syndicate/free,
 /turf/simulated/floor/wood/oak,
@@ -13954,11 +13957,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/ghost_bar/indoor)
-"fVj" = (
-/obj/machinery/light/spot/directional/south,
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "fVr" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -14124,6 +14122,7 @@
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/spawner/random/traders/science,
 /obj/structure/closet,
+/obj/effect/spawner/random/oil/maybe,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "navyblue"
 	},
@@ -15194,12 +15193,10 @@
 	},
 /area/ninja/holding)
 "gBF" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/donksoft,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 4
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "gBI" = (
 /obj/effect/turf_decal/siding/wood/oak/corner{
@@ -15851,6 +15848,13 @@
 /obj/effect/spawner/random/ccfood/dessert,
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/bar)
+"gPp" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "gPu" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/mapping_helpers/light,
@@ -16394,19 +16398,15 @@
 	id = "soltrader_north";
 	name = "Trade Deposits Door";
 	normaldoorcontrol = 1;
-	pixel_y = 8;
-	req_access = list(160)
-	},
-/obj/machinery/door_control/no_emag/east{
-	id = "trader_privacy";
-	name = "Privacy Shutters Control";
-	pixel_y = -8;
-	req_access = list(160)
+	pixel_y = 24;
+	req_access = list(160);
+	pixel_x = 0
 	},
 /obj/machinery/flasher_button{
 	id = "soltraderflash";
 	pixel_x = 24;
-	req_access = list(160)
+	req_access = list(160);
+	pixel_y = -4
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/package_wrap{
@@ -16422,6 +16422,12 @@
 	pixel_y = 9
 	},
 /obj/item/hand_labeler,
+/obj/machinery/door_control/no_emag/east{
+	id = "trader_privacy";
+	name = "Privacy Shutters Control";
+	pixel_y = 4;
+	req_access = list(160)
+	},
 /turf/simulated/floor/plasteel/dark{
 	dir = 5;
 	icon_state = "navyblue"
@@ -18052,8 +18058,10 @@
 	},
 /area/centcom/ss220/admin3)
 "hKx" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/parquet/oak,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "darkbrown"
+	},
 /area/shuttle/trade/sol)
 "hKA" = (
 /obj/effect/turf_decal/tile/neutral/full{
@@ -22381,15 +22389,6 @@
 	icon_state = "darkneutralfull"
 	},
 /area/syndicate_mothership/infteam)
-"jCs" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/civilian,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
 "jCR" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -22412,6 +22411,14 @@
 	icon_state = "dark_herringbone"
 	},
 /area/centcom/ss220/command)
+"jDq" = (
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "jDz" = (
 /turf/simulated/floor/plasteel/dark{
 	dir = 4;
@@ -22426,15 +22433,6 @@
 	icon_state = "darkbrown"
 	},
 /area/syndicate_mothership/jail)
-"jEb" = (
-/obj/structure/rack,
-/obj/item/storage/bag/money{
-	pixel_y = 8
-	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "jEd" = (
 /obj/structure/platform{
 	dir = 8;
@@ -23953,9 +23951,12 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
 "kne" = (
-/obj/item/flag/solgov,
+/obj/structure/rack,
+/obj/item/storage/bag/money{
+	pixel_y = 8
+	},
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "kni" = (
@@ -24136,14 +24137,13 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "kqx" = (
-/obj/item/paper_bin{
-	pixel_y = 3
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/engineering,
+/obj/effect/spawner/random/oil/maybe,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/obj/item/pen/fancy{
-	pixel_y = 4
-	},
-/obj/structure/table/wood/fancy/royalblue,
-/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "kqN" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -26312,13 +26312,6 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
-"lkK" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "lkU" = (
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/control)
@@ -26372,10 +26365,12 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/park)
 "lmP" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
+/obj/structure/chair/comfy/shuttle/dark{
+	dir = 8
 	},
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "lnf" = (
 /obj/structure/filingcabinet,
@@ -26530,13 +26525,11 @@
 	},
 /area/syndicate_mothership/control)
 "lqX" = (
-/obj/structure/closet/walllocker/emerglocker/directional/east,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/machinery/light/small/directional/east,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "lrc" = (
 /obj/docking_port/stationary{
@@ -29039,6 +29032,7 @@
 /area/syndicate_mothership/control)
 "mtL" = (
 /obj/effect/turf_decal/delivery/white,
+/obj/effect/spawner/random/oil/often,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -29110,13 +29104,14 @@
 /obj/machinery/door_control/no_emag/east{
 	id = "trader_privacy";
 	name = "Privacy Shutters Control";
-	pixel_y = 8;
+	pixel_y = 4;
 	req_access = list(160)
 	},
 /obj/machinery/flasher_button{
 	id = "soltraderflash";
 	pixel_x = 24;
-	req_access = list(160)
+	req_access = list(160);
+	pixel_y = -4
 	},
 /obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
@@ -30393,6 +30388,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape)
+"naO" = (
+/obj/machinery/light/small/directional/west,
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "darkbrown"
+	},
+/area/shuttle/trade/sol)
 "naQ" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -32747,13 +32749,11 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "oeK" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/minerals,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "darkbrown"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 5
 	},
+/obj/item/flag/solgov,
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "ofn" = (
 /obj/item/kirbyplants/large,
@@ -34002,12 +34002,9 @@
 	},
 /area/ghost_bar/indoor)
 "oIQ" = (
-/obj/structure/closet,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/traders/engineering,
-/obj/effect/spawner/random/oil/maybe,
+/obj/item/flag/solgov,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "oJf" = (
@@ -34607,12 +34604,6 @@
 	icon_state = "hydrofloor"
 	},
 /area/ghost_bar/indoor)
-"oWg" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
-	},
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "oWk" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/effect/spawner/random/ccfood/meat,
@@ -35188,6 +35179,13 @@
 	icon_state = "dark"
 	},
 /area/centcom/ss220/jail)
+"phG" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "phM" = (
 /obj/structure/table/glass/reinforced/titanium,
 /obj/item/kirbyplants/large{
@@ -36805,9 +36803,20 @@
 /area/trader_station/sol)
 "pVD" = (
 /obj/effect/turf_decal/siding/wood/oak{
-	dir = 10
+	dir = 9
 	},
+/obj/machinery/economy/vending/cigarette/beach,
 /turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
+"pWc" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
 /area/shuttle/trade/sol)
 "pWf" = (
 /turf/simulated/floor/holofloor{
@@ -38050,16 +38059,6 @@
 "qBQ" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/park)
-"qCq" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2
-	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
-/area/shuttle/trade/sol)
 "qCH" = (
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/simulated/wall/mineral/plastitanium,
@@ -38674,6 +38673,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
+"qQk" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "qQI" = (
 /obj/structure/table/glass,
 /obj/item/food/applepie,
@@ -39183,13 +39188,6 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/medbay)
-"raa" = (
-/obj/item/flag/solgov,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "ram" = (
 /obj/structure/mecha_wreckage/durand/old{
 	icon_state = "old_durand";
@@ -39471,13 +39469,12 @@
 	},
 /area/ghost_bar/indoor)
 "rhr" = (
-/obj/effect/turf_decal/delivery/white,
 /obj/structure/closet,
-/obj/effect/spawner/random/traders/service,
-/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/minerals,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark{
 	dir = 4;
-	icon_state = "navyblue"
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "rhs" = (
@@ -39872,6 +39869,12 @@
 	},
 /turf/simulated/floor/wood/parquet,
 /area/centcom/ss220/admin2)
+"rpQ" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "darkbrown"
+	},
+/area/shuttle/trade/sol)
 "rpU" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/machinery/photocopier/faxmachine/longrange{
@@ -40651,10 +40654,6 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/evac)
-"rCy" = (
-/obj/effect/spawner/window/shuttle,
-/turf/simulated/floor/plating,
-/area/space/nearstation/centcom)
 "rCF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/dirt,
@@ -40969,6 +40968,15 @@
 	},
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership/infteam)
+"rKz" = (
+/obj/structure/closet/walllocker/emerglocker/directional/east,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/machinery/light/small/directional/east,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "rKA" = (
 /obj/effect/decal/syndie_logo{
 	icon_state = "logo3"
@@ -42300,12 +42308,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
-"skn" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
-	},
 /area/shuttle/trade/sol)
 "skx" = (
 /turf/simulated/floor/plasteel{
@@ -43644,18 +43646,13 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "sOd" = (
-/obj/item/reagent_containers/drinks/bottle/whiskey,
-/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/item/clothing/mask/cigarette/cigar/havana,
-/obj/item/clothing/mask/cigarette/cigar/havana,
-/obj/item/lighter/zippo/engraved,
-/obj/item/lighter/zippo/engraved,
-/obj/structure/closet/cabinet,
-/obj/effect/turf_decal/delivery/white,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluecorners"
+/obj/structure/chair/comfy/corp{
+	dir = 8
 	},
+/obj/structure/chair/comfy/corp{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "sOo" = (
 /turf/simulated/wall/mineral/plastitanium,
@@ -43788,21 +43785,14 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "sQY" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
 	},
-/obj/structure/shuttle/engine/platform{
-	layer = 2.9;
-	dir = 4
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
 	},
-/obj/structure/shuttle/engine/heater{
-	icon_state = "heater2x2";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "sRe" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -43903,8 +43893,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
 "sSB" = (
-/turf/simulated/wall/mineral/titanium,
-/area/space/nearstation/centcom)
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "sTi" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/beach/away/water{
@@ -44929,14 +44922,6 @@
 	icon_state = "dark_herringbone"
 	},
 /area/centcom/ss220/admin1)
-"ttf" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/traders/medical,
-/obj/structure/closet,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "ttK" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -47181,16 +47166,15 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "uxC" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 4
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "uxD" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "darkbrown"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 10
 	},
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "uxH" = (
 /obj/structure/curtain/black{
@@ -48946,11 +48930,7 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/space/nearstation/centcom)
 "vlY" = (
-/obj/effect/turf_decal/delivery/white,
-/turf/simulated/floor/plasteel/dark{
-	dir = 10;
-	icon_state = "navyblue"
-	},
+/turf/simulated/floor/catwalk,
 /area/shuttle/trade/sol)
 "vmm" = (
 /obj/structure/fans/tiny/invisible,
@@ -49152,6 +49132,14 @@
 /obj/structure/flora/tree/jungle,
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/syndicate_mothership/outside)
+"vrn" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "vru" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/oak,
@@ -49540,10 +49528,10 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "vwx" = (
-/obj/effect/turf_decal/siding/wood/oak/end{
-	dir = 8
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "vwI" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
@@ -49856,6 +49844,20 @@
 "vCF" = (
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/park)
+"vCP" = (
+/obj/item/reagent_containers/drinks/bottle/whiskey,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/lighter/zippo/engraved,
+/obj/item/lighter/zippo/engraved,
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluecorners"
+	},
+/area/shuttle/trade/sol)
 "vCS" = (
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/assault_pod)
@@ -50325,11 +50327,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
 "vMa" = (
-/obj/structure/rack,
-/obj/item/storage/box/crewvend,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/structure/chair/comfy/corp{
+	dir = 4
 	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "vMi" = (
 /obj/structure/chair/sofa/corp/left{
@@ -50581,6 +50582,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate)
+"vSB" = (
+/obj/effect/turf_decal/siding/wood/oak/end{
+	dir = 8
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "vSF" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -52247,15 +52254,6 @@
 	},
 /turf/simulated/floor/wood/cherry,
 /area/ghost_bar/indoor)
-"wDB" = (
-/obj/structure/chair/comfy/corp{
-	dir = 8
-	},
-/obj/structure/chair/comfy/corp{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
 "wDC" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/item/folder/red{
@@ -52940,13 +52938,6 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership/elite_squad)
-"wSC" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/obj/machinery/economy/vending/cigarette/beach,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "wSY" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -53035,13 +53026,9 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/ss220/general)
 "wWd" = (
-/obj/structure/chair/comfy/shuttle/dark{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/space/nearstation/centcom)
 "wWg" = (
 /obj/machinery/door/poddoor{
 	id_tag = "SIT_ready";
@@ -54407,13 +54394,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/ninja/holding)
-"xAb" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 5
-	},
-/obj/item/flag/solgov,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "xAd" = (
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -55032,8 +55012,12 @@
 /turf/simulated/floor/plasteel/goonplaque/memorial,
 /area/centcom/ss220/park)
 "xOB" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/effect/spawner/random/traders/service,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "xOF" = (
@@ -55043,9 +55027,8 @@
 /obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "xOQ" = (
 /obj/machinery/economy/merch,
@@ -55102,10 +55085,15 @@
 	},
 /obj/machinery/door/window{
 	dir = 4;
-	name = "Стойка";
-	req_access = list(160)
+	name = "Стойка"
 	},
 /obj/structure/table/wood/fancy/royalblue,
+/obj/machinery/door/window/reinforced/normal{
+	dir = 8;
+	req_access = list(160);
+	name = "Стойка"
+	},
+/obj/item/desk_bell,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "xQE" = (
@@ -55918,19 +55906,6 @@
 "yjG" = (
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/park)
-"yjJ" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 15
-	},
-/obj/item/painter,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/toy/crayon/spraycan,
-/obj/structure/shelf,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "yjM" = (
 /obj/machinery/door/airlock/hatch/syndicate,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -94282,20 +94257,20 @@ adJ
 adJ
 adJ
 mYc
-sSB
+avr
 umj
-vwx
-eYC
+vSB
+uxC
+dvw
+beM
+lmP
+lmP
+uxC
 xOL
-skn
-wWd
-wWd
-eYC
-anB
-ftp
-ftp
+vlY
+vlY
 umj
-sSB
+avr
 mYc
 iTR
 iTR
@@ -94539,20 +94514,20 @@ adJ
 adJ
 adJ
 mYc
-rCy
-etQ
-dtV
-sOd
+wWd
+jDq
+lqX
+vCP
 ltM
 dyG
-avr
-avr
+sSB
+sSB
 msS
 ltM
 kry
-lqX
-yjJ
-sSB
+rKz
+fQO
+avr
 mYc
 iTR
 iTR
@@ -94797,13 +94772,13 @@ adJ
 adJ
 mYc
 lEE
-esY
-fVj
+sQY
+bwv
 umj
 ltM
 ltM
-xOB
-qCq
+bSn
+pWc
 ltM
 ltM
 ltM
@@ -95057,14 +95032,14 @@ lEE
 dvR
 kBd
 ltM
-jCs
+alD
 ima
 ima
 ima
 ima
-vlY
+eYC
 ltM
-dNq
+naO
 dOd
 ltM
 mYc
@@ -95315,13 +95290,13 @@ ltM
 ltM
 ltM
 jKW
-bSn
+esY
+phG
 fHx
-ttf
-bSn
+esY
 fYD
 ltM
-uxD
+hKx
 qnb
 lEE
 mYc
@@ -95568,18 +95543,18 @@ adJ
 adJ
 mYc
 ltM
-wSC
 pVD
-beM
+uxD
+cCP
 kcV
-bSn
+esY
 mtL
 rBy
-bSn
+esY
 bka
-beM
-uxD
-gBF
+cCP
+hKx
+vrn
 lEE
 mYc
 iTR
@@ -95825,18 +95800,18 @@ adJ
 adJ
 mYc
 ltM
-lkK
+gPp
+bfU
+ltM
+ftp
+esY
+xOB
+vwx
+esY
+oIQ
+ltM
 hKx
-ltM
-alD
-bSn
-bSn
-bSn
-bSn
 kne
-ltM
-uxD
-jEb
 ltM
 mYc
 iTR
@@ -96082,18 +96057,18 @@ adJ
 adJ
 mYc
 lEE
-bJE
-hKx
+vMa
+bfU
 ltM
 hbo
 nVU
-rhr
-bwv
+sSB
+sSB
 nVU
 muG
 ltM
-uxD
-vMa
+hKx
+bdG
 ltM
 mYc
 iTR
@@ -96339,7 +96314,7 @@ adJ
 adJ
 mYc
 lEE
-kqx
+dtV
 izZ
 ltM
 ltM
@@ -96350,7 +96325,7 @@ xQo
 ltM
 ltM
 ogy
-oIQ
+kqx
 lEE
 mYc
 iTR
@@ -96596,17 +96571,17 @@ adJ
 adJ
 mYc
 lEE
-wDB
-hKx
+sOd
+bfU
 ltM
-raa
+anB
 lkV
 aQD
 aQD
 lkV
 nHZ
 ltM
-uxD
+hKx
 uuh
 lEE
 mYc
@@ -96853,18 +96828,18 @@ adJ
 adJ
 mYc
 ltM
-xAb
-oWg
-qNq
-lmP
-sHv
-sHv
-sHv
-sHv
-bdG
-gTY
-dvw
 oeK
+qQk
+qNq
+dxj
+sHv
+sHv
+sHv
+sHv
+bJE
+gTY
+rpQ
+rhr
 ltM
 xPv
 hOY
@@ -97110,8 +97085,8 @@ adJ
 adJ
 mYc
 ltM
-sQY
-cCP
+ltM
+ltM
 ltM
 mzP
 sHv
@@ -97120,8 +97095,8 @@ sHv
 sHv
 fAC
 ltM
-sQY
-cCP
+ltM
+ltM
 ltM
 xPv
 glh
@@ -97372,8 +97347,8 @@ bFH
 ltM
 xAm
 ske
-uxC
-uxC
+gBF
+gBF
 fAB
 aAt
 ltM

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -371,8 +371,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/general)
 "alD" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "alK" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -422,7 +424,10 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
 "anB" = (
-/turf/simulated/floor/catwalk,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "anH" = (
 /obj/structure/table/tray,
@@ -517,6 +522,16 @@
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar/indoor)
+"apc" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/obj/machinery/door_control/shutter/south{
+	id = "traderwinshut";
+	req_access = list(160)
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "apf" = (
 /obj/structure/table/reinforced{
 	color = "#444444"
@@ -1639,6 +1654,14 @@
 "aPF" = (
 /turf/simulated/floor/carpet/purple,
 /area/wizard_station)
+"aPH" = (
+/obj/item/flag/solgov,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "aPJ" = (
 /obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
 /obj/machinery/door/airlock/hatch{
@@ -2240,10 +2263,9 @@
 "bdG" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/closet,
-/obj/effect/spawner/random/traders/civilian,
+/obj/effect/spawner/random/traders/service,
 /turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "navyblue"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "bed" = (
@@ -2270,9 +2292,9 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "beM" = (
-/obj/effect/turf_decal/delivery/white,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 5;
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "beO" = (
@@ -2989,6 +3011,11 @@
 /obj/structure/statue/cyberiad/nw,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
+"brQ" = (
+/obj/machinery/light/spot/directional/south,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "brY" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkredalt";
@@ -3192,9 +3219,7 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "bwv" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 4
-	},
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "bwG" = (
@@ -3716,10 +3741,14 @@
 	},
 /area/ghost_bar/indoor)
 "bJE" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/paper_bin{
+	pixel_y = 3
 	},
-/turf/simulated/floor/wood/parquet/oak,
+/obj/item/pen/fancy{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "bJI" = (
 /obj/structure/table/wood,
@@ -4179,8 +4208,12 @@
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/bar)
 "bSn" = (
+/obj/structure/rack,
+/obj/item/storage/bag/money{
+	pixel_y = 8
+	},
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "bSp" = (
@@ -4291,14 +4324,6 @@
 	},
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
-"bUc" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "bUd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -4552,6 +4577,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/vox)
+"bXo" = (
+/obj/effect/spawner/random/traders/large_item,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "bXB" = (
 /obj/structure/table/wood,
 /obj/item/grenade/clusterbuster/syndieminibomb,
@@ -4631,6 +4663,15 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/bar)
+"bZA" = (
+/obj/structure/closet/walllocker/emerglocker/directional/east,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/machinery/light/small/directional/east,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "bZE" = (
 /obj/machinery/economy/vending/hydronutrients,
 /turf/simulated/floor/plasteel/dark,
@@ -5477,6 +5518,16 @@
 	name = "vox floor"
 	},
 /area/shuttle/vox)
+"csH" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "csN" = (
 /obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
@@ -5806,13 +5857,10 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "cCP" = (
-/obj/structure/closet/walllocker/emerglocker/directional/east,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/machinery/light/small/directional/east,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "cCU" = (
 /turf/simulated/floor/beach/away/water{
@@ -6431,6 +6479,13 @@
 	water_overlay_image = null
 	},
 /area/centcom/ss220/admin1)
+"cQS" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "cRb" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy,
@@ -6557,20 +6612,6 @@
 	icon_state = "darkbluealt"
 	},
 /area/centcom/ss220/admin3)
-"cUS" = (
-/obj/item/reagent_containers/drinks/bottle/whiskey,
-/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
-/obj/item/clothing/mask/cigarette/cigar/havana,
-/obj/item/clothing/mask/cigarette/cigar/havana,
-/obj/item/lighter/zippo/engraved,
-/obj/item/lighter/zippo/engraved,
-/obj/structure/closet/cabinet,
-/obj/effect/turf_decal/delivery/white,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluecorners"
-	},
-/area/shuttle/trade/sol)
 "cUU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -7796,12 +7837,10 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "dtV" = (
-/obj/effect/spawner/window/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "traderwinshut"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dub" = (
 /obj/structure/window/reinforced{
@@ -7853,10 +7892,9 @@
 /area/centcom/ss220/admin2)
 "dvw" = (
 /obj/item/flag/solgov,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 10
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dvG" = (
 /obj/machinery/computer/arcade/battle,
@@ -7873,10 +7911,7 @@
 /obj/item/bedsheet/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 5
-	},
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "dwn" = (
 /obj/structure/table/wood/fancy/purple,
@@ -9245,6 +9280,12 @@
 	},
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/jail)
+"dYx" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "dYP" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -9438,12 +9479,6 @@
 	name = "vox floor"
 	},
 /area/vox_base)
-"eeJ" = (
-/obj/effect/turf_decal/siding/wood/oak/end{
-	dir = 8
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "eeQ" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -10078,10 +10113,8 @@
 	},
 /area/tdome/tdomeadmin)
 "esY" = (
-/obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "darkbrown"
+	icon_state = "dark_large"
 	},
 /area/shuttle/trade/sol)
 "etc" = (
@@ -10589,14 +10622,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
-"eEG" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
-/area/shuttle/trade/sol)
 "eEH" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkredaltstrip"
@@ -11608,10 +11633,8 @@
 	},
 /area/ghost_bar/indoor)
 "eYC" = (
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
-/area/shuttle/trade/sol)
+/turf/simulated/wall/mineral/titanium,
+/area/space/nearstation/centcom)
 "eYF" = (
 /obj/structure/light_fake,
 /turf/simulated/floor/wood/parquet,
@@ -11623,6 +11646,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
+"eYR" = (
+/obj/structure/chair/comfy/corp{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
 "eZF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12151,6 +12180,11 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
+"fjc" = (
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/turf/simulated/floor/carpet/royalblack,
+/area/shuttle/trade/sol)
 "fje" = (
 /obj/machinery/sleeper/upgraded{
 	dir = 1
@@ -12733,16 +12767,6 @@
 /obj/item/gun/syringe/rapidsyringe,
 /turf/simulated/floor/wood/oak,
 /area/admin)
-"fsE" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2
-	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
-/area/shuttle/trade/sol)
 "fsG" = (
 /obj/structure/table/glass,
 /obj/item/folder/red{
@@ -12779,10 +12803,12 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "ftp" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/spawner/random/traders/medical,
+/obj/structure/closet,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "fts" = (
 /obj/item/flag/nt,
@@ -15212,12 +15238,11 @@
 	},
 /area/ninja/holding)
 "gBF" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/traders/medical,
-/obj/structure/closet,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
 	},
+/obj/machinery/economy/vending/cigarette/beach,
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "gBI" = (
 /obj/effect/turf_decal/siding/wood/oak/corner{
@@ -17103,14 +17128,6 @@
 	icon_state = "dark_large"
 	},
 /area/centcom/ss220/bar)
-"hqg" = (
-/obj/item/flag/solgov,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
 "hqz" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/effect/turf_decal/box/white,
@@ -18081,7 +18098,7 @@
 /area/centcom/ss220/admin3)
 "hKx" = (
 /turf/simulated/floor/plasteel/dark{
-	dir = 5;
+	dir = 1;
 	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
@@ -19741,6 +19758,19 @@
 	icon_state = "cult"
 	},
 /area/holodeck/source_theatre)
+"isl" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/painter,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/structure/shelf,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/crayon/spraycan,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "isq" = (
 /obj/structure/gunrack,
 /obj/effect/turf_decal/delivery/red,
@@ -21244,18 +21274,6 @@
 	},
 /turf/simulated/floor/wood/fancy,
 /area/ghost_bar/outdoor)
-"iZf" = (
-/obj/structure/rack,
-/obj/item/eftpos{
-	pixel_x = -6
-	},
-/obj/item/storage/box/crewvend{
-	pixel_x = 4
-	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "iZn" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -23977,6 +23995,9 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
 "kne" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -24159,14 +24180,13 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "kqx" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/paper_bin{
-	pixel_y = 3
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/engineering,
+/obj/effect/spawner/random/oil/maybe,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/obj/item/pen/fancy{
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "kqN" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24184,16 +24204,18 @@
 /turf/simulated/wall/indestructible/riveted,
 /area/space/centcomm)
 "kry" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 1;
-	pixel_y = 6
+/obj/item/reagent_containers/drinks/bottle/whiskey,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/lighter/zippo/engraved,
+/obj/item/lighter/zippo/engraved,
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
 	},
-/obj/item/storage/toolbox/emergency{
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "krQ" = (
 /obj/structure/chair/wood{
@@ -24617,10 +24639,11 @@
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership/jail)
 "kBd" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
+/obj/machinery/light/small/directional/west,
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "darkbrown"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "kBw" = (
 /obj/structure/table/glass,
@@ -25062,6 +25085,12 @@
 	name = "sand"
 	},
 /area/syndicate_mothership/outside)
+"kHp" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plasteel/dark,
+/area/shuttle/trade/sol)
 "kHq" = (
 /obj/structure/table/reinforced{
 	color = "#444444"
@@ -26133,6 +26162,15 @@
 	dir = 1
 	},
 /area/centcom/ss220/admin3)
+"lgF" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "lgH" = (
 /turf/space/transit,
 /area/space/centcomm)
@@ -26388,13 +26426,10 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/park)
 "lmP" = (
-/obj/structure/closet,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/traders/engineering,
-/obj/effect/spawner/random/oil/maybe,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 4
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "lnf" = (
 /obj/structure/filingcabinet,
@@ -26549,10 +26584,10 @@
 	},
 /area/syndicate_mothership/control)
 "lqX" = (
-/obj/effect/turf_decal/siding/wood/oak,
 /obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood/oak/corner,
 /turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "lrc" = (
@@ -27037,6 +27072,11 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
+"lyx" = (
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "lyy" = (
 /obj/structure/chair/comfy/green{
 	dir = 1
@@ -27982,13 +28022,6 @@
 /obj/structure/chair/comfy/red,
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
-"lUj" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "lUm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sunnybush,
@@ -28393,13 +28426,6 @@
 	icon_state = "brownoldfull"
 	},
 /area/syndicate_mothership/jail)
-"mdh" = (
-/obj/effect/spawner/random/traders/large_item,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "mdm" = (
 /obj/effect/baseturf_helper{
 	baseturf = /turf/simulated/floor/indestructible
@@ -30683,19 +30709,6 @@
 /obj/structure/table/glass/reinforced/titanium,
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/general)
-"ngi" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 15
-	},
-/obj/item/painter,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/item/toy/crayon/spraycan,
-/obj/structure/shelf,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "ngG" = (
 /obj/machinery/atmospherics/portable/canister/toxins,
 /obj/effect/turf_decal/box/white,
@@ -31333,12 +31346,6 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership)
-"nwo" = (
-/obj/item/flag/solgov,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
 "nwt" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/turf_decal/delivery/white,
@@ -33721,6 +33728,13 @@
 /obj/item/book/manual/wiki/sop_service,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
+"oBL" = (
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 10
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "oCk" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkbluealtstrip"
@@ -34052,13 +34066,11 @@
 	},
 /area/ghost_bar/indoor)
 "oIQ" = (
-/obj/structure/rack,
-/obj/item/storage/bag/money{
-	pixel_y = 8
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
 	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
+/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "oJf" = (
 /obj/structure/table/wood,
@@ -36848,13 +36860,16 @@
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
 "pVD" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/minerals,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "darkbrown"
+/obj/structure/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 1;
+	pixel_y = 6
 	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "pWf" = (
 /turf/simulated/floor/holofloor{
@@ -36997,12 +37012,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
-"pZI" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
 "pZL" = (
 /obj/structure/closet/crate/trashcart{
 	name = "Специальная доставка с ЦК"
@@ -37264,12 +37273,6 @@
 	name = "vox floor"
 	},
 /area/vox_base)
-"qgo" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "qgz" = (
 /obj/item/flag/syndi,
 /obj/structure/curtain/black{
@@ -38324,6 +38327,7 @@
 "qGf" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
 	icon_state = "navybluecorners"
@@ -38678,13 +38682,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/syndicate_mothership)
-"qPp" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/obj/machinery/economy/vending/cigarette/beach,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "qPs" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/medal/silver{
@@ -39520,8 +39517,14 @@
 	},
 /area/ghost_bar/indoor)
 "rhr" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/parquet/oak,
+/obj/effect/turf_decal/delivery/white,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
+/turf/simulated/floor/plasteel/dark{
+	dir = 10;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "rhs" = (
 /obj/item/tank/internals/emergency_oxygen/nitrogen{
@@ -43677,8 +43680,13 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "sOd" = (
-/turf/simulated/wall/mineral/titanium,
-/area/space/nearstation/centcom)
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "traderwinshut"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "sOo" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
@@ -43810,14 +43818,12 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "sQY" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/flashlight/lamp{
-	pixel_y = 5
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "traderwinshut"
 	},
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "sRe" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -43919,8 +43925,7 @@
 /area/centcom/ss220/bar)
 "sSB" = (
 /turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "darkbrown"
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "sTi" = (
@@ -46889,14 +46894,6 @@
 /obj/item/bedsheet/yellow,
 /turf/simulated/floor/wood,
 /area/ghost_bar/indoor)
-"upE" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/donksoft,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "upJ" = (
 /obj/structure/chair/sofa/corner{
 	dir = 1
@@ -47201,11 +47198,10 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "uxC" = (
-/obj/effect/spawner/window/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "traderwinshut"
-	},
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "uxD" = (
@@ -48968,13 +48964,9 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/space/nearstation/centcom)
 "vlY" = (
-/obj/effect/spawner/window/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "traderwinshut"
-	},
-/turf/simulated/floor/plating,
-/area/space/nearstation/centcom)
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "vmm" = (
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/beach/away/water{
@@ -49563,14 +49555,13 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "vwx" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/item/stack/tile/disco_light/thirty,
-/obj/structure/closet,
-/turf/simulated/floor/plasteel/dark{
-	dir = 10;
-	icon_state = "navyblue"
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "traderwinshut"
 	},
-/area/shuttle/trade/sol)
+/turf/simulated/floor/plating,
+/area/space/nearstation/centcom)
 "vwI" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1;
@@ -50351,10 +50342,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
 "vMa" = (
-/obj/structure/chair/comfy/corp{
-	dir = 4
+/obj/structure/rack,
+/obj/item/eftpos{
+	pixel_x = -6
 	},
-/turf/simulated/floor/carpet/royalblue,
+/obj/item/storage/box/crewvend{
+	pixel_x = 4
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "vMi" = (
 /obj/structure/chair/sofa/corp/left{
@@ -50902,6 +50899,15 @@
 	icon_state = "darkredalt"
 	},
 /area/centcom/ss220/supply)
+"wbE" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "darkbrown"
+	},
+/area/shuttle/trade/sol)
 "wbL" = (
 /obj/structure/rack,
 /obj/item/mecha_parts/mecha_equipment/medical/rescue_jaw,
@@ -51032,15 +51038,6 @@
 /obj/structure/table/glass/reinforced/titanium,
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/admin2)
-"wfd" = (
-/obj/machinery/light/spot/directional/south,
-/obj/effect/turf_decal/siding/wood/oak,
-/obj/machinery/door_control/shutter/south{
-	id = "traderwinshut";
-	req_access = list(160)
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "wfs" = (
 /obj/machinery/chem_dispenser,
 /turf/simulated/floor/plasteel/dark{
@@ -53485,6 +53482,9 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
+"xgf" = (
+/turf/simulated/floor/catwalk,
+/area/shuttle/trade/sol)
 "xgE" = (
 /obj/structure/sink/kitchen/west,
 /turf/simulated/floor/plasteel{
@@ -55044,8 +55044,6 @@
 /area/centcom/ss220/park)
 "xOB" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/service,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -55057,8 +55055,9 @@
 /obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
 /area/shuttle/trade/sol)
 "xOQ" = (
 /obj/machinery/economy/merch,
@@ -94032,7 +94031,7 @@ adJ
 mYc
 cOi
 ltM
-uxC
+sOd
 ltM
 ltM
 qGf
@@ -94287,20 +94286,20 @@ adJ
 adJ
 adJ
 mYc
-sOd
+eYC
 umj
-eeJ
-bSn
-eEG
-pZI
-wWd
-wWd
-bSn
+anB
+dtV
 xOL
-anB
-anB
+alD
+wWd
+wWd
+sSB
+uxC
+xgf
+xgf
 umj
-sOd
+eYC
 mYc
 iTR
 iTR
@@ -94544,20 +94543,20 @@ adJ
 adJ
 adJ
 mYc
-vlY
-bUc
+vwx
+fjc
 lqX
-cUS
+kry
 ltM
 dyG
 avr
 avr
 msS
 ltM
-kry
-cCP
-ngi
-sOd
+pVD
+bZA
+isl
+eYC
 mYc
 iTR
 iTR
@@ -94801,14 +94800,14 @@ adJ
 adJ
 adJ
 mYc
-dtV
 sQY
-wfd
+oIQ
+brQ
 umj
 ltM
 ltM
-eYC
-fsE
+lyx
+csH
 ltM
 ltM
 ltM
@@ -95058,18 +95057,18 @@ adJ
 adJ
 adJ
 mYc
-dtV
+sQY
 dvR
+apc
+ltM
+lgF
+ima
+ima
+ima
+ima
+rhr
+ltM
 kBd
-ltM
-bdG
-ima
-ima
-ima
-ima
-vwx
-ltM
-esY
 dOd
 ltM
 mYc
@@ -95320,13 +95319,13 @@ ltM
 ltM
 ltM
 jKW
-kne
+esY
 fHx
-gBF
-kne
+ftp
+esY
 fYD
 ltM
-sSB
+hKx
 qnb
 lEE
 mYc
@@ -95573,18 +95572,18 @@ adJ
 adJ
 mYc
 ltM
-qPp
+gBF
 uxD
-ftp
+kHp
 kcV
-kne
+esY
 mtL
 rBy
-kne
+esY
 bka
-ftp
-sSB
-upE
+kHp
+hKx
+kne
 lEE
 mYc
 iTR
@@ -95830,18 +95829,18 @@ adJ
 adJ
 mYc
 ltM
-lUj
-rhr
+cQS
+vlY
 ltM
-hqg
-kne
+aPH
+esY
+bdG
 xOB
-beM
-kne
-nwo
+esY
+dvw
 ltM
-sSB
-oIQ
+hKx
+bSn
 ltM
 mYc
 iTR
@@ -96087,8 +96086,8 @@ adJ
 adJ
 mYc
 lEE
-vMa
-rhr
+eYR
+vlY
 ltM
 hbo
 nVU
@@ -96097,8 +96096,8 @@ avr
 nVU
 muG
 ltM
-sSB
-iZf
+hKx
+vMa
 ltM
 mYc
 iTR
@@ -96344,7 +96343,7 @@ adJ
 adJ
 mYc
 lEE
-kqx
+bJE
 izZ
 ltM
 ltM
@@ -96355,7 +96354,7 @@ xQo
 ltM
 ltM
 ogy
-lmP
+kqx
 lEE
 mYc
 iTR
@@ -96602,17 +96601,17 @@ adJ
 mYc
 lEE
 uuh
-rhr
+vlY
 ltM
 nHZ
 lkV
 aQD
 aQD
 lkV
-dvw
+oBL
 ltM
-sSB
-mdh
+hKx
+bXo
 lEE
 mYc
 mYc
@@ -96859,17 +96858,17 @@ adJ
 mYc
 ltM
 oeK
-bJE
+dYx
 qNq
-qgo
+cCP
 sHv
 sHv
 sHv
 sHv
-alD
+bwv
 gTY
-hKx
-pVD
+beM
+wbE
 ltM
 xPv
 hOY
@@ -97377,8 +97376,8 @@ bFH
 ltM
 xAm
 ske
-bwv
-bwv
+lmP
+lmP
 fAB
 aAt
 ltM

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -371,6 +371,9 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/general)
 "alD" = (
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "alK" = (
@@ -420,12 +423,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
-"anB" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
 "anH" = (
 /obj/structure/table/tray,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -850,10 +847,9 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "avr" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 5
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluecorners"
 	},
-/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "avt" = (
 /obj/structure/flora/tree/jungle/small,
@@ -1050,6 +1046,9 @@
 "aAt" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 6
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
@@ -1686,6 +1685,9 @@
 /area/centcom/ss220/evac)
 "aQD" = (
 /obj/item/kirbyplants/large,
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 8
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "aQG" = (
@@ -2235,10 +2237,8 @@
 	},
 /area/syndicate_mothership/jail)
 "bdG" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/green,
+/obj/machinery/light/small/directional/east,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "bed" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -2271,7 +2271,7 @@
 /obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "beO" = (
 /obj/structure/light_fake/spot{
@@ -2595,7 +2595,7 @@
 "bka" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/science,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "bki" = (
 /turf/simulated/floor/plasteel/stairs/medium{
@@ -3203,7 +3203,7 @@
 /obj/item/hand_labeler{
 	pixel_y = 14
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "bwG" = (
 /obj/structure/showcase,
@@ -3545,9 +3545,13 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
 "bGi" = (
-/obj/effect/turf_decal/siding/wood/cherry/corner,
-/obj/structure/table/wood/fancy/orange,
-/turf/simulated/floor/carpet/royalblack,
+/obj/machinery/computer/nonfunctional{
+	dir = 4;
+	desc = null
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
 /area/shuttle/trade/sol)
 "bGm" = (
 /obj/structure/chair/comfy/brown{
@@ -3719,10 +3723,11 @@
 	},
 /area/ghost_bar/indoor)
 "bJE" = (
+/obj/item/flag/solgov,
 /obj/effect/turf_decal/siding/wood/cherry{
-	dir = 5
+	dir = 9
 	},
-/turf/simulated/floor/carpet/royalblue,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "bJI" = (
 /obj/structure/table/wood,
@@ -4182,10 +4187,7 @@
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/bar)
 "bSn" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/royalblue,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "bSp" = (
 /obj/structure/table/glass/reinforced/plastitanium,
@@ -7783,10 +7785,9 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "dtV" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 9
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/carpet/green,
 /area/shuttle/trade/sol)
 "dub" = (
 /obj/structure/window/reinforced{
@@ -7846,7 +7847,7 @@
 /obj/machinery/door/airlock/titanium/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "dvG" = (
 /obj/machinery/computer/arcade/battle,
@@ -7890,7 +7891,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "dxd" = (
 /obj/structure/bed,
@@ -7943,7 +7944,10 @@
 /area/holodeck/source_boxingcourt)
 "dyG" = (
 /obj/machinery/light/spot/directional/north,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "dyK" = (
 /obj/structure/railing/corner{
@@ -10045,12 +10049,6 @@
 	icon_state = "vault"
 	},
 /area/tdome/tdomeadmin)
-"esY" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
 "etc" = (
 /obj/structure/mirror{
 	pixel_x = -30
@@ -11574,7 +11572,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "eYF" = (
 /obj/structure/light_fake,
@@ -12742,7 +12740,7 @@
 /obj/machinery/door/airlock/titanium/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "fts" = (
 /obj/item/flag/nt,
@@ -13091,11 +13089,15 @@
 	id = "soltraderflash";
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "fAC" = (
 /obj/machinery/light/spot/directional/south,
 /obj/machinery/economy/atm/directional/south,
+/obj/effect/turf_decal/siding/wood/cherry,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "fAH" = (
@@ -13396,12 +13398,6 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/medbay)
-"fHx" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
 "fHY" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/mug{
@@ -14096,7 +14092,7 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/medical,
 /obj/machinery/light/spot/directional/south,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "fZl" = (
 /turf/simulated/wall/indestructible/syndishuttle/nodiagonal,
@@ -15164,10 +15160,9 @@
 	},
 /area/ninja/holding)
 "gBF" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/green,
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "gBI" = (
 /obj/effect/turf_decal/siding/wood/oak/corner{
@@ -15981,8 +15976,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "gUm" = (
 /obj/structure/flora/ausbushes/fullgrass{
@@ -16383,7 +16377,7 @@
 	pixel_x = 24;
 	req_access = list(160)
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "hbp" = (
 /obj/structure/gunrack,
@@ -19372,7 +19366,7 @@
 "ima" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/security,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "img" = (
 /turf/simulated/floor/wood/parquet,
@@ -20894,11 +20888,10 @@
 /turf/simulated/floor/carpet/arcade,
 /area/admin)
 "iTn" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 6
+/turf/simulated/floor/plasteel/dark{
+	dir = 8;
+	icon_state = "navybluecorners"
 	},
-/obj/item/kirbyplants/large,
-/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "iTs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21034,13 +21027,12 @@
 	},
 /area/syndicate_mothership)
 "iVL" = (
-/obj/effect/turf_decal/siding/wood/cherry/corner{
-	dir = 4
-	},
 /obj/machinery/computer/shuttle/trade/sol{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/royalblack,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
 /area/shuttle/trade/sol)
 "iWc" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -22764,7 +22756,7 @@
 /obj/effect/spawner/random/traders/service,
 /obj/machinery/light/spot/directional/north,
 /obj/item/stack/tile/disco_light/thirty,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "jLd" = (
 /obj/structure/table/wood/fancy/blue,
@@ -23453,7 +23445,7 @@
 "kcV" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/civilian,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "kcW" = (
 /turf/simulated/floor/plasteel/dark{
@@ -23887,8 +23879,10 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
 "kne" = (
-/obj/effect/turf_decal/siding/wood/cherry,
-/turf/simulated/floor/carpet/royalblue,
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "kni" = (
 /obj/structure/light_fake/small{
@@ -24093,9 +24087,10 @@
 /turf/simulated/wall/indestructible/riveted,
 /area/space/centcomm)
 "kry" = (
-/obj/structure/table/wood/fancy/red,
 /obj/machinery/light/small/directional/east,
-/turf/simulated/floor/carpet/royalblue,
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "krQ" = (
 /obj/structure/chair/wood{
@@ -26242,6 +26237,9 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 8
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "lkZ" = (
@@ -26284,15 +26282,6 @@
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/park)
-"lmP" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 1
-	},
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/royalblack,
-/area/shuttle/trade/sol)
 "lnf" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel/dark,
@@ -26446,9 +26435,8 @@
 	},
 /area/syndicate_mothership/control)
 "lqX" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/simulated/floor/carpet/royalblue,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "lrc" = (
 /obj/docking_port/stationary{
@@ -28933,7 +28921,10 @@
 /area/centcom/ss220/supply)
 "msS" = (
 /obj/machinery/light/spot/directional/south,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark{
+	dir = 6;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "mth" = (
 /obj/structure/light_fake/small{
@@ -28949,7 +28940,7 @@
 /area/syndicate_mothership/control)
 "mtL" = (
 /obj/effect/landmark/spawner/tradergearminor,
-/turf/simulated/floor/carpet/royalblue,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "mtR" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -29034,7 +29025,7 @@
 	pixel_x = 24;
 	req_access = list(160)
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "muV" = (
 /obj/item/flag/nt,
@@ -29270,6 +29261,9 @@
 "mzP" = (
 /obj/machinery/light/spot/directional/north,
 /obj/machinery/economy/atm/directional/north,
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 1
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "mAc" = (
@@ -31733,6 +31727,9 @@
 /area/shuttle/syndicate)
 "nHZ" = (
 /obj/item/flag/solgov,
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 10
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "nIb" = (
@@ -32321,7 +32318,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "nVW" = (
 /obj/structure/fans/tiny/invisible,
@@ -33886,10 +33883,8 @@
 	},
 /area/ghost_bar/indoor)
 "oIQ" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/green,
+/obj/effect/turf_decal/siding/wood/cherry,
+/turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "oJf" = (
 /obj/structure/table/wood,
@@ -36678,12 +36673,6 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
-"pVD" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
 "pWf" = (
 /turf/simulated/floor/holofloor{
 	icon_state = "sand";
@@ -38135,11 +38124,10 @@
 	},
 /area/syndicate_mothership/jail)
 "qGf" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 5
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navybluecorners"
 	},
-/obj/item/kirbyplants/large,
-/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "qGr" = (
 /obj/effect/turf_decal/loading_area/white{
@@ -38416,8 +38404,7 @@
 	},
 /obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "qNs" = (
 /obj/structure/light_fake/small{
@@ -39345,7 +39332,7 @@
 /obj/item/hand_labeler{
 	pixel_y = -6
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "rhs" = (
 /obj/item/tank/internals/emergency_oxygen/nitrogen{
@@ -40481,7 +40468,7 @@
 /area/centcom/ss220/admin2)
 "rBy" = (
 /obj/effect/landmark/spawner/tradergearmajor,
-/turf/simulated/floor/carpet/royalblue,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "rBK" = (
 /obj/structure/chair/brass{
@@ -42156,6 +42143,9 @@
 	id = "soltraderflash";
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "skx" = (
@@ -43494,12 +43484,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
-"sOd" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/green,
-/area/shuttle/trade/sol)
 "sOo" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
@@ -43743,10 +43727,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
 "sSB" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 6
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navybluecorners"
 	},
-/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "sTi" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -47015,10 +46999,10 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "uxC" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 6
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/carpet/green,
 /area/shuttle/trade/sol)
 "uxD" = (
 /obj/machinery/door/airlock/titanium,
@@ -48788,7 +48772,7 @@
 "vlY" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/traders/engineering,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "vmm" = (
 /obj/structure/fans/tiny/invisible,
@@ -52855,11 +52839,10 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/ss220/general)
 "wWd" = (
-/obj/effect/turf_decal/siding/wood/cherry,
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/royalblack,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "wWg" = (
 /obj/machinery/door/poddoor{
@@ -54242,6 +54225,9 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wood/cherry{
+	dir = 5
+	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "xAG" = (
@@ -54445,7 +54431,7 @@
 	dheight = 1
 	},
 /obj/docking_port/mobile/trade_sol,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "xGu" = (
 /obj/effect/turf_decal/woodsiding{
@@ -54839,12 +54825,6 @@
 	},
 /turf/simulated/floor/plasteel/goonplaque/memorial,
 /area/centcom/ss220/park)
-"xOB" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/royalblue,
-/area/shuttle/trade/sol)
 "xOF" = (
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
@@ -54856,7 +54836,7 @@
 /obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "xOQ" = (
 /obj/machinery/economy/merch,
@@ -54904,7 +54884,6 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "xQo" = (
-/obj/structure/table/wood/fancy/orange,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "open";
@@ -54917,7 +54896,8 @@
 	name = "Стойка";
 	req_access = list(160)
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "xQE" = (
 /obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
@@ -93569,14 +93549,14 @@ mYc
 cOi
 cOi
 cOi
-ltM
+cOi
 ltM
 lEE
 lEE
 lEE
 lEE
 ltM
-ltM
+cOi
 cOi
 cOi
 cOi
@@ -93834,7 +93814,7 @@ bGi
 iTn
 ltM
 ltM
-lEE
+ltM
 ltM
 cOi
 mYc
@@ -94082,17 +94062,17 @@ adJ
 mYc
 cOi
 lEE
-sHv
-sHv
+gBF
+bSn
 xOL
-alD
-lmP
+uxC
 wWd
-alD
+wWd
+dtV
 xOL
-sHv
-sHv
-lEE
+bSn
+bSn
+ltM
 cOi
 mYc
 iTR
@@ -94347,9 +94327,9 @@ avr
 sSB
 msS
 ltM
-kry
-lqX
-lEE
+bdG
+bSn
+ltM
 cOi
 mYc
 iTR
@@ -94855,12 +94835,12 @@ ltM
 dvR
 kBd
 beM
-alD
-alD
+bSn
+bSn
 ima
 vlY
-alD
-alD
+bSn
+bSn
 eYC
 kBd
 dOd
@@ -95114,9 +95094,9 @@ hKx
 ltM
 jKW
 bSn
-fHx
-fHx
-esY
+bSn
+bSn
+bSn
 fYD
 ltM
 hKx
@@ -95370,10 +95350,10 @@ lEE
 uxD
 ltM
 kcV
-pVD
+bSn
 mtL
 rBy
-kne
+bSn
 bka
 ltM
 uxD
@@ -95626,12 +95606,12 @@ ltM
 hKx
 hKx
 beM
-alD
-bJE
-xOB
-xOB
-anB
-alD
+bSn
+bSn
+bSn
+bSn
+bSn
+bSn
 eYC
 hKx
 hKx
@@ -96397,7 +96377,7 @@ lEE
 uuh
 hKx
 ltM
-nHZ
+bJE
 lkV
 aQD
 aQD
@@ -96654,12 +96634,12 @@ ltM
 oeK
 hKx
 qNq
-alD
-dtV
-bdG
-bdG
+kne
+sHv
+sHv
+sHv
+sHv
 oIQ
-alD
 gTY
 hKx
 oeK
@@ -96912,10 +96892,10 @@ sQY
 cCP
 ltM
 mzP
-gBF
-sOd
-sOd
-uxC
+sHv
+sHv
+sHv
+sHv
 fAC
 ltM
 sQY

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -371,10 +371,12 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/general)
 "alD" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 4
+/obj/item/flag/solgov,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "alK" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -423,6 +425,12 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
+"anB" = (
+/obj/machinery/door/airlock/titanium,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "anH" = (
 /obj/structure/table/tray,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -848,7 +856,8 @@
 /area/syndicate_mothership/control)
 "avr" = (
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluecorners"
+	dir = 4;
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "avt" = (
@@ -1047,10 +1056,10 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "aAE" = (
 /obj/machinery/economy/vending/nt_food/free,
@@ -1684,11 +1693,10 @@
 	},
 /area/centcom/ss220/evac)
 "aQD" = (
-/obj/item/kirbyplants/large,
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "aQG" = (
 /obj/structure/table/wood,
@@ -2237,8 +2245,8 @@
 	},
 /area/syndicate_mothership/jail)
 "bdG" = (
-/obj/machinery/light/small/directional/east,
-/turf/simulated/floor/plasteel/dark,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "bed" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -2265,10 +2273,6 @@
 /area/centcom/ss220/supply)
 "beM" = (
 /obj/machinery/door/airlock/titanium/glass,
-/obj/effect/turf_decal/siding/wood/birch{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /turf/simulated/floor/plasteel/dark,
@@ -2593,9 +2597,10 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "bka" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/science,
-/turf/simulated/floor/plasteel/dark,
+/obj/machinery/light/floor,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "bki" = (
 /turf/simulated/floor/plasteel/stairs/medium{
@@ -3189,21 +3194,11 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "bwv" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap{
-	pixel_y = 3
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
 	},
-/obj/item/stack/package_wrap{
-	pixel_y = 6
-	},
-/obj/item/stack/package_wrap{
-	pixel_y = 9
-	},
-/obj/item/hand_labeler{
-	pixel_y = 14
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "bwG" = (
 /obj/structure/showcase,
@@ -3550,7 +3545,8 @@
 	desc = null
 	},
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
+	dir = 8;
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "bGm" = (
@@ -3723,11 +3719,10 @@
 	},
 /area/ghost_bar/indoor)
 "bJE" = (
-/obj/item/flag/solgov,
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 9
+/obj/structure/chair/comfy/corp{
+	dir = 4
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "bJI" = (
 /obj/structure/table/wood,
@@ -4187,7 +4182,9 @@
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/bar)
 "bSn" = (
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "bSp" = (
 /obj/structure/table/glass/reinforced/plastitanium,
@@ -5813,6 +5810,9 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	icon_state = "heater2x2_side";
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
@@ -7785,9 +7785,11 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "dtV" = (
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+/obj/effect/turf_decal/siding/wood/oak,
+/obj/effect/turf_decal/siding/wood/oak/corner{
+	dir = 1
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dub" = (
 /obj/structure/window/reinforced{
@@ -7838,16 +7840,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "dvw" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 8
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "darkbrown"
 	},
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 4
-	},
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "dvG" = (
 /obj/machinery/computer/arcade/battle,
@@ -7858,8 +7854,16 @@
 /turf/simulated/floor/wood/fancy/birch,
 /area/ghost_bar/outdoor/beach)
 "dvR" = (
-/obj/effect/spawner/random/traders/large_item,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 5
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dwn" = (
 /obj/structure/table/wood/fancy/purple,
@@ -7891,7 +7895,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "dxd" = (
 /obj/structure/bed,
@@ -7945,8 +7949,8 @@
 "dyG" = (
 /obj/machinery/light/spot/directional/north,
 /turf/simulated/floor/plasteel/dark{
-	dir = 5;
-	icon_state = "navyblue"
+	dir = 4;
+	icon_state = "navybluecorners"
 	},
 /area/shuttle/trade/sol)
 "dyK" = (
@@ -8794,6 +8798,13 @@
 	icon_state = "darkgreen"
 	},
 /area/centcom/ss220/admin3)
+"dNq" = (
+/obj/machinery/light/small/directional/west,
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "darkbrown"
+	},
+/area/shuttle/trade/sol)
 "dNJ" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/gavelblock{
@@ -8824,8 +8835,13 @@
 	},
 /area/shuttle/vox)
 "dOd" = (
-/obj/effect/spawner/random/traders/vehicle,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/security,
+/turf/simulated/floor/plasteel/dark{
+	dir = 8;
+	icon_state = "darkbrown"
+	},
 /area/shuttle/trade/sol)
 "dOx" = (
 /obj/structure/marker_beacon/spotlight/jade,
@@ -10049,6 +10065,16 @@
 	icon_state = "vault"
 	},
 /area/tdome/tdomeadmin)
+"esY" = (
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "etc" = (
 /obj/structure/mirror{
 	pixel_x = -30
@@ -10098,6 +10124,14 @@
 /obj/item/flag/species/vox,
 /turf/simulated/floor/plating/nitrogen,
 /area/vox_base)
+"etQ" = (
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "etS" = (
 /obj/effect/decal/nanotrasen_logo_circle{
 	icon_state = "ntlogo_sec";
@@ -11565,14 +11599,9 @@
 	},
 /area/ghost_bar/indoor)
 "eYC" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/turf_decal/siding/wood/birch,
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 1
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "eYF" = (
 /obj/structure/light_fake,
@@ -12731,16 +12760,7 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "ftp" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/catwalk,
 /area/shuttle/trade/sol)
 "fts" = (
 /obj/item/flag/nt,
@@ -13089,16 +13109,16 @@
 	id = "soltraderflash";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "fAC" = (
 /obj/machinery/light/spot/directional/south,
 /obj/machinery/economy/atm/directional/south,
-/obj/effect/turf_decal/siding/wood/cherry,
-/turf/simulated/floor/wood/fancy/cherry,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "fAH" = (
 /obj/structure/ore_box,
@@ -13398,6 +13418,13 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/medbay)
+"fHx" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "fHY" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/drinks/mug{
@@ -13927,6 +13954,11 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/ghost_bar/indoor)
+"fVj" = (
+/obj/machinery/light/spot/directional/south,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "fVr" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -14089,10 +14121,12 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/bar)
 "fYD" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/spawner/random/traders/science,
 /obj/structure/closet,
-/obj/effect/spawner/random/traders/medical,
-/obj/machinery/light/spot/directional/south,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "fZl" = (
 /turf/simulated/wall/indestructible/syndishuttle/nodiagonal,
@@ -15160,9 +15194,12 @@
 	},
 /area/ninja/holding)
 "gBF" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "gBI" = (
 /obj/effect/turf_decal/siding/wood/oak/corner{
@@ -15968,14 +16005,9 @@
 	},
 /area/shuttle/escape)
 "gTY" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "soltrader_south"
-	},
-/obj/effect/turf_decal/siding/wood/birch,
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "gUm" = (
@@ -16358,7 +16390,6 @@
 	},
 /area/shuttle/escape)
 "hbo" = (
-/obj/item/flag/solgov,
 /obj/machinery/door_control/no_emag/east{
 	id = "soltrader_north";
 	name = "Trade Deposits Door";
@@ -16377,7 +16408,24 @@
 	pixel_x = 24;
 	req_access = list(160)
 	},
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/item/stack/package_wrap{
+	pixel_y = -3
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 1
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 9
+	},
+/obj/item/hand_labeler,
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "hbp" = (
 /obj/structure/gunrack,
@@ -18004,7 +18052,8 @@
 	},
 /area/centcom/ss220/admin3)
 "hKx" = (
-/turf/simulated/floor/wood/fancy/birch,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "hKA" = (
 /obj/effect/turf_decal/tile/neutral/full{
@@ -19364,9 +19413,10 @@
 	},
 /area/centcom/ss220/bar)
 "ima" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/security,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	dir = 8;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "img" = (
 /turf/simulated/floor/wood/parquet,
@@ -20093,7 +20143,8 @@
 /area/ghost_bar/outdoor)
 "izZ" = (
 /obj/machinery/light/spot/directional/south,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "iAl" = (
 /turf/simulated/floor/plasteel/dark,
@@ -20888,6 +20939,8 @@
 /turf/simulated/floor/carpet/arcade,
 /area/admin)
 "iTn" = (
+/obj/structure/table/reinforced,
+/obj/item/megaphone,
 /turf/simulated/floor/plasteel/dark{
 	dir = 8;
 	icon_state = "navybluecorners"
@@ -21031,7 +21084,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
+	dir = 8;
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "iWc" = (
@@ -22327,6 +22381,15 @@
 	icon_state = "darkneutralfull"
 	},
 /area/syndicate_mothership/infteam)
+"jCs" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "navyblue"
+	},
+/area/shuttle/trade/sol)
 "jCR" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -22363,6 +22426,15 @@
 	icon_state = "darkbrown"
 	},
 /area/syndicate_mothership/jail)
+"jEb" = (
+/obj/structure/rack,
+/obj/item/storage/bag/money{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "jEd" = (
 /obj/structure/platform{
 	dir = 8;
@@ -22752,11 +22824,11 @@
 	},
 /area/syndicate_mothership/cargo)
 "jKW" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/service,
-/obj/machinery/light/spot/directional/north,
-/obj/item/stack/tile/disco_light/thirty,
-/turf/simulated/floor/plasteel/dark,
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "jLd" = (
 /obj/structure/table/wood/fancy/blue,
@@ -23443,9 +23515,11 @@
 	},
 /area/syndicate_mothership)
 "kcV" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/civilian,
-/turf/simulated/floor/plasteel/dark,
+/obj/machinery/light/floor,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "kcW" = (
 /turf/simulated/floor/plasteel/dark{
@@ -23879,10 +23953,10 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
 "kne" = (
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 1
+/obj/item/flag/solgov,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/wood/fancy/cherry,
 /area/shuttle/trade/sol)
 "kni" = (
 /obj/structure/light_fake/small{
@@ -24062,14 +24136,14 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "kqx" = (
-/obj/structure/table/wood/fancy/orange,
 /obj/item/paper_bin{
 	pixel_y = 3
 	},
 /obj/item/pen/fancy{
 	pixel_y = 4
 	},
-/turf/simulated/floor/wood/fancy/birch,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "kqN" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24087,10 +24161,16 @@
 /turf/simulated/wall/indestructible/riveted,
 /area/space/centcomm)
 "kry" = (
-/obj/machinery/light/small/directional/east,
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/rack,
+/obj/item/storage/firstaid/adv{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "krQ" = (
 /obj/structure/chair/wood{
@@ -24514,8 +24594,10 @@
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership/jail)
 "kBd" = (
-/obj/machinery/light/small/directional/west,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "kBw" = (
 /obj/structure/table/glass,
@@ -26230,17 +26312,24 @@
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
+"lkK" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "lkU" = (
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/control)
 "lkV" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/structure/chair/comfy/corp{
 	dir = 8
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "lkZ" = (
 /obj/structure/chair/comfy/brown{
@@ -26282,6 +26371,12 @@
 /obj/item/storage/bible,
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/park)
+"lmP" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "lnf" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/plasteel/dark,
@@ -26435,8 +26530,13 @@
 	},
 /area/syndicate_mothership/control)
 "lqX" = (
-/obj/structure/table/wood/fancy/royalblue,
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/closet/walllocker/emerglocker/directional/east,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/machinery/light/small/directional/east,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "lrc" = (
 /obj/docking_port/stationary{
@@ -28922,8 +29022,7 @@
 "msS" = (
 /obj/machinery/light/spot/directional/south,
 /turf/simulated/floor/plasteel/dark{
-	dir = 6;
-	icon_state = "navyblue"
+	icon_state = "navybluecorners"
 	},
 /area/shuttle/trade/sol)
 "mth" = (
@@ -28939,8 +29038,10 @@
 	},
 /area/syndicate_mothership/control)
 "mtL" = (
-/obj/effect/landmark/spawner/tradergearminor,
-/turf/simulated/floor/plasteel/dark,
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "mtR" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -29006,18 +29107,10 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "muG" = (
-/obj/item/flag/solgov,
 /obj/machinery/door_control/no_emag/east{
 	id = "trader_privacy";
 	name = "Privacy Shutters Control";
 	pixel_y = 8;
-	req_access = list(160)
-	},
-/obj/machinery/door_control/no_emag/east{
-	id = "soltrader_south";
-	name = "Trade Deposits Door";
-	normaldoorcontrol = 1;
-	pixel_y = -8;
 	req_access = list(160)
 	},
 /obj/machinery/flasher_button{
@@ -29025,7 +29118,22 @@
 	pixel_x = 24;
 	req_access = list(160)
 	},
-/turf/simulated/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/item/stack/package_wrap,
+/obj/item/stack/package_wrap{
+	pixel_y = 3
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 6
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 9
+	},
+/obj/item/hand_labeler,
+/turf/simulated/floor/plasteel/dark{
+	dir = 6;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "muV" = (
 /obj/item/flag/nt,
@@ -29261,10 +29369,10 @@
 "mzP" = (
 /obj/machinery/light/spot/directional/north,
 /obj/machinery/economy/atm/directional/north,
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 1
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "mAc" = (
 /obj/structure/table/holotable,
@@ -31727,10 +31835,10 @@
 /area/shuttle/syndicate)
 "nHZ" = (
 /obj/item/flag/solgov,
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "nIb" = (
 /obj/machinery/door_control/no_emag/east{
@@ -32315,10 +32423,13 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/centcom/ss220/admin2)
 "nVU" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/structure/chair/comfy/corp{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "nVW" = (
 /obj/structure/fans/tiny/invisible,
@@ -32636,8 +32747,13 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "oeK" = (
-/obj/item/kirbyplants/large,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "darkbrown"
+	},
 /area/shuttle/trade/sol)
 "ofn" = (
 /obj/item/kirbyplants/large,
@@ -32672,7 +32788,10 @@
 /area/centcom/ss220/court)
 "ogy" = (
 /obj/machinery/light/spot/directional/north,
-/turf/simulated/floor/wood/fancy/birch,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "darkbrown"
+	},
 /area/shuttle/trade/sol)
 "ogC" = (
 /obj/machinery/computer/arcade/recruiter,
@@ -33883,8 +34002,13 @@
 	},
 /area/ghost_bar/indoor)
 "oIQ" = (
-/obj/effect/turf_decal/siding/wood/cherry,
-/turf/simulated/floor/wood/fancy/cherry,
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/engineering,
+/obj/effect/spawner/random/oil/maybe,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "oJf" = (
 /obj/structure/table/wood,
@@ -34483,6 +34607,12 @@
 	icon_state = "hydrofloor"
 	},
 /area/ghost_bar/indoor)
+"oWg" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "oWk" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/effect/spawner/random/ccfood/meat,
@@ -36673,6 +36803,12 @@
 	},
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
+"pVD" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 10
+	},
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "pWf" = (
 /turf/simulated/floor/holofloor{
 	icon_state = "sand";
@@ -37277,9 +37413,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "qnb" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/minerals,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/effect/spawner/random/traders/vehicle,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/oil/often,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "qnl" = (
 /obj/structure/mirror{
@@ -37911,6 +38050,16 @@
 "qBQ" = (
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/park)
+"qCq" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "qCH" = (
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/simulated/wall/mineral/plastitanium,
@@ -38124,6 +38273,8 @@
 	},
 /area/syndicate_mothership/jail)
 "qGf" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
 	icon_state = "navybluecorners"
@@ -38399,11 +38550,8 @@
 /obj/machinery/door/airlock/titanium/glass{
 	id_tag = "soltrader_north"
 	},
-/obj/effect/turf_decal/siding/wood/birch{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/cherry,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "qNs" = (
@@ -39035,6 +39183,13 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/medbay)
+"raa" = (
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "ram" = (
 /obj/structure/mecha_wreckage/durand/old{
 	icon_state = "old_durand";
@@ -39316,23 +39471,14 @@
 	},
 /area/ghost_bar/indoor)
 "rhr" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/package_wrap{
-	pixel_y = 9
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/service,
+/obj/item/stack/tile/disco_light/thirty,
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "navyblue"
 	},
-/obj/item/stack/package_wrap{
-	pixel_y = 5
-	},
-/obj/item/stack/package_wrap{
-	pixel_y = 1
-	},
-/obj/item/stack/package_wrap{
-	pixel_y = -3
-	},
-/obj/item/hand_labeler{
-	pixel_y = -6
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "rhs" = (
 /obj/item/tank/internals/emergency_oxygen/nitrogen{
@@ -40467,8 +40613,11 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "rBy" = (
+/obj/effect/turf_decal/delivery/white,
 /obj/effect/landmark/spawner/tradergearmajor,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "rBK" = (
 /obj/structure/chair/brass{
@@ -40502,6 +40651,10 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/evac)
+"rCy" = (
+/obj/effect/spawner/window/shuttle,
+/turf/simulated/floor/plating,
+/area/space/nearstation/centcom)
 "rCF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/plating/dirt,
@@ -42143,10 +42296,16 @@
 	id = "soltraderflash";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
+"skn" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "skx" = (
 /turf/simulated/floor/plasteel{
@@ -43484,6 +43643,20 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
+"sOd" = (
+/obj/item/reagent_containers/drinks/bottle/whiskey,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/drinks/drinkingglass/shotglass,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/clothing/mask/cigarette/cigar/havana,
+/obj/item/lighter/zippo/engraved,
+/obj/item/lighter/zippo/engraved,
+/obj/structure/closet/cabinet,
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluecorners"
+	},
+/area/shuttle/trade/sol)
 "sOo" = (
 /turf/simulated/wall/mineral/plastitanium,
 /area/shuttle/assault_pod)
@@ -43626,6 +43799,9 @@
 	icon_state = "heater2x2";
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/trade/sol)
 "sRe" = (
@@ -43727,11 +43903,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
 "sSB" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "navybluecorners"
-	},
-/area/shuttle/trade/sol)
+/turf/simulated/wall/mineral/titanium,
+/area/space/nearstation/centcom)
 "sTi" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/beach/away/water{
@@ -44756,6 +44929,14 @@
 	icon_state = "dark_herringbone"
 	},
 /area/centcom/ss220/admin1)
+"ttf" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/spawner/random/traders/medical,
+/obj/structure/closet,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "ttK" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -46913,10 +47094,11 @@
 	},
 /area/syndicate_mothership/outside)
 "uuh" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
+/obj/effect/spawner/random/traders/large_item,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/turf/simulated/floor/wood/fancy/birch,
 /area/shuttle/trade/sol)
 "uus" = (
 /obj/item/flag/nt,
@@ -46999,22 +47181,16 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "uxC" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
-"uxD" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/turf_decal/siding/wood/birch{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/birch{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/carpet/orange,
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
+"uxD" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "darkbrown"
+	},
 /area/shuttle/trade/sol)
 "uxH" = (
 /obj/structure/curtain/black{
@@ -48770,9 +48946,11 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/space/nearstation/centcom)
 "vlY" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/engineering,
-/turf/simulated/floor/plasteel/dark,
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	dir = 10;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "vmm" = (
 /obj/structure/fans/tiny/invisible,
@@ -49362,9 +49540,10 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "vwx" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/donksoft,
-/turf/simulated/floor/wood/fancy/birch,
+/obj/effect/turf_decal/siding/wood/oak/end{
+	dir = 8
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "vwI" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
@@ -50146,10 +50325,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
 "vMa" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
+/obj/structure/rack,
+/obj/item/storage/box/crewvend,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/turf/simulated/floor/wood/fancy/birch,
 /area/shuttle/trade/sol)
 "vMi" = (
 /obj/structure/chair/sofa/corp/left{
@@ -50981,7 +51161,7 @@
 	name = "Docking Port"
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/wood/fancy/cherry,
+/turf/simulated/floor/plating,
 /area/trader_station/sol)
 "whj" = (
 /obj/structure/table,
@@ -52067,6 +52247,15 @@
 	},
 /turf/simulated/floor/wood/cherry,
 /area/ghost_bar/indoor)
+"wDB" = (
+/obj/structure/chair/comfy/corp{
+	dir = 8
+	},
+/obj/structure/chair/comfy/corp{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
 "wDC" = (
 /obj/structure/table/glass/reinforced/plastitanium,
 /obj/item/folder/red{
@@ -52751,6 +52940,13 @@
 	color = "#f63d3d"
 	},
 /area/syndicate_mothership/elite_squad)
+"wSC" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/obj/machinery/economy/vending/cigarette/beach,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "wSY" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -52839,10 +53035,12 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/centcom/ss220/general)
 "wWd" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/structure/chair/comfy/shuttle/dark{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "wWg" = (
 /obj/machinery/door/poddoor{
@@ -54209,6 +54407,13 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/ninja/holding)
+"xAb" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 5
+	},
+/obj/item/flag/solgov,
+/turf/simulated/floor/wood/parquet/oak,
+/area/shuttle/trade/sol)
 "xAd" = (
 /obj/item/kirbyplants/large,
 /turf/simulated/floor/wood/fancy/cherry,
@@ -54225,10 +54430,11 @@
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/cherry{
+/obj/effect/turf_decal/siding/wood/oak{
 	dir = 5
 	},
-/turf/simulated/floor/wood/fancy/cherry,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "xAG" = (
 /obj/structure/table/glass,
@@ -54431,7 +54637,7 @@
 	dheight = 1
 	},
 /obj/docking_port/mobile/trade_sol,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "xGu" = (
 /obj/effect/turf_decal/woodsiding{
@@ -54825,18 +55031,21 @@
 	},
 /turf/simulated/floor/plasteel/goonplaque/memorial,
 /area/centcom/ss220/park)
+"xOB" = (
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "xOF" = (
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
 "xOL" = (
-/obj/effect/turf_decal/siding/wood/cherry,
-/obj/effect/turf_decal/siding/wood/cherry{
-	dir = 1
-	},
 /obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
 /area/shuttle/trade/sol)
 "xOQ" = (
 /obj/machinery/economy/merch,
@@ -55709,6 +55918,19 @@
 "yjG" = (
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/park)
+"yjJ" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/painter,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/item/toy/crayon/spraycan,
+/obj/structure/shelf,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "yjM" = (
 /obj/machinery/door/airlock/hatch/syndicate,
 /turf/simulated/floor/mineral/plastitanium/red,
@@ -93550,12 +93772,12 @@ cOi
 cOi
 cOi
 cOi
-ltM
 lEE
 lEE
 lEE
 lEE
-ltM
+lEE
+lEE
 cOi
 cOi
 cOi
@@ -94060,20 +94282,20 @@ adJ
 adJ
 adJ
 mYc
-cOi
-lEE
-gBF
-bSn
+sSB
+umj
+vwx
+eYC
 xOL
-uxC
+skn
 wWd
 wWd
-dtV
-xOL
-bSn
-bSn
-ltM
-cOi
+eYC
+anB
+ftp
+ftp
+umj
+sSB
 mYc
 iTR
 iTR
@@ -94317,20 +94539,20 @@ adJ
 adJ
 adJ
 mYc
-cOi
-lEE
-lqX
-kry
+rCy
+etQ
+dtV
+sOd
 ltM
 dyG
 avr
-sSB
+avr
 msS
 ltM
-bdG
-bSn
-ltM
-cOi
+kry
+lqX
+yjJ
+sSB
 mYc
 iTR
 iTR
@@ -94574,15 +94796,15 @@ adJ
 adJ
 adJ
 mYc
+lEE
+esY
+fVj
+umj
 ltM
 ltM
+xOB
+qCq
 ltM
-ltM
-ltM
-dvw
-ltM
-ltM
-ftp
 ltM
 ltM
 ltM
@@ -94831,18 +95053,18 @@ adJ
 adJ
 adJ
 mYc
-ltM
+lEE
 dvR
 kBd
-beM
-bSn
-bSn
+ltM
+jCs
+ima
+ima
+ima
 ima
 vlY
-bSn
-bSn
-eYC
-kBd
+ltM
+dNq
 dOd
 ltM
 mYc
@@ -95089,19 +95311,19 @@ adJ
 adJ
 mYc
 ltM
-vwx
-hKx
+ltM
+ltM
 ltM
 jKW
 bSn
-bSn
-bSn
+fHx
+ttf
 bSn
 fYD
 ltM
-hKx
+uxD
 qnb
-ltM
+lEE
 mYc
 iTR
 iTR
@@ -95346,19 +95568,19 @@ adJ
 adJ
 mYc
 ltM
-lEE
-uxD
-ltM
+wSC
+pVD
+beM
 kcV
 bSn
 mtL
 rBy
 bSn
 bka
-ltM
+beM
 uxD
+gBF
 lEE
-ltM
 mYc
 iTR
 iTR
@@ -95603,18 +95825,18 @@ adJ
 adJ
 mYc
 ltM
+lkK
 hKx
-hKx
-beM
+ltM
+alD
 bSn
 bSn
 bSn
 bSn
-bSn
-bSn
-eYC
-hKx
-hKx
+kne
+ltM
+uxD
+jEb
 ltM
 mYc
 iTR
@@ -95860,7 +96082,7 @@ adJ
 adJ
 mYc
 lEE
-vMa
+bJE
 hKx
 ltM
 hbo
@@ -95870,9 +96092,9 @@ bwv
 nVU
 muG
 ltM
-hKx
+uxD
 vMa
-lEE
+ltM
 mYc
 iTR
 iTR
@@ -96128,7 +96350,7 @@ xQo
 ltM
 ltM
 ogy
-kqx
+oIQ
 lEE
 mYc
 iTR
@@ -96374,17 +96596,17 @@ adJ
 adJ
 mYc
 lEE
-uuh
+wDB
 hKx
 ltM
-bJE
+raa
 lkV
 aQD
 aQD
 lkV
 nHZ
 ltM
-hKx
+uxD
 uuh
 lEE
 mYc
@@ -96631,17 +96853,17 @@ adJ
 adJ
 mYc
 ltM
-oeK
-hKx
+xAb
+oWg
 qNq
-kne
+lmP
 sHv
 sHv
 sHv
 sHv
-oIQ
+bdG
 gTY
-hKx
+dvw
 oeK
 ltM
 xPv
@@ -97150,8 +97372,8 @@ bFH
 ltM
 xAm
 ske
-alD
-alD
+uxC
+uxC
 fAB
 aAt
 ltM

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -371,10 +371,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/general)
 "alD" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 4
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "alK" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -424,10 +424,9 @@
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
 "anB" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/turf/simulated/floor/wood/fancy/oak,
+/obj/item/bedsheet/black,
+/obj/structure/bed,
+/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "anH" = (
 /obj/structure/table/tray,
@@ -522,16 +521,6 @@
 /obj/structure/fans/tiny/invisible,
 /turf/simulated/floor/plasteel/dark,
 /area/ghost_bar/indoor)
-"apc" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
-	},
-/obj/machinery/door_control/shutter/south{
-	id = "traderwinshut";
-	req_access = list(160)
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "apf" = (
 /obj/structure/table/reinforced{
 	color = "#444444"
@@ -863,10 +852,11 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "avr" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "navyblue"
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/flashlight/lamp{
+	pixel_y = 5
 	},
+/turf/simulated/floor/carpet/royalblack,
 /area/shuttle/trade/sol)
 "avt" = (
 /obj/structure/flora/tree/jungle/small,
@@ -1573,6 +1563,18 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/jail)
+"aNk" = (
+/obj/machinery/light/small/directional/west,
+/obj/structure/closet/walllocker/emerglocker/directional/south,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/eva,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/grenade/chem_grenade/metalfoam,
+/turf/simulated/floor/catwalk,
+/area/shuttle/trade/sol)
 "aNn" = (
 /obj/machinery/gibber/upgraded,
 /turf/simulated/floor/plating{
@@ -1654,14 +1656,6 @@
 "aPF" = (
 /turf/simulated/floor/carpet/purple,
 /area/wizard_station)
-"aPH" = (
-/obj/item/flag/solgov,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
 "aPJ" = (
 /obj/effect/mapping_helpers/airlock/access/all/shuttles/vox,
 /obj/machinery/door/airlock/hatch{
@@ -2261,11 +2255,10 @@
 	},
 /area/syndicate_mothership/jail)
 "bdG" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/service,
+/obj/machinery/light/spot/directional/north,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 1;
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "bed" = (
@@ -2292,10 +2285,12 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/supply)
 "beM" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 5;
-	icon_state = "darkbrown"
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "traderwinshut"
 	},
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "beO" = (
 /obj/structure/light_fake/spot{
@@ -2617,7 +2612,6 @@
 	},
 /area/syndicate_mothership/elite_squad)
 "bka" = (
-/obj/machinery/light/floor,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "navyblue"
 	},
@@ -3011,11 +3005,6 @@
 /obj/structure/statue/cyberiad/nw,
 /turf/simulated/floor/grass/jungle,
 /area/centcom/ss220/park)
-"brQ" = (
-/obj/machinery/light/spot/directional/south,
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "brY" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkredalt";
@@ -3219,8 +3208,12 @@
 /turf/simulated/floor/mineral/plastitanium/red/nitrogen,
 /area/vox_base)
 "bwv" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/fancy/oak,
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 2;
+	id_tag = "tradercargowinshut"
+	},
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "bwG" = (
 /obj/structure/showcase,
@@ -3566,6 +3559,7 @@
 	dir = 4;
 	desc = null
 	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel/dark{
 	dir = 8;
 	icon_state = "navyblue"
@@ -3741,14 +3735,9 @@
 	},
 /area/ghost_bar/indoor)
 "bJE" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/paper_bin{
-	pixel_y = 3
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/obj/item/pen/fancy{
-	pixel_y = 4
-	},
-/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "bJI" = (
 /obj/structure/table/wood,
@@ -4208,13 +4197,10 @@
 /turf/simulated/floor/carpet/red,
 /area/centcom/ss220/bar)
 "bSn" = (
-/obj/structure/rack,
-/obj/item/storage/bag/money{
-	pixel_y = 8
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "bSp" = (
 /obj/structure/table/glass/reinforced/plastitanium,
@@ -4577,13 +4563,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/mineral/plastitanium,
 /area/shuttle/vox)
-"bXo" = (
-/obj/effect/spawner/random/traders/large_item,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
-	},
-/area/shuttle/trade/sol)
 "bXB" = (
 /obj/structure/table/wood,
 /obj/item/grenade/clusterbuster/syndieminibomb,
@@ -4663,15 +4642,6 @@
 	},
 /turf/simulated/floor/carpet/royalblack,
 /area/centcom/ss220/bar)
-"bZA" = (
-/obj/structure/closet/walllocker/emerglocker/directional/east,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/suit/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/machinery/light/small/directional/east,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "bZE" = (
 /obj/machinery/economy/vending/hydronutrients,
 /turf/simulated/floor/plasteel/dark,
@@ -5518,16 +5488,6 @@
 	name = "vox floor"
 	},
 /area/shuttle/vox)
-"csH" = (
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 2
-	},
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
-/area/shuttle/trade/sol)
 "csN" = (
 /obj/effect/turf_decal/siding/wood/cherry{
 	dir = 1
@@ -5857,10 +5817,12 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "cCP" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "traderbridgewinshut"
 	},
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "cCU" = (
 /turf/simulated/floor/beach/away/water{
@@ -6479,13 +6441,6 @@
 	water_overlay_image = null
 	},
 /area/centcom/ss220/admin1)
-"cQS" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "cRb" = (
 /obj/structure/table/wood,
 /obj/item/food/grown/poppy,
@@ -7837,10 +7792,10 @@
 /turf/simulated/floor/wood/oak,
 /area/admin)
 "dtV" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 10
+/turf/simulated/floor/plasteel/dark{
+	dir = 5;
+	icon_state = "darkbrown"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dub" = (
 /obj/structure/window/reinforced{
@@ -7891,10 +7846,11 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "dvw" = (
-/obj/item/flag/solgov,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
 	},
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "dvG" = (
 /obj/machinery/computer/arcade/battle,
@@ -7996,6 +7952,7 @@
 /area/holodeck/source_boxingcourt)
 "dyG" = (
 /obj/machinery/light/spot/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel/dark{
 	dir = 4;
 	icon_state = "navybluecorners"
@@ -8876,13 +8833,13 @@
 	},
 /area/shuttle/vox)
 "dOd" = (
-/obj/structure/closet,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/traders/security,
-/turf/simulated/floor/plasteel/dark{
-	dir = 8;
-	icon_state = "darkbrown"
+/obj/structure/chair/comfy/corp{
+	dir = 8
 	},
+/obj/structure/chair/comfy/corp{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "dOx" = (
 /obj/structure/marker_beacon/spotlight/jade,
@@ -9280,12 +9237,6 @@
 	},
 /turf/simulated/wall/indestructible/fakeglass,
 /area/centcom/ss220/jail)
-"dYx" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
-	},
-/turf/simulated/floor/wood/parquet/oak,
-/area/shuttle/trade/sol)
 "dYP" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -10113,8 +10064,12 @@
 	},
 /area/tdome/tdomeadmin)
 "esY" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/civilian,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 9;
+	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
 "etc" = (
@@ -11633,8 +11588,12 @@
 	},
 /area/ghost_bar/indoor)
 "eYC" = (
-/turf/simulated/wall/mineral/titanium,
-/area/space/nearstation/centcom)
+/obj/effect/turf_decal/siding/wood/oak/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/oak/corner,
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "eYF" = (
 /obj/structure/light_fake,
 /turf/simulated/floor/wood/parquet,
@@ -11646,11 +11605,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/syndicate_sit)
-"eYR" = (
-/obj/structure/chair/comfy/corp{
-	dir = 4
+"eZi" = (
+/obj/item/flag/solgov,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/simulated/floor/plasteel/dark{
+	dir = 1;
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "eZF" = (
 /obj/structure/disposalpipe/segment{
@@ -12180,11 +12141,6 @@
 	icon_state = "darkbrown"
 	},
 /area/centcom/ss220/admin3)
-"fjc" = (
-/obj/item/bedsheet/black,
-/obj/structure/bed,
-/turf/simulated/floor/carpet/royalblack,
-/area/shuttle/trade/sol)
 "fje" = (
 /obj/machinery/sleeper/upgraded{
 	dir = 1
@@ -12803,12 +12759,11 @@
 /turf/simulated/floor/indestructible/grass,
 /area/syndicate_mothership/outside)
 "ftp" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/effect/spawner/random/traders/medical,
-/obj/structure/closet,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
 	},
+/obj/machinery/economy/vending/cigarette,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "fts" = (
 /obj/item/flag/nt,
@@ -13468,7 +13423,8 @@
 /area/centcom/ss220/medbay)
 "fHx" = (
 /obj/effect/turf_decal/delivery/white,
-/obj/effect/landmark/spawner/tradergearminor,
+/obj/effect/spawner/random/traders/medical,
+/obj/structure/closet,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -15238,11 +15194,9 @@
 	},
 /area/ninja/holding)
 "gBF" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
 	},
-/obj/machinery/economy/vending/cigarette/beach,
-/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "gBI" = (
 /obj/effect/turf_decal/siding/wood/oak/corner{
@@ -16050,7 +16004,7 @@
 "gTY" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/machinery/door/airlock/titanium,
+/obj/machinery/door/airlock/public,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "gUm" = (
@@ -16535,6 +16489,14 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/cargo)
+"hbJ" = (
+/obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id_tag = "traderwinshut"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "hbZ" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/food/grown/potato,
@@ -17695,6 +17657,14 @@
 /obj/item/gun/energy/laser/tag/red,
 /turf/simulated/floor/carpet/arcade,
 /area/admin)
+"hDo" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/public,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "hDr" = (
 /turf/simulated/wall/indestructible/syndicate{
 	smoothing_flags = 2
@@ -18097,10 +18067,8 @@
 	},
 /area/centcom/ss220/admin3)
 "hKx" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 1;
-	icon_state = "darkbrown"
-	},
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "hKA" = (
 /obj/effect/turf_decal/tile/neutral/full{
@@ -19344,6 +19312,19 @@
 	smoothing_flags = 2
 	},
 /area/syndicate_mothership/elite_squad)
+"ikA" = (
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass{
+	amount = 25
+	},
+/obj/item/painter,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/glasses/welding,
+/obj/structure/shelf,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/crayon/spraycan,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "ikL" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -19460,10 +19441,11 @@
 	},
 /area/centcom/ss220/bar)
 "ima" = (
-/turf/simulated/floor/plasteel/dark{
-	dir = 8;
-	icon_state = "navyblue"
+/obj/item/flag/solgov,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "img" = (
 /turf/simulated/floor/wood/parquet,
@@ -19758,19 +19740,6 @@
 	icon_state = "cult"
 	},
 /area/holodeck/source_theatre)
-"isl" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass{
-	amount = 15
-	},
-/obj/item/painter,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/glasses/welding,
-/obj/structure/shelf,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/crayon/spraycan,
-/turf/simulated/floor/plating,
-/area/shuttle/trade/sol)
 "isq" = (
 /obj/structure/gunrack,
 /obj/effect/turf_decal/delivery/red,
@@ -20204,7 +20173,10 @@
 "izZ" = (
 /obj/machinery/light/spot/directional/south,
 /obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/parquet/oak,
+/obj/machinery/door_control/shutter/south{
+	id = "tradervacwinshut"
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "iAl" = (
 /turf/simulated/floor/plasteel/dark,
@@ -21143,6 +21115,7 @@
 /obj/machinery/computer/shuttle/trade/sol{
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel/dark{
 	dir = 8;
 	icon_state = "navyblue"
@@ -23557,7 +23530,6 @@
 	},
 /area/syndicate_mothership)
 "kcV" = (
-/obj/machinery/light/floor,
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
 	icon_state = "navyblue"
@@ -23995,9 +23967,7 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/general)
 "kne" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/donksoft,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/light/floor,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -24180,13 +24150,14 @@
 /turf/simulated/floor/carpet/black,
 /area/syndicate_mothership/control)
 "kqx" = (
-/obj/structure/closet,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/traders/engineering,
-/obj/effect/spawner/random/oil/maybe,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/paper_bin{
+	pixel_y = 3
 	},
+/obj/item/pen/fancy{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "kqN" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -24455,6 +24426,13 @@
 /obj/item/gun/projectile/automatic/ar,
 /turf/simulated/floor/wood/oak,
 /area/admin)
+"kvW" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 5
+	},
+/obj/item/flag/solgov,
+/turf/simulated/floor/wood/fancy/oak,
+/area/shuttle/trade/sol)
 "kwM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -24639,11 +24617,14 @@
 /turf/simulated/wall/indestructible/opsglass,
 /area/syndicate_mothership/jail)
 "kBd" = (
-/obj/machinery/light/small/directional/west,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "darkbrown"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
 	},
+/obj/machinery/door_control/shutter/south{
+	id = "traderwinshut";
+	req_access = list(160)
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "kBw" = (
 /obj/structure/table/glass,
@@ -25085,12 +25066,6 @@
 	name = "sand"
 	},
 /area/syndicate_mothership/outside)
-"kHp" = (
-/obj/machinery/door/airlock/titanium/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark,
-/area/shuttle/trade/sol)
 "kHq" = (
 /obj/structure/table/reinforced{
 	color = "#444444"
@@ -25743,6 +25718,11 @@
 	icon_state = "darkblue"
 	},
 /area/centcom/ss220/evac)
+"kXb" = (
+/obj/machinery/atmospherics/portable/pump,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "kXh" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/airlock/external{
@@ -26162,15 +26142,6 @@
 	dir = 1
 	},
 /area/centcom/ss220/admin3)
-"lgF" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/civilian,
-/turf/simulated/floor/plasteel/dark{
-	dir = 9;
-	icon_state = "navyblue"
-	},
-/area/shuttle/trade/sol)
 "lgH" = (
 /turf/space/transit,
 /area/space/centcomm)
@@ -26426,10 +26397,12 @@
 /turf/simulated/floor/carpet/green,
 /area/centcom/ss220/park)
 "lmP" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 4
+/obj/effect/spawner/random/traders/vehicle,
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/oil/often,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "lnf" = (
 /obj/structure/filingcabinet,
@@ -26584,11 +26557,7 @@
 	},
 /area/syndicate_mothership/control)
 "lqX" = (
-/obj/effect/turf_decal/siding/wood/oak/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/oak/corner,
-/turf/simulated/floor/wood/fancy/oak,
+/turf/simulated/floor/catwalk,
 /area/shuttle/trade/sol)
 "lrc" = (
 /obj/docking_port/stationary{
@@ -27072,11 +27041,6 @@
 	icon_state = "darkyellowaltstrip"
 	},
 /area/syndicate_mothership/control)
-"lyx" = (
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
-/area/shuttle/trade/sol)
 "lyy" = (
 /obj/structure/chair/comfy/green{
 	dir = 1
@@ -27349,6 +27313,10 @@
 /area/centcom/ss220/admin2)
 "lEE" = (
 /obj/effect/spawner/window/shuttle,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id_tag = "tradervacwinshut"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "lEI" = (
@@ -29078,6 +29046,7 @@
 /area/centcom/ss220/supply)
 "msS" = (
 /obj/machinery/light/spot/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "navybluecorners"
 	},
@@ -29189,6 +29158,14 @@
 	pixel_y = 9
 	},
 /obj/item/hand_labeler,
+/obj/machinery/door_control/no_emag/east{
+	id = "soltrader_north";
+	name = "Trade Deposits Door";
+	normaldoorcontrol = 1;
+	pixel_y = -24;
+	req_access = list(160);
+	pixel_x = 0
+	},
 /turf/simulated/floor/plasteel/dark{
 	dir = 6;
 	icon_state = "navyblue"
@@ -31895,7 +31872,7 @@
 "nHZ" = (
 /obj/item/flag/solgov,
 /obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
+	dir = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
@@ -32806,11 +32783,13 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "oeK" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 5
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/minerals,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	dir = 4;
+	icon_state = "darkbrown"
 	},
-/obj/item/flag/solgov,
-/turf/simulated/floor/wood/parquet/oak,
 /area/shuttle/trade/sol)
 "ofn" = (
 /obj/item/kirbyplants/large,
@@ -32844,7 +32823,6 @@
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/court)
 "ogy" = (
-/obj/machinery/light/spot/directional/north,
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
 	icon_state = "darkbrown"
@@ -33728,13 +33706,6 @@
 /obj/item/book/manual/wiki/sop_service,
 /turf/simulated/floor/wood/parquet/tile,
 /area/centcom/ss220/admin2)
-"oBL" = (
-/obj/item/flag/solgov,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 10
-	},
-/turf/simulated/floor/wood/fancy/oak,
-/area/shuttle/trade/sol)
 "oCk" = (
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "darkbluealtstrip"
@@ -34066,11 +34037,10 @@
 	},
 /area/ghost_bar/indoor)
 "oIQ" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/flashlight/lamp{
-	pixel_y = 5
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/royalblack,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "oJf" = (
 /obj/structure/table/wood,
@@ -36860,16 +36830,14 @@
 /turf/simulated/floor/carpet/arcade,
 /area/trader_station/sol)
 "pVD" = (
-/obj/structure/rack,
-/obj/item/storage/firstaid/adv{
-	pixel_x = 1;
-	pixel_y = 6
+/obj/effect/turf_decal/delivery/white,
+/obj/item/stack/tile/disco_light/thirty,
+/obj/structure/closet,
+/obj/item/storage/box/lights/mixed,
+/turf/simulated/floor/plasteel/dark{
+	dir = 10;
+	icon_state = "navyblue"
 	},
-/obj/item/storage/toolbox/emergency{
-	pixel_y = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "pWf" = (
 /turf/simulated/floor/holofloor{
@@ -37414,6 +37382,16 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/centcom/ss220/admin2)
+"qlb" = (
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2
+	},
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navybluefull"
+	},
+/area/shuttle/trade/sol)
 "qlc" = (
 /obj/machinery/economy/vending/shoedispenser/free,
 /turf/simulated/floor/wood/parquet/tile,
@@ -37475,11 +37453,12 @@
 /turf/simulated/floor/wood/fancy/cherry,
 /area/wizard_station)
 "qnb" = (
-/obj/effect/spawner/random/traders/vehicle,
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/oil/often,
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/security,
 /turf/simulated/floor/plasteel/dark{
-	icon_state = "dark_large"
+	dir = 8;
+	icon_state = "darkbrown"
 	},
 /area/shuttle/trade/sol)
 "qnl" = (
@@ -38327,7 +38306,11 @@
 "qGf" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/door_control/shutter/south{
+	id = "traderbridgewinshut";
+	pixel_y = 24;
+	req_access = list(160)
+	},
 /turf/simulated/floor/plasteel/dark{
 	dir = 1;
 	icon_state = "navybluecorners"
@@ -38600,11 +38583,9 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate_sit)
 "qNq" = (
-/obj/machinery/door/airlock/titanium/glass{
-	id_tag = "soltrader_north"
-	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
+/obj/machinery/door/airlock/public/glass,
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "qNs" = (
@@ -39517,12 +39498,8 @@
 	},
 /area/ghost_bar/indoor)
 "rhr" = (
-/obj/effect/turf_decal/delivery/white,
-/obj/item/stack/tile/disco_light/thirty,
-/obj/structure/closet,
-/obj/item/storage/box/lights/mixed,
 /turf/simulated/floor/plasteel/dark{
-	dir = 10;
+	dir = 4;
 	icon_state = "navyblue"
 	},
 /area/shuttle/trade/sol)
@@ -39592,6 +39569,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/court)
+"rii" = (
+/obj/effect/turf_decal/delivery/white,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "riq" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/mapping_helpers/light,
@@ -43680,12 +43663,10 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "sOd" = (
-/obj/effect/spawner/window/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 8;
-	id_tag = "traderwinshut"
+/obj/item/flag/solgov,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "navyblue"
 	},
-/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "sOo" = (
 /turf/simulated/wall/mineral/plastitanium,
@@ -43818,12 +43799,9 @@
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
 "sQY" = (
-/obj/effect/spawner/window/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "traderwinshut"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/light/spot/directional/south,
+/obj/effect/turf_decal/siding/wood/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "sRe" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -43924,9 +43902,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/bar)
 "sSB" = (
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navyblue"
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
 	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "sTi" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -44930,6 +44909,18 @@
 	water_overlay_image = null
 	},
 /area/centcom/ss220/admin1)
+"tsC" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_y = -1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/trade/sol)
 "tsH" = (
 /obj/structure/light_fake{
 	dir = 1
@@ -47109,13 +47100,11 @@
 	},
 /area/syndicate_mothership/outside)
 "uuh" = (
-/obj/structure/chair/comfy/corp{
-	dir = 8
+/obj/effect/spawner/random/traders/large_item,
+/obj/effect/turf_decal/delivery,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/obj/structure/chair/comfy/corp{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/royalblue,
 /area/shuttle/trade/sol)
 "uus" = (
 /obj/item/flag/nt,
@@ -47198,17 +47187,17 @@
 /turf/simulated/floor/plasteel,
 /area/centcom/ss220/supply)
 "uxC" = (
-/obj/machinery/door/airlock/titanium,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/landmark/spawner/tradergearminor,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
 /area/shuttle/trade/sol)
 "uxD" = (
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
-/turf/simulated/floor/wood/parquet/oak,
+/turf/simulated/floor/wood/fancy/oak,
 /area/shuttle/trade/sol)
 "uxH" = (
 /obj/structure/curtain/black{
@@ -48964,8 +48953,10 @@
 /turf/simulated/floor/plating/nitrogen,
 /area/space/nearstation/centcom)
 "vlY" = (
-/obj/effect/turf_decal/siding/wood/oak,
-/turf/simulated/floor/wood/parquet/oak,
+/turf/simulated/floor/plasteel/dark{
+	dir = 8;
+	icon_state = "navyblue"
+	},
 /area/shuttle/trade/sol)
 "vmm" = (
 /obj/structure/fans/tiny/invisible,
@@ -49555,13 +49546,14 @@
 /turf/simulated/floor/wood/oak,
 /area/syndicate_mothership)
 "vwx" = (
-/obj/effect/spawner/window/shuttle,
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 1;
-	id_tag = "traderwinshut"
+/obj/structure/closet,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/traders/engineering,
+/obj/effect/spawner/random/oil/maybe,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
 	},
-/turf/simulated/floor/plating,
-/area/space/nearstation/centcom)
+/area/shuttle/trade/sol)
 "vwI" = (
 /obj/machinery/atmospherics/portable/canister/oxygen{
 	anchored = 1;
@@ -50349,6 +50341,10 @@
 /obj/item/storage/box/crewvend{
 	pixel_x = 4
 	},
+/obj/machinery/door_control/shutter/south{
+	id = "tradercargowinshut";
+	req_access = list(160)
+	},
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -50899,15 +50895,6 @@
 	icon_state = "darkredalt"
 	},
 /area/centcom/ss220/supply)
-"wbE" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/traders/minerals,
-/obj/effect/turf_decal/delivery/hollow,
-/turf/simulated/floor/plasteel/dark{
-	dir = 4;
-	icon_state = "darkbrown"
-	},
-/area/shuttle/trade/sol)
 "wbL" = (
 /obj/structure/rack,
 /obj/item/mecha_parts/mecha_equipment/medical/rescue_jaw,
@@ -53482,9 +53469,6 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
-"xgf" = (
-/turf/simulated/floor/catwalk,
-/area/shuttle/trade/sol)
 "xgE" = (
 /obj/structure/sink/kitchen/west,
 /turf/simulated/floor/plasteel{
@@ -54935,6 +54919,12 @@
 	dir = 5
 	},
 /area/ghost_bar/outdoor/beach)
+"xLs" = (
+/obj/structure/chair/comfy/corp{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/royalblue,
+/area/shuttle/trade/sol)
 "xLG" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/indestructible/grass/no_creep,
@@ -54988,6 +54978,14 @@
 	},
 /turf/simulated/floor/indestructible/grass/no_creep,
 /area/centcom/ss220/admin1)
+"xNO" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/donksoft,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark{
+	icon_state = "dark_large"
+	},
+/area/shuttle/trade/sol)
 "xNR" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/sniper_rounds/penetrator,
@@ -55044,6 +55042,8 @@
 /area/centcom/ss220/park)
 "xOB" = (
 /obj/effect/turf_decal/delivery/white,
+/obj/structure/closet,
+/obj/effect/spawner/random/traders/service,
 /turf/simulated/floor/plasteel/dark{
 	icon_state = "dark_large"
 	},
@@ -55052,12 +55052,11 @@
 /turf/simulated/floor/plating,
 /area/syndicate_mothership/elite_squad)
 "xOL" = (
-/obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/centcomm/traders,
-/turf/simulated/floor/plasteel/dark{
-	icon_state = "navybluefull"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/simulated/floor/plating,
 /area/shuttle/trade/sol)
 "xOQ" = (
 /obj/machinery/economy/merch,
@@ -55122,7 +55121,9 @@
 	req_access = list(160);
 	name = "Стойка"
 	},
-/obj/item/desk_bell,
+/obj/item/desk_bell{
+	anchored = 1
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/shuttle/trade/sol)
 "xQE" = (
@@ -55571,6 +55572,12 @@
 	},
 /turf/simulated/wall/indestructible/riveted,
 /area/centcom/ss220/admin2)
+"ybj" = (
+/turf/simulated/floor/plasteel/dark{
+	dir = 9;
+	icon_state = "darkbrown"
+	},
+/area/shuttle/trade/sol)
 "ybt" = (
 /turf/simulated/floor/plating,
 /area/centcom/ss220/bar)
@@ -93776,12 +93783,12 @@ cOi
 cOi
 cOi
 cOi
-lEE
-lEE
-lEE
-lEE
-lEE
-lEE
+ltM
+cCP
+cCP
+cCP
+cCP
+ltM
 cOi
 cOi
 cOi
@@ -94031,7 +94038,7 @@ adJ
 mYc
 cOi
 ltM
-sOd
+hbJ
 ltM
 ltM
 qGf
@@ -94286,20 +94293,20 @@ adJ
 adJ
 adJ
 mYc
-eYC
+ltM
 umj
-anB
-dtV
-xOL
-alD
-wWd
-wWd
 sSB
-uxC
-xgf
-xgf
+uxD
+hDo
+kcV
+wWd
+wWd
+bka
+xOL
+lqX
+aNk
 umj
-eYC
+ltM
 mYc
 iTR
 iTR
@@ -94543,20 +94550,20 @@ adJ
 adJ
 adJ
 mYc
-vwx
-fjc
-lqX
+beM
+anB
+eYC
 kry
 ltM
 dyG
-avr
-avr
+rhr
+rhr
 msS
 ltM
-pVD
-bZA
-isl
-eYC
+kXb
+lqX
+tsC
+ltM
 mYc
 iTR
 iTR
@@ -94800,19 +94807,19 @@ adJ
 adJ
 adJ
 mYc
+beM
+avr
 sQY
-oIQ
-brQ
 umj
 ltM
 ltM
-lyx
-csH
+gBF
+qlb
 ltM
 ltM
-ltM
-ltM
-ltM
+umj
+lqX
+ikA
 ltM
 mYc
 iTR
@@ -95057,19 +95064,19 @@ adJ
 adJ
 adJ
 mYc
-sQY
+beM
 dvR
-apc
-ltM
-lgF
-ima
-ima
-ima
-ima
-rhr
-ltM
 kBd
-dOd
+ltM
+esY
+vlY
+vlY
+vlY
+vlY
+pVD
+ltM
+xOL
+ltM
 ltM
 mYc
 iTR
@@ -95319,15 +95326,15 @@ ltM
 ltM
 ltM
 jKW
-esY
+bJE
+uxC
 fHx
-ftp
-esY
+bJE
 fYD
 ltM
-hKx
+ybj
 qnb
-lEE
+ltM
 mYc
 iTR
 iTR
@@ -95572,19 +95579,19 @@ adJ
 adJ
 mYc
 ltM
-gBF
+ftp
 uxD
-kHp
+qNq
 kcV
-esY
+kne
 mtL
 rBy
-esY
-bka
-kHp
-hKx
 kne
-lEE
+bka
+gTY
+ogy
+lmP
+bwv
 mYc
 iTR
 iTR
@@ -95829,19 +95836,19 @@ adJ
 adJ
 mYc
 ltM
-cQS
-vlY
-ltM
-aPH
-esY
-bdG
-xOB
-esY
 dvw
-ltM
 hKx
-bSn
 ltM
+eZi
+bJE
+xOB
+rii
+bJE
+sOd
+ltM
+ogy
+xNO
+bwv
 mYc
 iTR
 iTR
@@ -96086,17 +96093,17 @@ adJ
 adJ
 mYc
 lEE
-eYR
-vlY
+xLs
+hKx
 ltM
 hbo
 nVU
-avr
-avr
+rhr
+rhr
 nVU
 muG
 ltM
-hKx
+bdG
 vMa
 ltM
 mYc
@@ -96343,7 +96350,7 @@ adJ
 adJ
 mYc
 lEE
-bJE
+kqx
 izZ
 ltM
 ltM
@@ -96354,8 +96361,8 @@ xQo
 ltM
 ltM
 ogy
-kqx
-lEE
+vwx
+bwv
 mYc
 iTR
 iTR
@@ -96600,19 +96607,19 @@ adJ
 adJ
 mYc
 lEE
-uuh
-vlY
-ltM
-nHZ
-lkV
-aQD
-aQD
-lkV
-oBL
-ltM
+dOd
 hKx
-bXo
-lEE
+ltM
+ima
+lkV
+aQD
+aQD
+lkV
+nHZ
+ltM
+ogy
+uuh
+bwv
 mYc
 mYc
 eGo
@@ -96857,18 +96864,18 @@ adJ
 adJ
 mYc
 ltM
-oeK
-dYx
+kvW
+bSn
 qNq
-cCP
+oIQ
 sHv
 sHv
 sHv
 sHv
-bwv
+hKx
 gTY
-beM
-wbE
+dtV
+oeK
 ltM
 xPv
 hOY
@@ -97376,8 +97383,8 @@ bFH
 ltM
 xAm
 ske
-lmP
-lmP
+alD
+alD
 fAB
 aAt
 ltM


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Немного изменяет торговый шаттл на ЦК-уровне:
- Передел одного из гостевых помещений в склад;
- Передел одной из кают в техническое помещение;
- Добавление мини-техов с аварийными приблудами;
- Добавление КрюВенда на борт шаттла;
- Перекрас полов.

## Почему это хорошо для игры

- Красивый шаттл;
- Благодаря новым инструментам и небольшому количеству металла и стекла на шаттле торговцам будет намного легче красиво оформить свой шаттл перед полетом на станцию;
- Торговцы стали чуть более живучими благодаря добавленным на шаттл ЕВАм, пеннометаллическим гранатам, огнетушителям и аптечке. Ибо это элитные торговцы! Они должны уметь выживать в случае ЧС;
- С КрюВендом на борту торговцы смогут настроить автоматическую продажу товаров.

## Изображения изменений

![изображение](https://github.com/user-attachments/assets/04621ee5-661b-42d4-a7e6-4bbdae8dc977)

## Тестирование

- Закомпилил билд, 0 ошибок;
- На локальном сервере прошелся по шаттлу, заменился успешно;
- Шаттл летает от торгового поста к станции без нареканий;
- Новые створки в каюте шаттла работают.

## Changelog

:cl: Osetrokarasek
tweak: Транспортное судно ТСФ было модернезировано: улучшены его безопасность и удобство.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
