### PR TITLE
Add Missing Airlock Helpers On Box

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -45036,6 +45036,7 @@
 	pixel_x = -24;
 	req_access = list(13)
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "duF" = (
@@ -64118,6 +64119,7 @@
 	pixel_x = -24;
 	req_access = list(13)
 	},
+/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "jXI" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Добавляет забытые хелперы болтов на северо-западный шлюз на Кибериаде.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Нет открытого шлюза раундстартом.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Тута хелперов болтов не было, а теперь есть.

![изображение](https://github.com/user-attachments/assets/d5a3a50b-bb87-4f74-9aac-5a4d4158e7c4)

## Тестирование

Ну хз, хелпер болтов тестить, лень чота. Два раза на тайл не накликал, и того достаточно, i guess.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Северо-западный шлюз Кибериады заболтирован раундстартом, как и положено.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
