### PR TITLE
Adds Atmos Access To The Delta Station's Incinerator

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -81154,7 +81154,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
 "oEP" = (
@@ -111323,6 +111323,7 @@
 	heat_proof = 1
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/simulated/floor/engine,
 /area/station/maintenance/incinerator)
 "yeH" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Навешивает буквально на пару шлюзов дельтовского мусорожигателя доступы атмоса.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Так сделано на коробке, пусть будет и на дельте. Мусоросжигатель не должен быть проходным двором.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

<img width="595" height="605" alt="изображение" src="https://github.com/user-attachments/assets/9543a01e-a681-472a-a34e-be2389d8082a" />

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

-1 +2 строчек кода...

## Changelog

:cl:
tweak: На шлюзы в мусоросжигатель Кербероса выставлены доступы атмосферных техников.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
