### PR TITLE
Reduce PDA's security alarm spam

### DIFF
--- a/modular_ss220/balance/code/items/pda.dm
+++ b/modular_ss220/balance/code/items/pda.dm
@@ -52,10 +52,10 @@
 /datum/data/pda/app/alarm/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	if(..())
 		return TRUE
-	
+
 	if(!pda.silent)
 		playsound(pda, 'sound/machines/terminal_select.ogg', 15, TRUE)
-	
+
 	switch(action)
 		if("submit")
 			handle_alarm_button()
@@ -72,7 +72,7 @@
 		last_response_success = FALSE
 		last_response_acts = list("ok")
 		return
-	
+
 	var/turf/location = get_turf(pda)
 	if(!pda.radio.on || (!is_station_level(location.z) && !is_mining_level(location.z)))
 		last_response_title = "Ошибка"
@@ -91,7 +91,7 @@
 /datum/data/pda/app/alarm/proc/call_security()
 	var/turf/loc = get_turf(pda)
 	log_game("[usr] ([usr.client.ckey]) has triggered an alarm button at ([loc.x], [loc.y], [loc.z]) using PDA of [pda.owner], [pda.ownrank].")
-	
+
 	var/area/area = get_area(pda)
 	var/message = "Внимание! [pda.owner], [pda.ownrank], использует тревожную кнопку в [area.name]! \
 		Необходимо[prioritized ? " немедленное" : ""] реагирование."
@@ -115,7 +115,8 @@
 		ghost_sound = 'sound/effects/electheart.ogg',
 		enter_link = "<a href=byond://?src=[pda.UID()];follow=1>(Click to follow)</a>",
 		source = pda,
-		action = NOTIFY_FOLLOW
+		action = NOTIFY_FOLLOW,
+		flashwindow = FALSE,
 	)
 
 /datum/data/pda/app/alarm/heads


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Убирает flashwindow для гостов от алёрта - меньше спама

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Приложение есть у всех членов экипажа, нажать его может любой клоун (литералли, но оффенс). Флешвиндоу создан больше для различных событий, которые редко проявляются (мидраунд ивенты, особые события созданные игроками) 
Вызов СБ в этот счёт не входит, получить флешвиндоу из-за того, что капитан обнаружил у себя в кабинете мима - не круто

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Работает

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Окно игры больше не подсвечивается гостам всякий раз, когда кто-то использует вызов СБ через ПДА.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
