### PR TITLE
Альтернативные куртки детектива в лодауте

### DIFF
--- a/modular_ss220/loadout/code/suit.dm
+++ b/modular_ss220/loadout/code/suit.dm
@@ -9,3 +9,21 @@
 /datum/gear/suit/browntrenchcoat_oldparadise
 	display_name = "Старое коричневое пальто"
 	path = /obj/item/clothing/suit/storage/browntrenchcoat
+
+/datum/gear/suit/detective_blue_jacket
+	display_name = "Синяя куртка детектива"
+	path = /obj/item/clothing/suit/storage/det_suit/forensics/blue
+	allowed_roles = list("Detective")
+	cost = 1
+
+/datum/gear/suit/detective_red_jacket
+	display_name = "Красная куртка детектива"
+	path = /obj/item/clothing/suit/storage/det_suit/forensics/red
+	allowed_roles = list("Detective")
+	cost = 1
+
+/datum/gear/suit/detective_black_jacket
+	display_name = "Черная куртка детектива"
+	path = /obj/item/clothing/suit/storage/det_suit/forensics/black
+	allowed_roles = list("Detective")
+	cost = 1


### PR DESCRIPTION


<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет альтернативные версии курток детектива из его гардероба в лодаут.
## Почему это хорошо для игры

Позволяет разнообразить гардероб детектива не тратя деньги в автомате с его одеждой и не прибегая к сумке с его одеждой.

## Изображения изменений

![image](https://github.com/user-attachments/assets/720206c0-8c7e-4fa8-93ad-9bcfee40cc2b)
![image](https://github.com/user-attachments/assets/2ce5bc89-f563-4caa-83c5-54511cf46254)

## Тестирование

Запустил локалку, проверил ограничения для должности и зашёл с новыми предметами в раунд.

## Changelog

:cl:
add: добавлены альтернативные куртки для детектива в лодаут

/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
