### PR TITLE
Translations: item info window + crayons + chess

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -421,17 +421,30 @@
 
 /atom/proc/build_base_description(infix = "", suffix = "")
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
-	var/f_name = "\a [src][infix]."
+	var/object_title = "[src.declent_ru(NOMINATIVE)][infix]"
+	var/f_name = "[object_title]."
 	if(src.blood_DNA)
 		if(gender == PLURAL)
-			f_name = "some "
+			if(blood_color != "#030303")
+				f_name = "<span class='danger'>окровавленные</span> [object_title]!"
+			else
+				f_name = "испачканные в масле [object_title]."
+		else if (gender == MALE)
+			if(blood_color != "#030303")
+				f_name = "<span class='danger'>окровавленный</span> [object_title]!"
+			else
+				f_name = "испачканый в масле [object_title]."
+		else if (gender == FEMALE)
+			if(blood_color != "#030303")
+				f_name = "<span class='danger'>окровавленная</span> [object_title]!"
+			else
+				f_name = "испачканная в масле [object_title]."
 		else
-			f_name = "a "
-		if(blood_color != "#030303")
-			f_name += "<span class='danger'>blood-stained</span> [name][infix]!"
-		else
-			f_name += "oil-stained [name][infix]."
-	. = list("[bicon(src)] That's [f_name] [suffix]")
+			if(blood_color != "#030303")
+				f_name = "<span class='danger'>окровавленное</span> [object_title]!"
+			else
+				f_name = "испачканное в масле [object_title]."
+	. = list("[bicon(src)] Это [f_name] [suffix]")
 	if(desc)
 		. += desc
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -424,26 +424,27 @@
 	var/object_title = "[src.declent_ru(NOMINATIVE)][infix]"
 	var/f_name = "[object_title]."
 	if(src.blood_DNA)
-		if(gender == PLURAL)
-			if(blood_color != "#030303")
-				f_name = "<span class='danger'>окровавленные</span> [object_title]!"
+		switch(gender)
+			if(PLURAL)
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленные</span> [object_title]!"
+				else
+					f_name = "испачканые в масле [object_title]."
+			if(MALE)
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленный</span> [object_title]!"
+				else
+					f_name = "испачканый в масле [object_title]."
+			if(FEMALE)
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленная</span> [object_title]!"
+				else
+					f_name = "испачканая в масле [object_title]."
 			else
-				f_name = "испачканные в масле [object_title]."
-		else if (gender == MALE)
-			if(blood_color != "#030303")
-				f_name = "<span class='danger'>окровавленный</span> [object_title]!"
-			else
-				f_name = "испачканый в масле [object_title]."
-		else if (gender == FEMALE)
-			if(blood_color != "#030303")
-				f_name = "<span class='danger'>окровавленная</span> [object_title]!"
-			else
-				f_name = "испачканная в масле [object_title]."
-		else
-			if(blood_color != "#030303")
-				f_name = "<span class='danger'>окровавленное</span> [object_title]!"
-			else
-				f_name = "испачканное в масле [object_title]."
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленное</span> [object_title]!"
+				else
+					f_name = "испачканое в масле [object_title]."
 	. = list("[bicon(src)] Это [f_name] [suffix]")
 	if(desc)
 		. += desc

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -100,28 +100,30 @@
 		reagents.add_reagent_list(scoop_reagents)
 
 /obj/effect/decal/build_base_description(infix, suffix) // overriding this is a sin but it fixes a worse sin
-	var/f_name = "\a [src.declent_ru(NOMINATIVE)][infix]."
+	var/object_title = "[src.declent_ru(NOMINATIVE)][infix]"
+	var/f_name = "[object_title]."
 	if(src.blood_DNA)
-		if(gender == PLURAL)
-			if(blood_color != "#030303")
-				f_name += "<span class='danger'>окровавленные</span> [name][infix]!"
+		switch(gender)
+			if(PLURAL)
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленные</span> [object_title]!"
+				else
+					f_name = "испачканые в масле [object_title]."
+			if(MALE)
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленный</span> [object_title]!"
+				else
+					f_name = "испачканый в масле [object_title]."
+			if(FEMALE)
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленная</span> [object_title]!"
+				else
+					f_name = "испачканая в масле [object_title]."
 			else
