### PR TITLE
[TM ONLY] Clothing now protects from foam

### DIFF
--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -56,7 +56,9 @@
 			var/amount = foamed.reagents?.get_reagent_amount(R.id)
 			var/foam_content_amount = reagents.get_reagent_amount(R.id)
 			if(amount < max_reagent_filling)
-				foamed.reagents?.add_reagent(R.id, min(round(foam_content_amount / 2), 15))
+				amount = round(min(round(foam_content_amount / 2), 15) * (1 - foamed.get_permeability_protection()), 0.1)
+				if(amount >= 0.5)
+					foamed.reagents?.add_reagent(R.id, amount)
 
 /obj/effect/particle_effect/foam/proc/initial_process()
 	process()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет снижение количества реагентов передающихся от пены к мобу, в зависимости от защиты одежды на этом мобе
Таким образом пользователи условных модсьютов, биосьютов и прочего будут игнорировать реагенты от пены, ну и в целом большинство одежды будет снижать количество этих реагентов

магическое число 0.5 взято с тг

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Отсутствие проверки на защиту явный оверсайт

ТМ потому что надо будет в целом зарефакторить это всё и на оффы закинуть, но так как и мерджи апстрима, и ревью на апстриме раз в году, то проще сделать так

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Работает!

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
experiment: кто это замержил
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
