### PR TITLE
Fixing Accesses On Mining Outpost A Little

### DIFF
--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -2703,7 +2703,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/mine/laborcamp)
 "qA" = (
-/obj/effect/mapping_helpers/airlock/access/any/supply/smith,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2712,6 +2711,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mining/glass,
+/obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrownfull"
 	},
@@ -7610,6 +7610,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkfull"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

- Заменяет на малом складе припасов доступ со smith на mining_outpost;
- Добавляет на внешний шлюз в аванпостовском офисе КМа any доступ blueshield'а.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Корректный доступ, БЩ сможет заходить в офис главы карго с обеих сторон.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Визуальный изменений нет, но вот пара картинок для наглядности:
<img width="1208" height="790" alt="изображение" src="https://github.com/user-attachments/assets/527c6e35-cdf8-4e77-9d83-2d906ab2c53e" />

<img width="1114" height="482" alt="изображение" src="https://github.com/user-attachments/assets/dcb3bc73-4ddd-4120-a3f1-9ed8eae6a1ad" />

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Лишнего не накликал, доступы стоят нужные. Все остальные дверки на всякий тоже перепроверил. Всего -1 и +2 строчек кода...

## Changelog

:cl:
tweak: На внешний шлюз офиса КМа шахтерского аванпоста добавлен доступ Синего Щита;
fix: Исправлен некорректный доступ на одном из шлюзов шахтерского аванпоста.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
