### PR TITLE
Fix dir of multi-tile airlocks on Lavaland

### DIFF
--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -4397,7 +4397,9 @@
 /area/lavaland/surface/gulag_rock)
 "BY" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/airlock/multi_tile/supply/glass,
+/obj/machinery/door/airlock/multi_tile/supply/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Вращает шлюзы до нужного положения.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
На аванпосте больше не дует.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Нет.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Maxiemar
fix: Исправлено положение многотайловых шлюзов на шахтерском аванпосте.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Исправления ошибок:
- Поворот многосекционных шлюзов в файле карты Lavaland в правильном направлении

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Rotate multi-tile airlocks in the Lavaland map file to their proper directions

</details>