### PR TITLE
Возвращение Чизуза

### DIFF
--- a/modular_ss220/unique_objects/code/cheese_statue.dm
+++ b/modular_ss220/unique_objects/code/cheese_statue.dm
@@ -63,10 +63,12 @@ GLOBAL_LIST_INIT(cheese_recipes, list(
 //////////////////////////////////////////
 //Reinforced cheese
 //////////////////////////////////////////
-/datum/recipe/oven/reinforcedcheese
-	reagents = list("sodiumchloride" = 10)
-	items = list(
-		/obj/item/food/sliceable/cheesewheel,
-		/obj/item/food/sliceable/cheesewheel
+/datum/cooking/recipe/reinforcedcheese
+	container_type = /obj/item/reagent_containers/cooking/oven
+	product_type = /obj/item/stack/sheet/cheese
+	steps = list(
+		PCWJ_ADD_ITEM(/obj/item/food/sliceable/cheesewheel),
+		PCWJ_ADD_ITEM(/obj/item/food/sliceable/cheesewheel),
+		PCWJ_ADD_REAGENT("sodiumchloride", 10),
+		PCWJ_USE_OVEN(J_MED, 10 SECONDS),
 	)
-	result = /obj/item/stack/sheet/cheese


### PR DESCRIPTION
## Что этот PR делает
Исправляет рецепт листов сыра из которого создается статуя сырного Иисуса. Прошедшая переработака кухни не затронула этот рецепт.
Рецепт - 2 круга сыра, 10 юнитов соли в духовку на среднюю температуру и таймер на 10 секунд.


## Почему это хорошо для игры
Возвращение святыни на станцию.

## Тестирование
Протестировал на локальном сервере:
Положил на противень 2 круга сыра, 10 юнитов соли. 
Запихнул в духовку на медиум и 10 секунд. 
Результат - один сырный строительный лист.

## Changelog

:cl:
fix: Исправлено создание сырных листов
/:cl:

## Обзор от Sourcery

Исправлен рецепт армированного сыра для использования новой системы приготовления и правильного производства листов сыра из двух головок сыра и соли в духовке.

Исправления ошибок:
- Перенос рецепта армированного сыра на новую платформу приготовления.
- Требуется две головки сыра и 10 единиц хлорида натрия в духовке при среднем огне в течение 10 секунд для получения листа сыра.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the reinforced cheese recipe to use the new cooking system and properly produce cheese sheets from two cheese wheels and salt in an oven.

Bug Fixes:
- Migrate the reinforced cheese recipe to the new cooking framework.
- Require two cheese wheels and 10 units of sodium chloride in an oven at medium heat for 10 seconds to yield a cheese sheet.

</details>