### PR TITLE
[FIX] Mining outpost missing disposal pipe segment

### DIFF
--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -7817,6 +7817,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/random/dirt/maybe,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrownfull"
 	},


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Вдогонку к https://github.com/ss220club/Paradise-SS220/pull/2026 добавляет пропущенный сегмент мусоропровода.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Изображения изменений
<img width="882" height="382" alt="StrongDMM_2025-08-12_15-38-57" src="https://github.com/user-attachments/assets/919d6aee-5d6d-4f3a-979d-aaec97f6c3ca" />

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Локальный тест

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Аванпост: добавлена недостающая секция мусоропровода.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