-				f_name += "испачканные в масле [name][infix]."
-		else if (gender == MALE)
-			if(blood_color != "#030303")
-				f_name += "<span class='danger'>окровавленный</span> [name][infix]!"
-			else
-				f_name += "испачканый в масле [name][infix]."
-		else if (gender == FEMALE)
-			if(blood_color != "#030303")
-				f_name += "<span class='danger'>окровавленная</span> [name][infix]!"
-			else
-				f_name += "испачканная в масле [name][infix]."
-		else
-			if(blood_color != "#030303")
-				f_name += "<span class='danger'>окровавленное</span> [name][infix]!"
-			else
-				f_name += "испачканное в масле [name][infix]."
+				if(blood_color != "#030303")
+					f_name = "<span class='danger'>окровавленное</span> [object_title]!"
+				else
+					f_name = "испачканое в масле [object_title]."
 	. = list("[bicon(src)] Это [f_name] [suffix]")
 	if(desc)
 		. += desc

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -100,7 +100,29 @@
 		reagents.add_reagent_list(scoop_reagents)
 
 /obj/effect/decal/build_base_description(infix, suffix) // overriding this is a sin but it fixes a worse sin
-	. = list("[bicon(src)] That's \a [src][infix]. [suffix]")
+	var/f_name = "\a [src.declent_ru(NOMINATIVE)][infix]."
+	if(src.blood_DNA)
+		if(gender == PLURAL)
+			if(blood_color != "#030303")
+				f_name += "<span class='danger'>окровавленные</span> [name][infix]!"
+			else
+				f_name += "испачканные в масле [name][infix]."
+		else if (gender == MALE)
+			if(blood_color != "#030303")
+				f_name += "<span class='danger'>окровавленный</span> [name][infix]!"
+			else
+				f_name += "испачканый в масле [name][infix]."
+		else if (gender == FEMALE)
+			if(blood_color != "#030303")
+				f_name += "<span class='danger'>окровавленная</span> [name][infix]!"
+			else
+				f_name += "испачканная в масле [name][infix]."
+		else
+			if(blood_color != "#030303")
+				f_name += "<span class='danger'>окровавленное</span> [name][infix]!"
+			else
+				f_name += "испачканное в масле [name][infix]."
+	. = list("[bicon(src)] Это [f_name] [suffix]")
 	if(desc)
 		. += desc
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -263,19 +263,19 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/size
 	switch(src.w_class)
 		if(WEIGHT_CLASS_TINY)
-			size = "tiny"
+			size = "крошечный предмет."
 		if(WEIGHT_CLASS_SMALL)
-			size = "small"
+			size = "маленький предмет."
 		if(WEIGHT_CLASS_NORMAL)
-			size = "normal-sized"
+			size = "предмет нормального размера."
 		if(WEIGHT_CLASS_BULKY)
-			size = "bulky"
+			size = "громоздкий предмет."
 		if(WEIGHT_CLASS_HUGE)
-			size = "huge"
+			size = "огромный предмет."
 		if(WEIGHT_CLASS_GIGANTIC)
-			size = "gigantic"
+			size = "гигантский предмет."
 
