### PR TITLE
Delta Unnecessary Sidings Removal

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -27858,7 +27858,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mapping_helpers/airlock/access/any/command/ntrep,
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/plasteel,
 /area/station/command/office/ntrep)
 "ckv" = (
 /turf/simulated/floor/plasteel{
@@ -27878,7 +27878,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/plasteel,
 /area/station/command/office/blueshield)
 "ckx" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
@@ -64463,7 +64463,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/plasteel,
 /area/station/medical/psych)
 "jsE" = (
 /obj/machinery/drone_fabricator,
@@ -108966,7 +108966,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/turf/simulated/floor/wood/oak,
+/turf/simulated/floor/plasteel,
 /area/station/command/office/hop)
 "xoF" = (
 /obj/machinery/light/small/directional/west,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Удаляет на Керберосе лишние плинтусы у таких плиток, как ковры, а также добавляет недостающие в атриум и библиотеку и мб еще какие зоны я забыл чо вообще там маппил. Ну и местами заменяет уродск старые деревянные полы на новые.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Красиво, логично.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Представь тут ту же Дельту, но без сайдингов на коврах. Ну или мапдифф посмотри яхз.

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Ну билд компилится вроде, да. 0 ошибок. Мапа тоже поменялась.

## Changelog

:cl:
tweak: Керберос: удаленые лишние и добавлены недостающие плинтусы. Также, в некоторых офисах изменены полы.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Краткое описание от Sourcery

Небольшая корректировка карты Delta station: удалены лишние боковые стенки на ковровых плитках, добавлены недостающие боковые стенки в атриуме, библиотеке и других областях, а также обновлен устаревший деревянный пол в некоторых офисах.

Улучшения:
- Удалены ненужные боковые стенки вокруг ковровых плиток
- Добавлены недостающие боковые стенки в атриуме, библиотеке и других обозначенных зонах
- Заменены устаревшие деревянные полы на обновленные варианты в нескольких офисах

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tweak Delta station’s map by removing excess wall sidings on carpeted tiles, adding missing sidings in the atrium, library, and other areas, and updating outdated wooden flooring in select offices.

Enhancements:
- Remove unnecessary wall sidings around carpet tiles
- Add missing wall sidings in the atrium, library, and other mapped zones
- Replace outdated wooden floors with the updated variants in several offices

</details>