### PR TITLE
Update the cyborg upgrade category

### DIFF
--- a/modular_ss220/silicons/code/mechfabricator_designs.dm
+++ b/modular_ss220/silicons/code/mechfabricator_designs.dm
@@ -6,7 +6,7 @@
 	req_tech = list("bluespace" = 5, "materials" = 7, "engineering" = 5)
 	materials = list(MAT_METAL=15000, MAT_BLUESPACE=2000, MAT_SILVER=6000)
 	construction_time = 12 SECONDS
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrades")
 
 /datum/design/borg_upgrade_hypospray
 	name = "Medical Cyborg Upgrade (Upgraded Hypospray)"
@@ -16,7 +16,7 @@
 	req_tech = list("biotech" = 7, "materials" = 7)
 	materials = list(MAT_METAL=15000, MAT_URANIUM=2000, MAT_DIAMOND=5000, MAT_SILVER=10000)
 	construction_time = 12 SECONDS
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrades")
 
 // Улучшения голопроектора //
 /datum/design/borg_upgrade_atmos/better
@@ -28,7 +28,7 @@
 	req_tech = list("materials" = 5, "engineering" = 5, "magnets" = 5)
 	materials = list(MAT_METAL=5000, MAT_SILVER=2500, MAT_GOLD=2500, MAT_GLASS=2500)
 	construction_time = 12 SECONDS
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrades")
 
 /datum/design/borg_upgrade_atmos/best
 	name = "Engineer Cyborg Upgrade (Advanced ATMOS holofan projector)"
@@ -39,4 +39,4 @@
 	req_tech = list("materials" = 7, "engineering" = 7, "magnets" = 7, "programming" = 7)
 	materials = list(MAT_TITANIUM=5000, MAT_SILVER=5000, MAT_GOLD = 5000, MAT_GLASS=2500, MAT_DIAMOND=1500)
 	construction_time = 12 SECONDS
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrades")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Исправляет видимость модульных чертежей фабрикатора.
~~Я ебал рот повсеместных литералов в коде~~
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Теперь можно применить улучшения боргов.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Нет.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Maxiemar
fix: Некоторые улучшения боргов снова доступны в фабрикаторе.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->

## Обзор от Sourcery

Исправления ошибок:
- Переименована категория дизайна с "Cyborg Upgrade Modules" на "Cyborg Upgrades", чтобы восстановить видимость улучшений боргов.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Rename design category from "Cyborg Upgrade Modules" to "Cyborg Upgrades" to restore visibility of borg enhancements

</details>