### PR TITLE
Fix bubblegum's loot

### DIFF
--- a/modular_ss220/balance/code/loot/megafauna.dm
+++ b/modular_ss220/balance/code/loot/megafauna.dm
@@ -15,24 +15,10 @@
 	if(length(loot))
 		new /obj/structure/closet/crate/necropolis/tendril(loc)
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/round_2
-	loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged)
-	crusher_loot = list(/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher)
-
-/obj/structure/closet/crate/necropolis/bubblegum/populate_contents()
-	new /obj/item/clothing/suit/space/hostile_environment(src)
-	new /obj/item/clothing/head/helmet/space/hostile_environment(src)
-
-/obj/structure/closet/crate/necropolis/bubblegum/enraged/populate_contents()
+/mob/living/simple_animal/hostile/megafauna/bubblegum/Initialize(mapload)
 	. = ..()
-	new /obj/item/melee/spellblade/random(src)
-
-/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher
-	name = "bloody bubblegum chest"
-
-/obj/structure/closet/crate/necropolis/bubblegum/enraged/crusher/populate_contents()
-	. = ..()
-	new /obj/item/crusher_trophy/demon_claws(src)
+	if(!second_life)
+		loot -= /obj/item/melee/spellblade/random
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/hallucination
 	loot_chance = 100


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фиксит последствия недавнего рефактора лута мегафауны с оффов, из-за которого Бубльгум дропал спеллблейд даже без хардмода

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Фикс

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Скомпилировал, проверил списки лута у Бубльгума, его галлюцинации и его второй фазы

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Бубльгум вновь выдаёт спеллблейд лишь в хардмод режиме.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
