### PR TITLE
Fix TTS change option not shown in VV dropdown

### DIFF
--- a/modular_ss220/text_to_speech/code/tts_vv.dm
+++ b/modular_ss220/text_to_speech/code/tts_vv.dm
@@ -1,5 +1,9 @@
 #define VV_HK_CHANGETTS "changetts"
 
+/atom/vv_get_dropdown()
+	. = ..()
+	VV_DROPDOWN_OPTION(VV_HK_CHANGETTS, "Change TTS")
+
 /client/view_var_Topic(href, href_list, hsrc)
 	. = ..()
 	if(href_list[VV_HK_CHANGETTS])
@@ -7,10 +11,5 @@
 			return
 		var/atom/A = GET_VV_TARGET
 		A.change_tts_seed(src.mob, TRUE, TRUE)
-
-/atom/vv_get_dropdown()
-	. = ..()
-	VV_DROPDOWN_OPTION(VV_HK_CHANGETTS, "Change TTS")
-
 
 #undef VV_HK_CHANGETTS


### PR DESCRIPTION
## Что этот PR делает
Возвращает Change TTS обратно в меню УиУи после рефактора.

## Тестирование
Кнопка в меню есть, кнопка рабочая.

## Changelog

:cl: Maxiemar
fix: Измение TTS снова доступно через VV.
/:cl:
