### PR TITLE
Fix runtime in NNFO outfit

### DIFF
--- a/modular_ss220/outfits/code/outfits.dm
+++ b/modular_ss220/outfits/code/outfits.dm
@@ -131,16 +131,11 @@
 
 /datum/outfit/job/admin/ntnavyofficer/field
 	name = "Nanotrasen Navy Field Officer"
-
 	gloves = /obj/item/clothing/gloves/combat
 	suit = /obj/item/clothing/suit/space/deathsquad/officer/field
 	head = /obj/item/clothing/head/helmet/space/deathsquad/beret/field
 	l_pocket = /obj/item/melee/baseball_bat/homerun/central_command
-
-	bio_chips = list(
-		/obj/item/bio_chip/mindshield,
-		/obj/item/bio_chip/dust,
-		/obj/item/organ/internal/cyberimp/brain/anti_sleep/hardened,
+	cybernetic_implants = list(
 		/obj/item/organ/internal/cyberimp/chest/reviver/hardened,
 		/obj/item/organ/internal/cyberimp/eyes/hud/medical,
 		/obj/item/organ/internal/cyberimp/brain/anti_stam/hardened,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

фиксит рантайм при попытке имплантации импланта
убирает из списка имплантов нейроджампстартер, т.к. он перезаписывается цнс ребутером (они ставятся в один слот)
позволяет остальным имплантам из списка нормально вставляться т.к. рантайма нет

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

рантайм!!!!! точнее его отсутствие

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

не рантаймит!

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Аутфит ПОЦК теперь корректно выдаёт владельцу импланты.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
