### PR TITLE
Disable changelog translation

### DIFF
--- a/.github/workflows/merge_upstream.yml
+++ b/.github/workflows/merge_upstream.yml
@@ -41,7 +41,7 @@ jobs:
           UPSTREAM_BRANCH: 'master'
           MERGE_BRANCH: 'merge-upstream'
           CHANGELOG_AUTHOR: 'ParadiseSS13'
-          TRANSLATE_CHANGES: 'true'
+          TRANSLATE_CHANGES: false
           OPENAI_API_KEY: ${{ secrets.ORG_EMPTY_TOKEN }}
           LOG_LEVEL: ${{ runner.debug && 'DEBUG' || 'INFO' }}
         run: |


### PR DESCRIPTION
## Что этот PR делает
Отрубаю перевод чейнджлога, пока не заработает

## Обзор от Sourcery

CI:
- Установите для TRANSLATE_CHANGES значение false в конфигурации .github/workflows/merge_upstream.yml, чтобы отключить перевод журнала изменений.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Set TRANSLATE_CHANGES to false in the .github/workflows/merge_upstream.yml configuration to disable changelog translation

</details>