### PR TITLE
Delta RnD Tox Storage Button Fix

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -58123,6 +58123,11 @@
 	id_tag = "rndstorage";
 	name = "Secure Storage Blast Doors"
 	},
+/obj/machinery/door_control/shutter/south{
+	id = "rndstorage";
+	name = "RnD Secure Storage Control";
+	req_access = list(8)
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "blackcorner"
@@ -97921,11 +97926,6 @@
 /turf/simulated/wall,
 /area/station/medical/reception)
 "tJj" = (
-/obj/machinery/door_control/shutter/west{
-	id = "rndstorage";
-	name = "RnD Secure Storage Control";
-	req_access = list(8)
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Помещает кнопку открытия бластдоров на один тайл с ними, позволяя дотянуться до нее с обеих сторон.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Убираем риск застрять в хранилище токсинов по глупости.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

![изображение](https://github.com/user-attachments/assets/7d0f2e74-7b02-47fe-a054-9b35f42e5c9b)


## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Запустил на локальном сервере, кнопка работает.

## Changelog

:cl:
tweak: Керберос: кнопка контроля дверьми в хранилище токсинов РНД теперь доступна с обеих сторон, что устраняет риск застрять в нем по глупости.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
