### PR TITLE
Plastic Chair Craft Fix

### DIFF
--- a/modular_ss220/objects/_objects.dm
+++ b/modular_ss220/objects/_objects.dm
@@ -20,7 +20,7 @@
 	)
 
 	GLOB.plastic_recipes += list(
-		new /datum/stack_recipe("пластиковый стул", /obj/structure/chair/plastic, time = 2 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
+		new /datum/stack_recipe("пластиковый стул", /obj/structure/chair/plastic, 2, time = 2 SECONDS, one_per_turf = TRUE, on_floor = TRUE),
 	)
 
 	GLOB.cardboard_recipes += list(


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Приписывает забытую двоечку в строку с крафтом пластикового стола, чтобы затраты при создании стула соответствовали тому количеству пластика, что выпадает из него при разборе/ломании.

## Почему это хорошо для игры

Ну типа, минус дюп пластика.

## Изображения изменений

А они тут нужны? Я буквально в код 3 символа вставил, считая пробел.

## Тестирование

Протестировал крафт на локальном сервере, стул реально требует 2 листа пластика для создания.

## Changelog

:cl: Osetrokarasek
fix: Пластик больше не материализуется из Блюспейс-пространства при создании пластикового стула.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
