### PR TITLE
Fix curtains' icon states

### DIFF
--- a/_maps/map_files220/RandomZLevels/wildwest.dmm
+++ b/_maps/map_files220/RandomZLevels/wildwest.dmm
@@ -23,7 +23,6 @@
 /area/awaymission/wildwest/wildwest_mines)
 "al" = (
 /obj/structure/curtain/medical{
-	icon_state = "open";
 	opacity = 0
 	},
 /obj/effect/mine/dnascramble,
@@ -2069,8 +2068,7 @@
 /area/awaymission/wildwest/wildwest_mines)
 "tQ" = (
 /obj/structure/curtain/black{
-	opacity = 0;
-	icon_state = "open"
+	opacity = 0
 	},
 /obj/effect/mine/dnascramble,
 /obj/item/dice/d6,
@@ -2569,8 +2567,7 @@
 /area/awaymission/wildwest/wildwest_mines)
 "zy" = (
 /obj/structure/curtain/black{
-	opacity = 0;
-	icon_state = "open"
+	opacity = 0
 	},
 /obj/effect/mine/dnascramble,
 /obj/item/stack/tile/wood,
@@ -2932,8 +2929,7 @@
 /area/awaymission/wildwest/wildwest_mines)
 "CQ" = (
 /obj/structure/curtain/black{
-	opacity = 0;
-	icon_state = "open"
+	opacity = 0
 	},
 /obj/effect/mine/dnascramble,
 /obj/item/trash/chips,
@@ -4378,8 +4374,7 @@
 /area/awaymission/wildwest/wildwest_refine)
 "QS" = (
 /obj/structure/curtain/black{
-	opacity = 0;
-	icon_state = "open"
+	opacity = 0
 	},
 /turf/simulated/floor/carpet/orange,
 /area/awaymission/wildwest/wildwest_mines)

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -65698,7 +65698,6 @@
 /area/station/maintenance/aft)
 "lZu" = (
 /obj/structure/curtain/open/shower/security{
-	icon_state = "closed";
 	opacity = 1
 	},
 /turf/simulated/floor/wood/fancy/cherry,
@@ -79094,7 +79093,6 @@
 /area/station/service/chapel)
 "qPF" = (
 /obj/structure/curtain/open/shower/security{
-	icon_state = "closed";
 	opacity = 1
 	},
 /obj/effect/turf_decal/siding/wood/cherry{
@@ -81137,7 +81135,6 @@
 /area/station/command/office/ce)
 "rLf" = (
 /obj/structure/curtain/open/shower/security{
-	icon_state = "closed";
 	opacity = 1
 	},
 /obj/effect/turf_decal/siding/wood/cherry{

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -36369,7 +36369,6 @@
 	dir = 6
 	},
 /obj/structure/curtain/open/shower/security{
-	icon_state = "closed";
 	opacity = 1
 	},
 /turf/simulated/floor/carpet/arcade,
@@ -52816,9 +52815,7 @@
 	},
 /area/station/science/lobby)
 "fKW" = (
-/obj/structure/curtain/open/shower/security{
-	icon_state = "closed"
-	},
+/obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/wood/fancy,
 /area/station/service/theatre)
 "fLx" = (
@@ -69774,9 +69771,7 @@
 "lds" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/curtain/open/shower/security{
-	icon_state = "closed"
-	},
+/obj/structure/curtain/open/shower/security,
 /turf/simulated/floor/wood/fancy,
 /area/station/service/theatre)
 "ldv" = (
@@ -111345,7 +111340,6 @@
 /area/station/security/main)
 "xYL" = (
 /obj/structure/curtain/open/shower/security{
-	icon_state = "closed";
 	opacity = 1
 	},
 /obj/effect/turf_decal/siding/blue{

--- a/tools/UpdatePaths/Scripts/ss220/xx_curtains.txt
+++ b/tools/UpdatePaths/Scripts/ss220/xx_curtains.txt
@@ -1,0 +1,1 @@
+/obj/structure/curtain/@SUBTYPES : /obj/structure/curtain/@SUBTYPES{@OLD;icon_state=@SKIP}


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фиксит то, что у занавесок не было их крутого металлического стержня сверху

Их рефакторили пару месяцев назад и больше не нужно задавать их икон стейт, достаточно только opacity а дальше оно само при инициализации поменяет

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Фикс

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Запустил Дельту и глянул на занавески в театре и дормах + MDB

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Исправлены невидимые занавески в гейте Дикого Запада, на Кибериаде и Керберосе.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