-	. = ..(user, "", "It is a [size] item.")
+	. = ..(user, "", "<span class='italics'>Это [size].</span>")
 
 	if(user.research_scanner) //Mob has a research scanner active.
 		var/msg = "*--------* <BR>"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -263,17 +263,17 @@ GLOBAL_DATUM_INIT(welding_sparks, /mutable_appearance, mutable_appearance('icons
 	var/size
 	switch(src.w_class)
 		if(WEIGHT_CLASS_TINY)
-			size = "крошечный предмет."
+			size = "крошечный предмет"
 		if(WEIGHT_CLASS_SMALL)
-			size = "маленький предмет."
+			size = "маленький предмет"
 		if(WEIGHT_CLASS_NORMAL)
-			size = "предмет нормального размера."
+			size = "предмет нормального размера"
 		if(WEIGHT_CLASS_BULKY)
-			size = "громоздкий предмет."
+			size = "громоздкий предмет"
 		if(WEIGHT_CLASS_HUGE)
-			size = "огромный предмет."
+			size = "огромный предмет"
 		if(WEIGHT_CLASS_GIGANTIC)
-			size = "гигантский предмет."
+			size = "гигантский предмет"
 
 	. = ..(user, "", "<span class='italics'>Это [size].</span>")
 

--- a/code/game/objects/items/chess.dm
+++ b/code/game/objects/items/chess.dm
@@ -2,7 +2,7 @@
 
 /obj/item/chesspiece
 	name = "Chess Piece"
-	desc = "A generic chess piece used in a game of chess."
+	desc = "Обычная шахматная фигура, используемая в игре в шахматы."
 	icon = 'icons/obj/chess.dmi'
 	w_class = WEIGHT_CLASS_NORMAL
 
@@ -10,62 +10,62 @@
 
 /obj/item/chesspiece/bpawn
 	name = "Black Pawn"
-	desc = "A Black Pawn. The most basic chess piece, yet capable of ascending to royalty."
+	desc = "Черная пешка. Самая простая шахматная фигура, но способная достичь королевского сана."
 	icon_state = "bpawn"
 
 /obj/item/chesspiece/brook
 	name = "Black Rook"
-	desc = "A Black Rook. Stalwart guard of the Black King and Queen."
+	desc = "Черная ладья. Стойкий страж черного короля и королевы."
 	icon_state = "brook"
 
 /obj/item/chesspiece/bknight
 	name = "Black Knight"
-	desc = "A Black Knight. A noble knight in the service of the Black King and Queen."
+	desc = "Черный конь. Благородный рыцарь на службе у черного короля и королевы."
 	icon_state = "bknight"
 
 /obj/item/chesspiece/bbishop
 	name = "Black Bishop"
-	desc = "A Black Bishop. Close advisor to the Black King and Queen."
+	desc = "Черный слон. Близкий советник черного короля и королевы."
 	icon_state = "bbishop"
 
 /obj/item/chesspiece/bqueen
 	name = "Black Queen"
-	desc = "The Black Queen. Loyal wife of the Black King."
+	desc = "Черная королева. Верная супруга черного короля."
 	icon_state = "bqueen"
 
 /obj/item/chesspiece/bking
 	name = "Black King"
-	desc = "The Black King. Wise and mighty ruler of the Black Kingdom."
+	desc = "Черный король. Мудрый и могущественный правитель черного королевства."
 	icon_state = "bking"
 
 //White chess pieces.
 
 /obj/item/chesspiece/wpawn
 	name = "White Pawn"
-	desc = "A White Pawn. The most basic chess piece, yet capable of ascending to royalty."
+	desc = "Белая пешка. Самая простая шахматная фигура, но способная достичь королевского сана."
 	icon_state = "wpawn"
 
 /obj/item/chesspiece/wrook
 	name = "White Rook"
-	desc = "A White Rook. Stalwart guard of the White King and Queen."
+	desc = "Белая ладья. Стойкий страж белого короля и королевы."
 	icon_state = "wrook"
 
 /obj/item/chesspiece/wknight
 	name = "White Knight"
-	desc = "A White Knight. A noble knight in the service of the White King and Queen."
+	desc = "Белый конь. Благородный рыцарь на службе у белого короля и королевы."
 	icon_state = "wknight"
 
 /obj/item/chesspiece/wbishop
 	name = "White Bishop"
-	desc = "A White Bishop. Close advisor to the White King and Queen."
+	desc = "Белый слон. Близкий советник белого короля и королевы."
 	icon_state = "wbishop"
 
 /obj/item/chesspiece/wqueen
 	name = "White Queen"
-	desc = "The White Queen. Loyal wife of the White King."
+	desc = "Белая королева. Верная супруга белого короля."
 	icon_state = "wqueen"
 
 /obj/item/chesspiece/wking
 	name = "White King"
-	desc = "The White King. Wise and mighty ruler of the White Kingdom."
+	desc = "Белый король. Мудрый и могущественный правитель белого королевства."
 	icon_state = "wking"

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -7,7 +7,7 @@
  */
 /obj/item/toy/crayon
 	name = "crayon"
-	desc = "A colourful crayon. Looks tasty. Mmmm..."
+	desc = "Цветной мелок. Выглядит подозрительно вкусно. Мммм..."
 	icon = 'icons/obj/crayons.dmi'
 	icon_state = "crayonred"
 	w_class = WEIGHT_CLASS_TINY
@@ -37,7 +37,7 @@
 	var/consumable = TRUE
 
 /obj/item/toy/crayon/suicide_act(mob/user)
-	user.visible_message("<span class='suicide'>[user] is jamming the [name] up [user.p_their()] nose and into [user.p_their()] brain. It looks like [user.p_theyre()] trying to commit suicide!</span>")
+	user.visible_message("<span class='suicide'>[user] засовывает [name] в [user.p_their()] нос и в [user.p_their()] мозг. Похоже, [user.p_theyre()] пытается совершить НаноТрейзенНадзор!</span>")
 	return BRUTELOSS|OXYLOSS
 
 /obj/item/toy/crayon/Initialize(mapload)
@@ -56,20 +56,20 @@
 		current_drawtype += "<u>[preset_message[preset_message_index]]</u>"
 		current_drawtype += copytext(preset_message, preset_message_index + 1)
 		current_drawtype = uppertext(current_drawtype)
-	dat += "<center><h2>Currently selected: [current_drawtype]</h2><br>"
-	dat += "<a href='byond://?src=[UID()];type=random_letter'>Random letter</a><a href='byond://?src=[UID()];type=letter'>Pick letter</a><br />"
-	dat += "<a href='byond://?src=[UID()];type=message'>Message</a>"
+	dat += "<center><h2>Текущий выбор: [current_drawtype]</h2><br>"
+	dat += "<a href='byond://?src=[UID()];type=random_letter'>Случайная буква</a><a href='byond://?src=[UID()];type=letter'>Выбрать букву</a><br />"
+	dat += "<a href='byond://?src=[UID()];type=message'>Сообщение</a>"
 	dat += "<hr>"
-	dat += "<h3>Runes:</h3><br>"
-	dat += "<a href='byond://?src=[UID()];type=random_rune'>Random rune</a>"
+	dat += "<h3>Руны:</h3><br>"
+	dat += "<a href='byond://?src=[UID()];type=random_rune'>Случайная руна</a>"
 	for(var/i = 1; i <= 8; i++)
-		dat += "<a href='byond://?src=[UID()];type=rune[i]'>Rune [i]</a>"
+		dat += "<a href='byond://?src=[UID()];type=rune[i]'>Руна [i]</a>"
 		if(!((i + 1) % 3)) //3 buttons in a row
 			dat += "<br>"
 	dat += "<hr>"
 	graffiti.Find()
-	dat += "<h3>Graffiti:</h3><br>"
-	dat += "<a href='byond://?src=[UID()];type=random_graffiti'>Random graffiti</a>"
+	dat += "<h3>Граффити:</h3><br>"
+	dat += "<a href='byond://?src=[UID()];type=random_graffiti'>Случайное граффити</a>"
 	var/c = 1
 	for(var/T in graffiti)
 		dat += "<a href='byond://?src=[UID()];type=[T]'>[T]</a>"
@@ -89,14 +89,14 @@
 		if("random_letter")
 			temp = pick(letters)
 		if("letter")
-			temp = input("Choose the letter.", "Scribbles") in letters
+			temp = input("Выберите букву.", "Каракули") in letters
 		if("random_rune")
 			temp = "rune[rand(1, 8)]"
 		if("random_graffiti")
 			temp = pick(graffiti)
 		if("message")
 			var/regex/graffiti_chars = regex("\[^a-zA-Z0-9+\\-!?=%&,.#\\/\]", "g")
-			var/new_preset = input(usr, "Set the message. Max length [CRAYON_MESSAGE_MAX_LENGTH] characters.")
+			var/new_preset = input(usr, "Укажите сообщение. Максимальная длина [CRAYON_MESSAGE_MAX_LENGTH] символов.")
 			new_preset = copytext(new_preset, 1, CRAYON_MESSAGE_MAX_LENGTH)
 			preset_message = lowertext(graffiti_chars.Replace(new_preset, ""))
 			if(preset_message != "")
@@ -116,20 +116,20 @@
 	if(busy)
 		return
 	if(is_type_in_list(target,validSurfaces))
-		var/temp = "rune"
+		var/temp = "руку"
 		if(preset_message_index > 0)
-			temp = "letter"
+			temp = "букву"
 			drawtype = preset_message[preset_message_index]
 		else if(letters.Find(drawtype))
-			temp = "letter"
+			temp = "букву"
 		else if(graffiti.Find(drawtype))
-			temp = "graffiti"
-		to_chat(user, "<span class='notice'>You start drawing a [temp] on the [target.name].</span>")
+			temp = "граффити"
+		to_chat(user, "<span class='notice'>Вы начинаете рисовать [temp] на [target.name].</span>")
 		busy = TRUE
 		if(instant || do_after(user, 50 * toolspeed, target = target))
 			var/obj/effect/decal/cleanable/crayon/C = new /obj/effect/decal/cleanable/crayon(target,colour,drawtype,temp)
 			C.add_hiddenprint(user)
-			to_chat(user, "<span class='notice'>You finish drawing [temp].</span>")
+			to_chat(user, "<span class='notice'>Вы закончили рисовать [temp].</span>")
 
 			if(preset_message_index > 0)
 				preset_message_index++
@@ -140,7 +140,7 @@
 			if(uses)
 				uses--
 				if(!uses)
-					to_chat(user, "<span class='danger'>You used up your [name]!</span>")
+					to_chat(user, "<span class='danger'>Вы использовали свой [name]!</span>")
 					qdel(src)
 		busy = FALSE
 
@@ -151,15 +151,15 @@
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			if(!H.check_has_mouth())
-				to_chat(user, "<span class='warning'>You do not have a mouth!</span>")
+				to_chat(user, "<span class='warning'>У вас нет рта!</span>")
 				return
 		times_eaten++
 		playsound(loc, 'sound/items/eatfood.ogg', 50, 0)
 		user.adjust_nutrition(5)
 		if(times_eaten < max_bites)
-			to_chat(user, "<span class='notice'>You take a bite of the [name]. Delicious!</span>")
+			to_chat(user, "<span class='notice'>Вы откусываете [name]. Вкусно!</span>")
 		else
-			to_chat(user, "<span class='warning'>There is no more of [name] left!</span>")
+			to_chat(user, "<span class='warning'>Вы полностью сгрызли [name], больше кусать нечего!</span>")
 			qdel(src)
 
 /obj/item/toy/crayon/examine(mob/user)
@@ -167,9 +167,9 @@
 	if(!user.Adjacent(src) || !times_eaten)
 		return
 	if(times_eaten == 1)
-		. += "<span class='notice'>[src] was bitten by someone!</span>"
+		. += "<span class='notice'>[src] был надкушен кем-то!</span>"
 	else
-		. += "<span class='notice'>[src] was bitten multiple times!</span>"
+		. += "<span class='notice'>[src] был надкушен несколько раз!</span>"
 
 /obj/item/toy/crayon/red
 	name = "red crayon"
@@ -250,20 +250,20 @@
 
 /obj/item/toy/crayon/white/chalk
 	name = "detective's chalk"
-	desc = "A stick of white chalk for marking crime scenes."
+	desc = "Кусочек белого мела для разметки места преступления."
 	gender = PLURAL
 	toolspeed = 0.25
 
 /obj/item/toy/crayon/mime
 	name = "mime crayon"
-	desc = "A very sad-looking crayon."
+	desc = "Очень грустно выглядящий карандаш."
 	icon_state = "crayonmime"
 	colour = "#FFFFFF"
 	dye_color = DYE_MIME
 	uses = 0
 
 /obj/item/toy/crayon/mime/update_window(mob/living/user as mob)
-	dat += "<center><span style='border:1px solid #161616; background-color: [colour];'>&nbsp;&nbsp;&nbsp;</span><a href='byond://?src=[UID()];color=1'>Change color</a></center>"
+	dat += "<center><span style='border:1px solid #161616; background-color: [colour];'>&nbsp;&nbsp;&nbsp;</span><a href='byond://?src=[UID()];color=1'>Изменить цвет</a></center>"
 	..()
 
 /obj/item/toy/crayon/mime/Topic(href,href_list)
@@ -286,14 +286,14 @@
 	uses = 0
 
 /obj/item/toy/crayon/rainbow/update_window(mob/living/user as mob)
-	dat += "<center><span style='border:1px solid #161616; background-color: [colour];'>&nbsp;&nbsp;&nbsp;</span><a href='byond://?src=[UID()];color=1'>Change color</a></center>"
+	dat += "<center><span style='border:1px solid #161616; background-color: [colour];'>&nbsp;&nbsp;&nbsp;</span><a href='byond://?src=[UID()];color=1'>Изменить цвет</a></center>"
 	..()
 
 /obj/item/toy/crayon/rainbow/Topic(href,href_list[])
 	if(!Adjacent(usr) || usr.incapacitated())
 		return
 	if(href_list["color"])
-		var/temp = tgui_input_color(usr, "Please select crayon color.", "Crayon color")
+		var/temp = tgui_input_color(usr, "Пожалуйста, выберите цвет мелка.", "Цвет мелка")
 		if(isnull(temp))
 			return
 		colour = temp
@@ -306,7 +306,7 @@
 
 /obj/item/toy/crayon/spraycan
 	name = "\improper Nanotrasen-brand Rapid Paint Applicator"
-	desc = "A metallic container containing spray paint."
+	desc = "Металлический контейнер с краской-спреем."
 	icon_state = "spraycan_cap"
 	slot_flags = ITEM_SLOT_BELT
 	var/capped = TRUE
@@ -323,16 +323,16 @@
 /obj/item/toy/crayon/spraycan/activate_self(mob/user)
 	if(..())
 		return
-	var/choice = tgui_input_list(user, "Do you want to...", "Spraycan Options", list("Toggle Cap","Change Drawing", "Change Color"))
+	var/choice = tgui_input_list(user, "Вы хотите...", "Spraycan Options", list("Проверить колпачок","Изменить рисунок", "Изменить цвет"))
 	switch(choice)
-		if("Toggle Cap")
-			to_chat(user, "<span class='notice'>You [capped ? "remove" : "replace"] the cap of [src].</span>")
+		if("Проверить колпачок")
+			to_chat(user, "<span class='notice'>Вы [capped ? "открыли" : "закрыли"] крышку [src].</span>")
 			capped = !capped
 			update_icon()
-		if("Change Drawing")
+		if("Изменить рисунок")
 			update_window(user)
-		if("Change Color")
-			colour = tgui_input_color(user,"Please select a paint color.","Spray Can Color")
+		if("Изменить цвет")
+			colour = tgui_input_color(user,"Пожалуйста, выберите цвет краски.","Цвет краски")
 			if(isnull(colour))
 				return
 			update_icon()
@@ -342,7 +342,7 @@
 	if(!proximity_flag)
 		return
 	if(capped)
-		to_chat(user, "<span class='warning'>You cannot spray [target] while the cap is still on!</span>")
+		to_chat(user, "<span class='warning'>Вы не можете нарисовать [target] пока колпачок закрыт!</span>")
 		return
 	if(istype(target, /obj/item/clothing/head/cardborg) || istype(target, /obj/item/clothing/suit/cardborg))	// Spraypainting your cardborg suit for more fashion options.
 		cardborg_recolor(target, user)
@@ -351,10 +351,10 @@
 		return
 	var/mob/living/carbon/human/attackee = target
 	if(uses < 10)
-		to_chat(user, "<span class='warning'>Theres not enough paint left to have an effect!</span>")
+		to_chat(user, "<span class='warning'>Осталось недостаточно краски, чтобы оказать какой-либо реальный эффект!</span>")
 		return
 	uses -= 10
-	user.visible_message("<span class='danger'>[user] sprays [src] into the face of [target]!</span>")
+	user.visible_message("<span class='danger'>[user] распыляет [src] прямо в лицо [target]!</span>")
 	if(!attackee.is_eyes_covered()) // eyes aren't covered? ARGH IT BURNS.
 		attackee.Confused(6 SECONDS)
 		attackee.KnockDown(6 SECONDS)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -116,7 +116,7 @@
 	if(busy)
 		return
 	if(is_type_in_list(target,validSurfaces))
-		var/temp = "руку"
+		var/temp = "руну"
 		if(preset_message_index > 0)
 			temp = "букву"
 			drawtype = preset_message[preset_message_index]
@@ -323,9 +323,9 @@
 /obj/item/toy/crayon/spraycan/activate_self(mob/user)
 	if(..())
 		return
-	var/choice = tgui_input_list(user, "Вы хотите...", "Spraycan Options", list("Проверить колпачок","Изменить рисунок", "Изменить цвет"))
+	var/choice = tgui_input_list(user, "Вы хотите...", "Spraycan Options", list("Снять/надеть колпачок","Изменить рисунок", "Изменить цвет"))
 	switch(choice)
-		if("Проверить колпачок")
+		if("Снять/надеть колпачок")
 			to_chat(user, "<span class='notice'>Вы [capped ? "открыли" : "закрыли"] крышку [src].</span>")
 			capped = !capped
 			update_icon()

--- a/modular_ss220/translations/code/translation_data/ru_names.toml
+++ b/modular_ss220/translations/code/translation_data/ru_names.toml
@@ -16979,6 +16979,15 @@ instrumental = "усиленной стеной"
 prepositional = "усиленной стене"
 gender = "female"
 
+["reinforced window"]
+nominative = "усиленное окно"
+genitive = "усиленного окна"
+dative = "усиленному окну"
+accusative = "усиленное окно"
+instrumental = "усиленным окном"
+prepositional = "усиленном окне"
+gender = "neuter"
+
 # MARK: Command
 
 ["command uniform"]
@@ -21687,12 +21696,12 @@ prepositional = "принадлежностях для игры \"Приколи
 gender = "plural"
 
 ["box of crayons"]
-nominative = "коробка цветных карандашей"
-genitive = "коробки цветных карандашей"
-dative = "коробке цветных карандашей"
-accusative = "коробку цветных карандашей"
-instrumental = "коробкой цветных карандашей"
-prepositional = "коробке цветных карандашей"
+nominative = "коробка цветных мелков"
+genitive = "коробки цветных мелков"
+dative = "коробке цветных мелков"
+accusative = "коробку цветных мелков"
+instrumental = "коробкой цветных мелков"
+prepositional = "коробке цветных мелков"
 gender = "female"
 
 ["paint palette"]
@@ -22385,3 +22394,241 @@ dative = "своим"
 accusative = "свои"
 instrumental = "своими"
 prepositional = "своих"
+
+# MARK: Chess pieces
+
+["Chess Piece"]
+nominative = "шахматная фигура"
+genitive = "шахматной фигуры"
+dative = "шахматной фигуре"
+accusative = "шахматную фигуру"
+instrumental = "шахматной фигурой"
+prepositional = "шахматной фигуре"
+gender = "female"
+
+["Black Pawn"]
+nominative = "черная пешка"
+genitive = "черной пешки"
+dative = "черной пешке"
+accusative = "черную пешку"
+instrumental = "черной пешкой"
+prepositional = "черной пешке"
+gender = "female"
+
+["Black Rook"]
+nominative = "черная ладья"
+genitive = "черной ладьи"
+dative = "черной ладье"
+accusative = "черную ладью"
+instrumental = "черной ладьей"
+prepositional = "черной ладье"
+gender = "female"
+
+["Black Knight"]
+nominative = "черный конь"
+genitive = "черного коня"
+dative = "черному коню"
+accusative = "черного коня"
+instrumental = "черным конем"
+prepositional = "черном коне"
+gender = "male"
+
+["Black Bishop"]
+nominative = "черный слон"
+genitive = "черного слона"
+dative = "черному слону"
+accusative = "черного слона"
+instrumental = "черным слоном"
+prepositional = "черном слоне"
+gender = "male"
+
+["Black Queen"]
+nominative = "черная королева"
+genitive = "черной королевы"
+dative = "черной королеве"
+accusative = "черную королеву"
+instrumental = "черной королевой"
+prepositional = "черной королеве"
+gender = "female"
+
+["Black King"]
+nominative = "черный король"
+genitive = "черного короля"
+dative = "черному королю"
+accusative = "черного короля"
+instrumental = "черным королем"
+prepositional = "черном короле"
+gender = "male"
+
+["White Pawn"]
+nominative = "белая пешка"
+genitive = "белой пешки"
+dative = "белой пешке"
+accusative = "белую пешку"
+instrumental = "белой пешкой"
+prepositional = "белой пешке"
+gender = "female"
+
+["White Rook"]
+nominative = "белая ладья"
+genitive = "белой ладьи"
+dative = "белой ладье"
+accusative = "белую ладью"
+instrumental = "белой ладьей"
+prepositional = "белой ладье"
+gender = "female"
+
+["White Knight"]
+nominative = "белый конь"
+genitive = "белого коня"
+dative = "белому коню"
+accusative = "белого коня"
+instrumental = "белым конем"
+prepositional = "белом коне"
+gender = "male"
+
+["White Bishop"]
+nominative = "белый слон"
+genitive = "белого слона"
+dative = "белому слону"
+accusative = "белого слона"
+instrumental = "белым слоном"
+prepositional = "белом слоне"
+gender = "male"
+
+["White Queen"]
+nominative = "белая королева"
+genitive = "белой королевы"
+dative = "белой королеве"
+accusative = "белую королеву"
+instrumental = "белой королевой"
+prepositional = "белой королеве"
+gender = "female"
+
+["White King"]
+nominative = "белый король"
+genitive = "белого короля"
+dative = "белому королю"
+accusative = "белого короля"
+instrumental = "белым королем"
+prepositional = "белом короле"
+gender = "male"
+
+# MARK: Crayons
+
+["crayon"]
+nominative = "мелок"
+genitive = "мелка"
+dative = "мелку"
+accusative = "мелок"
+instrumental = "мелком"
+prepositional = "мелке"
+gender = "male"
+
+["red crayon"]
+nominative = "красный мелок"
+genitive = "красного мелка"
+dative = "красному мелку"
+accusative = "красный мелок"
+instrumental = "красным мелком"
+prepositional = "красном мелке"
+gender = "male"
+
+["orange crayon"]
+nominative = "оранжевый мелок"
+genitive = "оранжевого мелка"
+dative = "оранжевому мелку"
+accusative = "оранжевый мелок"
+instrumental = "оранжевым мелком"
+prepositional = "оранжевом мелке"
+gender = "male"
+
+["yellow crayon"]
+nominative = "желтый мелок"
+genitive = "желтого мелка"
+dative = "желтому мелку"
+accusative = "желтый мелок"
+instrumental = "желтым мелком"
+prepositional = "желтом мелке"
+gender = "male"
+
+["green crayon"]
+nominative = "зеленый мелок"
+genitive = "зеленого мелка"
+dative = "зеленому мелку"
+accusative = "зеленый мелок"
+instrumental = "зеленым мелком"
+prepositional = "зеленом мелке"
+gender = "male"
+
+["blue crayon"]
+nominative = "синий мелок"
+genitive = "синего мелка"
+dative = "синему мелку"
+accusative = "синий мелок"
+instrumental = "синим мелком"
+prepositional = "синем мелке"
+gender = "male"
+
+["purple crayon"]
+nominative = "фиолетовый мелок"
+genitive = "фиолетового мелка"
+dative = "фиолетовому мелку"
+accusative = "фиолетовый мелок"
+instrumental = "фиолетовым мелком"
+prepositional = "фиолетовом мелке"
+gender = "male"
+
+["black crayon"]
+nominative = "черный мелок"
+genitive = "черного мелка"
+dative = "черному мелку"
+accusative = "черный мелок"
+instrumental = "черным мелком"
+prepositional = "черном мелке"
+gender = "male"
+
+["white crayon"]
+nominative = "белый мелок"
+genitive = "белого мелка"
+dative = "белому мелку"
+accusative = "белый мелок"
+instrumental = "белым мелком"
+prepositional = "белом мелке"
+gender = "male"
+
+["detective's chalk"]
+nominative = "мел детектива"
+genitive = "мела детектива"
+dative = "мелу детектива"
+accusative = "мел детектива"
+instrumental = "мелом детектива"
+prepositional = "меле детектива"
+gender = "male"
+
+["mime crayon"]
+nominative = "мелок мима"
+genitive = "мелка мима"
+dative = "мелку мима"
+accusative = "мелок мима"
+instrumental = "мелком мима"
+prepositional = "мелке мима"
+gender = "male"
+
+["rainbow crayon"]
+nominative = "радужный мелок"
+genitive = "радужного мелка"
+dative = "радужному мелку"
+accusative = "радужный мелок"
+instrumental = "радужным мелком"
+prepositional = "радужном мелке"
+gender = "male"
+
+["Nanotrasen-brand Rapid Paint Applicator"]
+nominative = "быстрый аппликатор краски от НаноТрейзен"
+genitive = "быстрого аппликатора краски от НаноТрейзен"
+dative = "быстрому аппликатору краски от НаноТрейзен"
+accusative = "быстрый аппликатор краски от НаноТрейзен"
+instrumental = "быстрым аппликатором краски от НаноТрейзен"
+prepositional = "быстром аппликаторе краски от НаноТрейзен"
+gender = "male"


### PR DESCRIPTION
## Что этот PR делает

Перевод нескольких игровых предметов плюс общий шаблон окна информации о предмете
(changelog стоит как typo ибо нету подходящего тега для переводов)

## Почему это хорошо для игры

Увеличение покрытия русского перевода, помощь игрокам со слабым знанием английского языка

## Тестирование

Запуск локального сервера, проверка взаимодействия с объектами в мире

## Changelog

:cl:
typo: перевод в окне информации о предмете (окно Shift+Click): фраза "Это ...." + статусы окровавлено/в масле + размер предмета (маленький, большой, и т.д.)
typo: перевод манипуляций с цветными мелками: названия мелков, окно и статусы рисования, попытка отгрызть кусок, попытка совершить НаноТрейзенНадзор
typo: перевод названий шахматных фигур
/:cl: