### PR TITLE
Some more mining outpost fixes

### DIFF
--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -5640,7 +5640,6 @@
 	},
 /area/mine/outpost/cafeteria)
 "JX" = (
-/obj/item/gps/mining,
 /obj/structure/closet/secure_closet/quartermaster/lavaland,
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 9

--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -7,13 +7,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /turf/simulated/floor/plating,
 /area/mine/outpost/airlock)
-"ad" = (
-/obj/structure/platform/reinforced/corner{
-	dir = 4;
-	anchored = 1
-	},
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "af" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -27,6 +20,14 @@
 	dir = 1
 	},
 /area/mine/outpost/smith_workshop)
+"aj" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "an" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -90,10 +91,6 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
-"aE" = (
-/obj/structure/platform/reinforced/corner,
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "aF" = (
 /obj/machinery/door/airlock/titanium{
 	id_tag = "s_docking_airlock";
@@ -141,13 +138,6 @@
 	dir = 1
 	},
 /area/mine/outpost/hallway/east)
-"aX" = (
-/obj/structure/platform/reinforced{
-	dir = 8;
-	anchored = 1
-	},
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "aY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -384,6 +374,16 @@
 	icon_state = "whitebluecorner"
 	},
 /area/mine/outpost/medbay)
+"cE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "cH" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/cable{
@@ -516,7 +516,8 @@
 /turf/simulated/floor/plating,
 /area/mine/outpost/hallway/west)
 "dq" = (
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "du" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -590,6 +591,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "dM" = (
@@ -821,6 +823,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "fc" = (
@@ -929,8 +932,9 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/shuttle/siberia)
 "fG" = (
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "fL" = (
 /obj/machinery/suit_storage_unit/lavaland,
@@ -1053,13 +1057,6 @@
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /turf/simulated/floor/plating,
 /area/mine/outpost/airlock)
-"gA" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/random/dirt/maybe,
-/obj/structure/marker_beacon/dock_marker,
-/turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "gD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -1076,6 +1073,18 @@
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
 /area/mine/outpost/production)
+"gH" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/marker_beacon/dock_marker,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "gL" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1116,8 +1125,9 @@
 	network = list("Mining Outpost");
 	dir = 8
 	},
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "gY" = (
 /obj/machinery/hologram/holopad,
@@ -1148,6 +1158,9 @@
 	},
 /obj/machinery/alarm/directional/north,
 /obj/effect/spawner/random/dirt/maybe,
+/obj/item/gps/ruin/mining_base{
+	pixel_x = 32
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "navyblue";
 	dir = 4
@@ -1863,6 +1876,18 @@
 	icon_state = "darkbrown"
 	},
 /area/mine/outpost/hallway/west)
+"lL" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing,
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "lO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1989,9 +2014,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/spawner/random/dirt/maybe,
 /obj/structure/marker_beacon/dock_marker,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "mt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2276,6 +2302,12 @@
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/catwalk,
 /area/mine/outpost/maintenance/south)
+"oi" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "oj" = (
 /turf/simulated/wall,
 /area/mine/outpost/cafeteria)
@@ -2781,7 +2813,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "rj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2919,6 +2953,14 @@
 	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
+"rR" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "rT" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/carpet/grimey,
@@ -3131,15 +3173,6 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
 /area/mine/outpost/maintenance/east)
-"tA" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "tB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/window/reinforced/plasma/grilled,
@@ -3244,10 +3277,6 @@
 	icon_state = "barber"
 	},
 /area/mine/laborcamp)
-"uo" = (
-/obj/effect/spawner/random/dirt/often,
-/turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "uq" = (
 /obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/fancy/oak,
@@ -3440,6 +3469,14 @@
 	icon_state = "dark"
 	},
 /area/mine/outpost/mechbay)
+"vB" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "vJ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners";
@@ -3451,6 +3488,7 @@
 	dir = 6
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "vP" = (
@@ -3567,16 +3605,6 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
 /area/mine/laborcamp)
-"wy" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "wz" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -3639,13 +3667,6 @@
 	dir = 1
 	},
 /area/mine/outpost/hallway/west)
-"wW" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "wY" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/volcanic/lava_land_surface,
@@ -3661,7 +3682,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "xl" = (
 /obj/structure/ore_box,
@@ -3703,13 +3726,10 @@
 "xs" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "xu" = (
@@ -3752,8 +3772,9 @@
 	network = list("Mining Outpost");
 	dir = 8
 	},
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "xB" = (
 /obj/structure/lattice/catwalk/mining,
@@ -4031,6 +4052,7 @@
 	dir = 5
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "zm" = (
@@ -4326,13 +4348,6 @@
 "Bb" = (
 /turf/simulated/wall,
 /area/lavaland/surface/outdoors/targetable)
-"Bd" = (
-/obj/structure/platform/reinforced{
-	dir = 1;
-	anchored = 1
-	},
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "Be" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4354,8 +4369,9 @@
 "Bg" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Bh" = (
 /obj/structure/rack,
@@ -4589,6 +4605,7 @@
 "CK" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing/corner,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "CL" = (
@@ -4612,7 +4629,8 @@
 	dir = 4
 	},
 /obj/structure/marker_beacon/dock_marker,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "CS" = (
 /obj/machinery/power/apc/directional/north,
@@ -4639,6 +4657,7 @@
 	dir = 1
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "CW" = (
@@ -4669,9 +4688,9 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/effect/spawner/random/dirt/maybe,
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "De" = (
 /turf/template_noop,
@@ -4852,6 +4871,7 @@
 /obj/structure/railing{
 	dir = 10
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "EF" = (
@@ -4949,8 +4969,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Fc" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -5230,7 +5250,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "GY" = (
 /obj/machinery/light/small/directional/east,
@@ -5282,7 +5304,9 @@
 "Ht" = (
 /obj/structure/railing/corner,
 /obj/structure/marker_beacon/dock_marker,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Hx" = (
 /obj/machinery/light/directional/south,
@@ -5370,7 +5394,9 @@
 "Ic" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/structure/marker_beacon/dock_marker,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "If" = (
 /obj/machinery/alarm/directional/south,
@@ -5608,13 +5634,6 @@
 	icon_state = "darkbrowncorners"
 	},
 /area/mine/outpost/hallway/east)
-"JQ" = (
-/obj/structure/platform/reinforced/corner{
-	dir = 8;
-	anchored = 1
-	},
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "JR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5881,6 +5900,7 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "LE" = (
@@ -6316,6 +6336,17 @@
 	icon_state = "brown"
 	},
 /area/mine/laborcamp)
+"Ns" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Nv" = (
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plasteel{
@@ -6414,8 +6445,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Od" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -6594,6 +6625,17 @@
 	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
+"Ps" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/sign/nanotrasen{
+	pixel_x = 32
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Pw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -6602,7 +6644,9 @@
 	dir = 1
 	},
 /obj/structure/marker_beacon/dock_marker,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Py" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6631,6 +6675,7 @@
 	dir = 4
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "PL" = (
@@ -6763,13 +6808,6 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
-"QE" = (
-/obj/structure/platform/reinforced/corner{
-	dir = 1;
-	anchored = 1
-	},
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "QG" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/mapping_helpers/no_lava,
@@ -6870,6 +6908,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/mine/laborcamp)
+"Ry" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "RK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -6946,6 +6992,14 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/siberia)
+"Sa" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "Sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -7202,10 +7256,6 @@
 	},
 /turf/simulated/floor/noslip,
 /area/mine/outpost/airlock)
-"TC" = (
-/obj/structure/platform/reinforced,
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "TF" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -7264,8 +7314,8 @@
 "TS" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/marker_beacon/dock_marker,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "TT" = (
 /obj/structure/chair/sofa/bench/left{
@@ -7417,6 +7467,7 @@
 	dir = 9
 	},
 /obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Uv" = (
@@ -7650,13 +7701,6 @@
 	icon_state = "dark"
 	},
 /area/mine/outpost/lockers)
-"VO" = (
-/obj/structure/platform/reinforced{
-	dir = 4;
-	anchored = 1
-	},
-/turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/targetable)
 "VP" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -7976,8 +8020,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/spawner/random/dirt/maybe,
-/turf/simulated/floor/plating/lavaland_air,
+/obj/effect/mapping_helpers/no_lava,
+/obj/effect/spawner/random/dirt/frequent,
+/turf/simulated/floor/plating,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "XK" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -12225,14 +12270,14 @@ oO
 oO
 wg
 ra
-SQ
-VP
-VP
-VP
-VP
-VP
-VP
-VP
+vB
+Sa
+Sa
+Sa
+Sa
+Sa
+Sa
+Sa
 EA
 Es
 Iy
@@ -12390,10 +12435,10 @@ Ut
 CV
 Ht
 Oa
-Oa
-tA
-tA
-Oa
+Ns
+Ns
+Ns
+Ns
 Oa
 CO
 EA
@@ -12558,7 +12603,7 @@ AV
 hh
 It
 GX
-CE
+oi
 EU
 IJ
 oO
@@ -12719,8 +12764,8 @@ zL
 pB
 YR
 EF
-wy
-CE
+GX
+oi
 EU
 IJ
 oO
@@ -12881,8 +12926,8 @@ xZ
 pB
 dc
 EF
-GX
-CE
+gH
+oi
 EU
 IJ
 oO
@@ -13035,7 +13080,7 @@ oO
 IJ
 oY
 dL
-gA
+TS
 EF
 sI
 Wn
@@ -13043,8 +13088,8 @@ yl
 pB
 ql
 EF
-GX
-CE
+cE
+oi
 EU
 IJ
 oO
@@ -13196,7 +13241,7 @@ oO
 oO
 oO
 oY
-wW
+xG
 Db
 ri
 EF
@@ -13205,8 +13250,8 @@ ft
 AV
 hh
 It
-wy
-CE
+GX
+oi
 EU
 oO
 oO
@@ -13358,7 +13403,7 @@ oO
 oO
 oO
 TY
-wW
+xG
 dq
 ms
 xh
@@ -13368,7 +13413,7 @@ mZ
 Fb
 xh
 Pw
-CE
+oi
 EU
 oO
 IJ
@@ -13685,12 +13730,12 @@ yY
 Vy
 Vy
 dL
-uo
+fG
 dp
 Uv
 uy
-uo
-CE
+fG
+oi
 Vy
 Vy
 PL
@@ -13841,18 +13886,18 @@ oO
 oO
 oO
 jF
-FJ
-VP
+Ps
+Sa
 LD
-VP
-VP
-mK
+Sa
+Sa
+Ry
 gV
 wp
 LZ
 wp
 xz
-LO
+aj
 Yt
 Yt
 Yt
@@ -15938,8 +15983,8 @@ lR
 IJ
 Yr
 Yr
-Yr
-zP
+oO
+oO
 oO
 oO
 IJ
@@ -16100,12 +16145,12 @@ oO
 IJ
 oO
 oO
-aE
-VO
-VO
-VO
-VO
-JQ
+oO
+IJ
+IJ
+oO
+oO
+oO
 xG
 bk
 NE
@@ -16262,12 +16307,12 @@ IJ
 IJ
 oO
 oO
-TC
-CM
-Xp
-Xp
-Qe
-Bd
+wg
+Ol
+Ol
+Ol
+Ol
+Iy
 cc
 eU
 bk
@@ -16424,12 +16469,12 @@ IJ
 IJ
 oO
 oO
-TC
-vQ
-mC
-KT
-KK
-LV
+TY
+CM
+Xp
+Xp
+Qe
+EU
 xs
 oO
 IJ
@@ -16585,14 +16630,14 @@ oO
 oO
 IJ
 oO
-oO
-TC
+IJ
+TY
 vQ
 mC
-cZ
-Jp
-Bd
-lE
+KT
+KK
+LV
+lL
 oO
 IJ
 oj
@@ -16747,14 +16792,14 @@ oO
 oO
 oO
 oO
-oO
-TC
-NX
-SV
-SV
-DW
-Bd
-VM
+IJ
+TY
+vQ
+mC
+cZ
+Jp
+EU
+rR
 oO
 oj
 oj
@@ -16910,13 +16955,13 @@ oO
 oO
 oO
 oO
-QE
-aX
-aX
-aX
-aX
-ad
-VM
+TY
+NX
+SV
+SV
+DW
+EU
+rR
 oO
 oj
 lf
@@ -17072,12 +17117,12 @@ oO
 zP
 oO
 oO
-oO
-oO
-oO
-oO
-oO
-oO
+yY
+Vy
+Vy
+Vy
+Vy
+PL
 VM
 oO
 tB
@@ -17235,10 +17280,10 @@ Yr
 Yr
 aI
 oO
+IJ
+IJ
 oO
-oO
-oO
-oO
+IJ
 oO
 VM
 oO

--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -211,6 +211,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowaltstrip"
 	},
@@ -382,7 +383,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "cH" = (
 /obj/structure/lattice/catwalk/mining,
@@ -517,7 +518,7 @@
 /area/mine/outpost/hallway/west)
 "dq" = (
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "du" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -934,7 +935,7 @@
 "fG" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "fL" = (
 /obj/machinery/suit_storage_unit/lavaland,
@@ -1083,7 +1084,7 @@
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "gL" = (
 /obj/machinery/hologram/holopad,
@@ -1103,6 +1104,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "gO" = (
@@ -1127,7 +1129,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "gY" = (
 /obj/machinery/hologram/holopad,
@@ -1200,6 +1202,7 @@
 /area/mine/outpost/hallway/west)
 "hn" = (
 /obj/structure/closet/crate,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "ho" = (
@@ -1224,6 +1227,7 @@
 "hq" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowaltstrip";
 	dir = 1
@@ -1297,7 +1301,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors South West";
+	c_tag = "Mining Outpost - Outdoors South East";
 	network = list("Mining Outpost");
 	dir = 4
 	},
@@ -1310,14 +1314,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/bluegrid,
 /area/mine/outpost/mechbay)
-"hL" = (
-/obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors North West";
-	network = list("Mining Outpost");
-	dir = 1
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
 "hQ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "brown"
@@ -1477,6 +1473,7 @@
 /obj/structure/platform/reinforced/corner{
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "jh" = (
@@ -1797,7 +1794,7 @@
 	amount = 10
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "lv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2017,7 +2014,7 @@
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "mt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -2094,13 +2091,6 @@
 	icon_state = "dark_large"
 	},
 /area/mine/outpost/mechbay)
-"mK" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "mN" = (
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
@@ -2610,6 +2600,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowcornersalt";
 	dir = 8
@@ -2815,7 +2806,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "rj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2834,6 +2825,7 @@
 	dir = 4;
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "rm" = (
@@ -2953,14 +2945,6 @@
 	icon_state = "darkredyellowfull"
 	},
 /area/mine/laborcamp)
-"rR" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "rT" = (
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/carpet/grimey,
@@ -3118,6 +3102,7 @@
 	},
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowcornersalt";
 	dir = 1
@@ -3335,6 +3320,7 @@
 /area/mine/laborcamp)
 "uK" = (
 /obj/structure/ore_box,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "uL" = (
@@ -3557,6 +3543,7 @@
 	dir = 4;
 	network = list("Labor Camp")
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "we" = (
@@ -3625,7 +3612,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
 /obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors South East";
+	c_tag = "Mining Outpost - Outdoors South West";
 	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/lava/mapping_lava,
@@ -3684,7 +3671,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "xl" = (
 /obj/structure/ore_box,
@@ -3774,7 +3761,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "xB" = (
 /obj/structure/lattice/catwalk/mining,
@@ -3868,7 +3855,10 @@
 /area/mine/laborcamp/security)
 "yd" = (
 /obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/camera{
+	c_tag = "Mining Outpost - Shuttle";
+	network = list("Mining Outpost")
+	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
 "ye" = (
@@ -3936,6 +3926,7 @@
 	},
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowcornersalt"
 	},
@@ -4158,18 +4149,10 @@
 /area/mine/laborcamp)
 "zL" = (
 /obj/effect/turf_decal/delivery/hollow,
-/obj/machinery/camera{
-	c_tag = "Mining Outpost - Shuttle";
-	dir = 5;
-	network = list("Mining Outpost")
-	},
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/light/directional/west,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
-"zN" = (
-/obj/structure/flora/ash/rock/style_random,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/gulag_rock)
 "zO" = (
 /obj/machinery/power/apc/directional/south,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4287,6 +4270,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowaltstrip";
 	dir = 4
@@ -4336,6 +4320,7 @@
 	},
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowcornersalt";
 	dir = 4
@@ -4371,7 +4356,7 @@
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Bh" = (
 /obj/structure/rack,
@@ -4408,6 +4393,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plasteel/lavaland_air{
 	icon_state = "darkyellowaltstrip";
 	dir = 8
@@ -4563,6 +4549,7 @@
 	dir = 8;
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "CE" = (
@@ -4618,6 +4605,14 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/engine/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
+"CN" = (
+/obj/machinery/camera{
+	c_tag = "Mining Outpost - Outdoors North East";
+	network = list("Mining Outpost");
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/explored)
 "CO" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -4630,7 +4625,7 @@
 	},
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "CS" = (
 /obj/machinery/power/apc/directional/north,
@@ -4650,6 +4645,7 @@
 	dir = 8;
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "CV" = (
@@ -4690,7 +4686,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "De" = (
 /turf/template_noop,
@@ -4745,7 +4741,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/ore_box,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "DJ" = (
 /obj/structure/table/reinforced,
 /obj/item/ashtray/bronze{
@@ -4970,7 +4966,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Fc" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -5252,7 +5248,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "GY" = (
 /obj/machinery/light/small/directional/east,
@@ -5306,7 +5302,7 @@
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Hx" = (
 /obj/machinery/light/directional/south,
@@ -5396,7 +5392,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "If" = (
 /obj/machinery/alarm/directional/south,
@@ -5932,6 +5928,7 @@
 	dir = 1;
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "LH" = (
@@ -6230,6 +6227,7 @@
 	dir = 1;
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "MS" = (
@@ -6345,7 +6343,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Nv" = (
 /obj/effect/spawner/random/dirt/maybe,
@@ -6446,7 +6444,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Od" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -6646,7 +6644,7 @@
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "Py" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6743,6 +6741,7 @@
 /obj/structure/platform/reinforced{
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "Ql" = (
@@ -7164,13 +7163,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
-"SQ" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 9
-	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "SV" = (
@@ -7315,7 +7308,7 @@
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "TT" = (
 /obj/structure/chair/sofa/bench/left{
@@ -7507,7 +7500,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors North East";
+	c_tag = "Mining Outpost - Outdoors North West";
 	network = list("Mining Outpost");
 	dir = 1
 	},
@@ -7723,6 +7716,7 @@
 	anchored = 1
 	},
 /obj/structure/flora/ash/cacti,
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "VW" = (
@@ -7772,7 +7766,6 @@
 /area/shuttle/siberia)
 "Wn" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/light/small/directional/east,
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
 "Ws" = (
@@ -7842,6 +7835,7 @@
 	dir = 4;
 	anchored = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/gulag_rock)
 "WO" = (
@@ -7892,6 +7886,11 @@
 	icon_state = "darkbrowncorners"
 	},
 /area/mine/outpost/hallway)
+"WX" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/catwalk)
 "WY" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners";
@@ -8022,7 +8021,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/lavaland_air,
 /area/lavaland/surface/outdoors/outpost/catwalk)
 "XK" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -9020,7 +9019,7 @@ Aw
 Aw
 AL
 LG
-uP
+za
 lR
 lR
 lR
@@ -9168,7 +9167,7 @@ lR
 lR
 lR
 lR
-uP
+za
 Qh
 bw
 nb
@@ -9182,8 +9181,8 @@ nb
 nb
 hq
 LG
-uP
-uP
+za
+za
 lR
 lR
 uP
@@ -9330,7 +9329,7 @@ lR
 lR
 lR
 lR
-zN
+Yb
 Qh
 bw
 fT
@@ -9344,7 +9343,7 @@ vP
 DY
 hq
 LG
-uP
+za
 lR
 lR
 lR
@@ -9491,8 +9490,8 @@ za
 za
 lR
 lR
-uP
-uP
+za
+za
 Qh
 bw
 fT
@@ -9506,7 +9505,7 @@ Wm
 DY
 hq
 LG
-uP
+za
 lR
 lR
 lR
@@ -9654,7 +9653,7 @@ lR
 lR
 lR
 lR
-sb
+ZL
 Qh
 bw
 fT
@@ -9816,7 +9815,7 @@ lR
 lR
 lR
 lR
-sb
+ZL
 Qh
 bw
 nb
@@ -10154,7 +10153,7 @@ Th
 CU
 CU
 WJ
-uP
+za
 za
 lR
 lR
@@ -10315,8 +10314,8 @@ en
 EH
 lR
 lR
-uP
-uP
+za
+za
 lR
 lR
 lR
@@ -11428,7 +11427,7 @@ sO
 uP
 lR
 lR
-uP
+za
 Th
 MV
 ni
@@ -11590,7 +11589,7 @@ sO
 uP
 sO
 lR
-uP
+za
 Th
 ZK
 QQ
@@ -13063,7 +13062,7 @@ uK
 hn
 hn
 hn
-uP
+za
 lR
 lR
 lR
@@ -13218,15 +13217,15 @@ sO
 sO
 sO
 sO
-uP
-uP
+za
+za
 wa
-uP
-uP
-uP
-uP
-uP
-uP
+za
+za
+za
+za
+za
+za
 lR
 lR
 lR
@@ -13382,13 +13381,13 @@ sO
 sO
 sO
 sO
-uP
-uP
-uP
-uP
-uP
-uP
-uP
+za
+za
+za
+za
+za
+za
+za
 lR
 lR
 lR
@@ -13544,13 +13543,13 @@ sO
 sO
 sO
 sO
-uP
-uP
-uP
-uP
-uP
-uP
-uP
+za
+za
+za
+za
+za
+za
+za
 lR
 lR
 lR
@@ -13706,13 +13705,13 @@ sO
 sO
 sO
 sO
-uP
-uP
-uP
-uP
-uP
-uP
-uP
+za
+za
+za
+za
+za
+za
+za
 lR
 lR
 lR
@@ -13874,7 +13873,7 @@ uK
 uK
 uK
 sO
-uP
+za
 lR
 lR
 oO
@@ -14036,7 +14035,7 @@ sO
 sO
 sO
 sO
-uP
+za
 lR
 lR
 oO
@@ -14694,8 +14693,8 @@ Yr
 oO
 oO
 IJ
-SQ
-mK
+vB
+Ry
 em
 LF
 rT
@@ -14856,7 +14855,7 @@ Yr
 Yr
 Yr
 Yr
-ZV
+WX
 fC
 em
 em
@@ -15018,7 +15017,7 @@ Kl
 Kl
 Kl
 Yr
-ZV
+WX
 eU
 fC
 yF
@@ -15180,7 +15179,7 @@ Bh
 OD
 Kl
 my
-ZV
+WX
 eU
 bt
 WH
@@ -15342,7 +15341,7 @@ kJ
 rI
 Ks
 UR
-ZV
+WX
 bk
 eN
 LH
@@ -16799,7 +16798,7 @@ mC
 cZ
 Jp
 EU
-rR
+lE
 oO
 oj
 oj
@@ -16961,7 +16960,7 @@ SV
 SV
 DW
 EU
-rR
+lE
 oO
 oj
 lf
@@ -20365,7 +20364,7 @@ zP
 zP
 zP
 zP
-hL
+zP
 fZ
 hy
 Kg
@@ -20527,7 +20526,7 @@ XA
 XA
 XA
 XA
-XA
+CN
 pW
 fZ
 pW

--- a/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
+++ b/_maps/map_files220/RandomRuins/LavaRuins/lavaland_surface_nt.dmm
@@ -27,7 +27,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "an" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -63,7 +63,7 @@
 	},
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "aA" = (
 /obj/machinery/conveyor/east{
 	id = "MiningDisposal"
@@ -110,6 +110,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/siberia)
+"aG" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "aI" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/flora/ash/rock/style_random,
@@ -171,7 +180,7 @@
 /area/mine/outpost/lockers)
 "bk" = (
 /turf/simulated/wall,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "bm" = (
 /obj/machinery/door_control/shutter/north{
 	req_access = list(54);
@@ -189,7 +198,7 @@
 "br" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors West";
+	c_tag = "Mining Outpost - Outdoors East";
 	network = list("Mining Outpost");
 	dir = 4
 	},
@@ -200,7 +209,7 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "bu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -282,6 +291,13 @@
 	icon_state = "darkbrown"
 	},
 /area/mine/outpost/storage)
+"bR" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/engine/lavaland_air,
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "bT" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
@@ -304,7 +320,7 @@
 /obj/structure/railing/corner,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "cd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
@@ -384,7 +400,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "cH" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/cable{
@@ -395,7 +411,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/targetable)
+/area/mine/outpost/maintenance/south)
 "cK" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -470,10 +486,10 @@
 	},
 /area/mine/outpost/storage)
 "cZ" = (
-/obj/machinery/radar,
 /obj/effect/mapping_helpers/no_lava,
+/obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "da" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -495,7 +511,6 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "dk" = (
@@ -519,7 +534,7 @@
 "dq" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "du" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -565,7 +580,7 @@
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "dD" = (
 /obj/machinery/door/airlock,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -586,7 +601,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "dL" = (
 /obj/structure/railing{
 	dir = 1
@@ -594,7 +609,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "dM" = (
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plasteel{
@@ -713,7 +728,7 @@
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plasteel,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "ew" = (
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
@@ -777,7 +792,7 @@
 	},
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "eO" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/decal/cleanable/dirt,
@@ -792,8 +807,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Mining Outpost - Outdoors North West";
+	network = list("Mining Outpost");
+	dir = 1
+	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "eR" = (
 /obj/machinery/economy/vending/sustenance,
 /turf/simulated/floor/plasteel{
@@ -808,7 +828,7 @@
 "eU" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "eX" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -826,7 +846,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "fc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -924,7 +944,7 @@
 /area/mine/outpost/production)
 "fC" = (
 /turf/simulated/mineral/ancient,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "fD" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Labor Shuttle Airlock"
@@ -936,7 +956,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "fL" = (
 /obj/machinery/suit_storage_unit/lavaland,
 /obj/machinery/firealarm/directional/south,
@@ -1085,7 +1105,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "gL" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1106,7 +1126,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "gO" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1130,7 +1150,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "gY" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1306,7 +1326,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "hJ" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -1330,6 +1350,7 @@
 "hZ" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners";
 	dir = 8
@@ -1514,14 +1535,12 @@
 /area/mine/outpost/hallway/west)
 "jw" = (
 /obj/structure/table/reinforced,
-/obj/item/shovel,
-/obj/item/pickaxe/mini,
-/obj/effect/spawner/random/dirt/often,
 /obj/item/toy/figure/crew/miner{
 	pixel_x = 6;
 	pixel_y = -12
 	},
 /obj/machinery/cell_charger,
+/obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark_large"
 	},
@@ -1547,7 +1566,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "jI" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
@@ -1794,7 +1813,7 @@
 	amount = 10
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "lv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -1857,12 +1876,15 @@
 "lE" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
-/obj/structure/railing{
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "lH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1873,18 +1895,6 @@
 	icon_state = "darkbrown"
 	},
 /area/mine/outpost/hallway/west)
-"lL" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing,
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "lO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2015,7 +2025,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "mt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -2073,7 +2083,7 @@
 "mC" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "mE" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/machine,
@@ -2263,6 +2273,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
+/obj/structure/lattice/catwalk/mining,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/targetable)
 "nX" = (
@@ -2297,7 +2308,7 @@
 /obj/structure/railing,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "oj" = (
 /turf/simulated/wall,
 /area/mine/outpost/cafeteria)
@@ -2562,7 +2573,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "pJ" = (
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -2807,7 +2818,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "rj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2890,7 +2901,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "rI" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -3157,7 +3168,7 @@
 	},
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "tB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/window/reinforced/plasma/grilled,
@@ -3426,7 +3437,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "vq" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external/glass{
@@ -3462,7 +3473,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "vJ" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners";
@@ -3476,7 +3487,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "vP" = (
 /obj/structure/shuttle/engine/heater,
 /obj/structure/window/plasmareinforced{
@@ -3485,15 +3496,12 @@
 /turf/simulated/floor/plating/lavaland_air,
 /area/shuttle/siberia)
 "vQ" = (
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
 /obj/structure/railing{
-	dir = 1
+	dir = 9
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "vR" = (
 /obj/structure/grille/broken,
 /obj/effect/spawner/wire_splicing/thirty,
@@ -3616,7 +3624,7 @@
 	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "wF" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -3641,7 +3649,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "wN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3657,7 +3665,7 @@
 "wY" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xa" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -3672,7 +3680,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xl" = (
 /obj/structure/ore_box,
 /obj/effect/spawner/random/dirt/frequent,
@@ -3718,7 +3726,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3762,7 +3770,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xB" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -3774,7 +3782,7 @@
 	pixel_y = 7
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xG" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -3782,7 +3790,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xK" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
@@ -3791,7 +3799,7 @@
 	network = list("Mining Outpost")
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "xM" = (
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
@@ -4031,7 +4039,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/item/lighter/zippo/engraved,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "zj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4045,7 +4053,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "zm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -4330,9 +4338,6 @@
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
 /area/shuttle/mining)
-"Bb" = (
-/turf/simulated/wall,
-/area/lavaland/surface/outdoors/targetable)
 "Be" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4357,7 +4362,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Bh" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -4556,7 +4561,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "CF" = (
 /obj/effect/decal/remains/human,
 /obj/effect/mapping_helpers/no_lava,
@@ -4594,23 +4599,17 @@
 /obj/structure/railing/corner,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "CL" = (
 /turf/simulated/wall,
 /area/mine/outpost/maintenance/south)
-"CM" = (
-/obj/structure/railing{
-	dir = 9
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "CN" = (
 /obj/machinery/camera{
 	c_tag = "Mining Outpost - Outdoors North East";
 	network = list("Mining Outpost");
 	dir = 1
 	},
+/obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
 "CO" = (
@@ -4626,7 +4625,7 @@
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "CS" = (
 /obj/machinery/power/apc/directional/north,
 /obj/machinery/computer/cryopod{
@@ -4655,7 +4654,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "CW" = (
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /obj/effect/mapping_helpers/damaged_window,
@@ -4677,6 +4676,13 @@
 	icon_state = "dark"
 	},
 /area/mine/outpost/airlock)
+"Da" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/targetable)
 "Db" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -4687,7 +4693,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "De" = (
 /turf/template_noop,
 /area/template_noop)
@@ -4705,7 +4711,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Dj" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Airlock";
@@ -4733,6 +4739,13 @@
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
 /area/mine/outpost/maintenance/south)
+"Dr" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/simulated/floor/engine/lavaland_air,
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "DB" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
@@ -4741,7 +4754,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/ore_box,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "DJ" = (
 /obj/structure/table/reinforced,
 /obj/item/ashtray/bronze{
@@ -4762,7 +4775,7 @@
 	layer = 3.9
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "DS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -4779,11 +4792,9 @@
 /area/mine/outpost/maintenance/south)
 "DW" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/railing{
-	dir = 6
-	},
+/obj/structure/railing,
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "DX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4804,7 +4815,7 @@
 "Ea" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "Ec" = (
 /obj/structure/door_assembly/door_assembly_silver,
 /turf/simulated/floor/mineral/titanium/blue,
@@ -4836,7 +4847,7 @@
 /obj/effect/spawner/random/dirt/frequent,
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plasteel,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "Ep" = (
 /obj/machinery/shower/directional/west,
 /obj/machinery/light_switch/west,
@@ -4861,7 +4872,7 @@
 /obj/structure/rack,
 /obj/item/storage/box/flares,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "EA" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing{
@@ -4869,7 +4880,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "EF" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/mining)
@@ -4894,7 +4905,7 @@
 	},
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "EN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4967,7 +4978,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Fc" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1
@@ -5041,7 +5052,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "FL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5249,7 +5260,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "GY" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/cable{
@@ -5303,7 +5314,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Hx" = (
 /obj/machinery/light/directional/south,
 /turf/simulated/floor/plasteel{
@@ -5334,6 +5345,17 @@
 	icon_state = "dark"
 	},
 /area/mine/outpost/storage)
+"HF" = (
+/obj/structure/lattice/catwalk/mining,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "HL" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/alarm/directional/south,
@@ -5393,7 +5415,7 @@
 /obj/structure/marker_beacon/dock_marker,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "If" = (
 /obj/machinery/alarm/directional/south,
 /obj/structure/table/glass,
@@ -5475,13 +5497,8 @@
 /obj/structure/railing/cap/reversed{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors North";
-	network = list("Mining Outpost");
-	dir = 1
-	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "IF" = (
 /obj/structure/closet/crate,
 /obj/item/poster/random_contraband,
@@ -5570,9 +5587,12 @@
 /area/lavaland/surface/gulag_rock)
 "Jp" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/railing,
+/obj/structure/railing/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Jq" = (
 /obj/machinery/economy/vending/minedrobe,
 /turf/simulated/floor/plasteel{
@@ -5639,6 +5659,16 @@
 	icon_state = "browncorner"
 	},
 /area/mine/outpost/cafeteria)
+"JS" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/engine/lavaland_air,
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "JX" = (
 /obj/structure/closet/secure_closet/quartermaster/lavaland,
 /obj/effect/turf_decal/siding/wood/oak{
@@ -5657,7 +5687,7 @@
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Kg" = (
 /obj/machinery/camera{
 	c_tag = "Mining Outpost - Warehouse";
@@ -5775,12 +5805,11 @@
 /area/mine/outpost/smith_workshop)
 "KK" = (
 /obj/effect/mapping_helpers/no_lava,
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
+/obj/structure/railing{
+	dir = 10
 	},
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "KL" = (
 /obj/machinery/computer/prisoner{
 	dir = 4
@@ -5793,7 +5822,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/item/chair/plastic,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "KP" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Shuttle Dock"
@@ -5818,10 +5847,12 @@
 /turf/simulated/floor/catwalk,
 /area/mine/outpost/smith_workshop)
 "KT" = (
+/obj/structure/railing{
+	dir = 8
+	},
 /obj/effect/mapping_helpers/no_lava,
-/obj/effect/baseturf_helper/lava_land,
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "KW" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -5889,7 +5920,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "LD" = (
 /obj/structure/railing{
 	dir = 8
@@ -5897,7 +5928,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "LE" = (
 /obj/structure/sign/electricshock{
 	pixel_y = -32
@@ -5913,7 +5944,7 @@
 	},
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "LF" = (
 /obj/machinery/requests_console/directional/north,
 /obj/machinery/computer/crew,
@@ -5941,7 +5972,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "LK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5967,7 +5998,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "LP" = (
 /obj/machinery/door/poddoor/shutters{
 	dir = 1;
@@ -5977,17 +6008,6 @@
 	icon_state = "darkpurplefull"
 	},
 /area/mine/outpost/mechbay)
-"LV" = (
-/obj/structure/lattice/catwalk/mining,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "LX" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -6343,7 +6363,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Nv" = (
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plasteel{
@@ -6358,14 +6378,14 @@
 /obj/effect/spawner/random/trash,
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "NE" = (
 /obj/effect/spawner/random/storage,
 /obj/item/storage/toolbox/mechanical/old,
 /obj/item/vending_refill/boozeomat,
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "NF" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6376,14 +6396,13 @@
 	},
 /area/mine/outpost/medbay)
 "NI" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/camera{
 	c_tag = "Mining Outpost - Lockers Room";
 	network = list("Mining Outpost");
 	dir = 8
 	},
-/obj/effect/spawner/random/dirt/maybe,
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkpurplecorners";
 	dir = 4
@@ -6408,7 +6427,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "NV" = (
 /obj/machinery/light/directional/west,
 /obj/effect/spawner/random/dirt/maybe,
@@ -6428,13 +6447,6 @@
 	dir = 6
 	},
 /area/mine/outpost/comms)
-"NX" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "Oa" = (
 /obj/structure/railing{
 	dir = 4
@@ -6444,12 +6456,12 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Od" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/mecha_wreckage/ripley,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Og" = (
 /obj/effect/spawner/random/dirt/maybe,
 /turf/simulated/floor/plasteel{
@@ -6559,7 +6571,7 @@
 "OQ" = (
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "OT" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -6632,7 +6644,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Pw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -6644,7 +6656,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Py" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -6674,7 +6686,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "PL" = (
 /obj/structure/platform/reinforced/corner{
 	dir = 4;
@@ -6703,7 +6715,7 @@
 "PO" = (
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plasteel,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "PR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/iv_drip,
@@ -6729,13 +6741,6 @@
 	dir = 1
 	},
 /area/mine/outpost/hallway/west)
-"Qe" = (
-/obj/effect/mapping_helpers/no_lava,
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "Qh" = (
 /obj/structure/platform/reinforced{
 	anchored = 1
@@ -6913,7 +6918,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "RK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -6924,15 +6929,11 @@
 	icon_state = "dark"
 	},
 /area/mine/outpost/airlock)
-"RM" = (
-/obj/effect/mapping_helpers/turfs/rust/maybe,
-/turf/simulated/wall,
-/area/lavaland/surface/outdoors/targetable)
 "RN" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/railing,
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "RP" = (
 /obj/item/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6997,7 +6998,7 @@
 	},
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Sb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -7164,14 +7165,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "SV" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/machinery/radar,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Tb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -7198,7 +7197,7 @@
 	pixel_y = 9
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Te" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7308,7 +7307,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "TT" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 1;
@@ -7331,18 +7330,17 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffel{
-	pixel_y = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/spawner/random/dirt/maybe,
 /obj/item/gps/mining{
 	pixel_x = -6;
 	pixel_y = 14
 	},
 /obj/effect/baseturf_helper/lava_land,
+/obj/item/pickaxe/mini,
+/obj/item/shovel,
+/obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark_large"
 	},
@@ -7358,6 +7356,13 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/targetable)
+"Ua" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/no_lava,
+/turf/simulated/floor/engine/lavaland_air,
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Ug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
@@ -7377,8 +7382,8 @@
 	},
 /area/mine/outpost/hallway)
 "Ui" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners";
 	dir = 4
@@ -7461,7 +7466,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Uv" = (
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/plasteel{
@@ -7498,13 +7503,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Mining Outpost - Outdoors North West";
-	network = list("Mining Outpost");
-	dir = 1
-	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "UI" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "laborcamp_away"
@@ -7542,6 +7542,15 @@
 	icon_state = "darkpurplecorners"
 	},
 /area/mine/outpost/lockers)
+"UO" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/machinery/camera{
+	c_tag = "Mining Outpost - Outdoors North";
+	network = list("Mining Outpost");
+	dir = 1
+	},
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/targetable)
 "UR" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/decal/cleanable/dirt,
@@ -7556,7 +7565,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Vf" = (
 /obj/structure/sign/fire,
 /turf/simulated/wall,
@@ -7619,7 +7628,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "Vy" = (
 /obj/structure/platform/reinforced{
 	dir = 8;
@@ -7644,6 +7653,11 @@
 	},
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/mining)
+"VE" = (
+/obj/effect/mapping_helpers/no_lava,
+/obj/item/pickaxe,
+/turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/targetable)
 "VF" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/firedoor,
@@ -7684,10 +7698,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "VN" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/secure_closet/miner,
 /obj/effect/spawner/random/dirt/often,
-/obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -7699,7 +7714,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "VR" = (
 /obj/machinery/conveyor/east{
 	id = "MiningDisposal"
@@ -7801,7 +7816,7 @@
 /obj/structure/railing,
 /obj/item/cigbutt,
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "WD" = (
 /obj/machinery/light_switch/south,
 /obj/item/kirbyplants/medium,
@@ -7889,7 +7904,7 @@
 /obj/structure/lattice/catwalk/mining,
 /obj/effect/mapping_helpers/no_lava,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "WY" = (
 /turf/simulated/floor/plasteel{
 	icon_state = "darkbrowncorners";
@@ -7909,7 +7924,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Xl" = (
 /obj/effect/mapping_helpers/no_lava,
 /obj/structure/lattice/catwalk/mining,
@@ -7920,7 +7935,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Xm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7935,13 +7950,6 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/plating,
 /area/mine/outpost/maintenance/south)
-"Xp" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/no_lava,
-/turf/simulated/floor/engine/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
 "Xq" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating{
@@ -7987,7 +7995,7 @@
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plasteel,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "XC" = (
 /obj/item/kirbyplants/medium,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8021,7 +8029,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/effect/spawner/random/dirt/frequent,
 /turf/simulated/floor/plating/lavaland_air,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "XK" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -8057,7 +8065,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/catwalk,
-/area/mine/outpost/maintenance/east)
+/area/mine/outpost/maintenance/north)
 "Yb" = (
 /obj/structure/flora/ash/rock/style_random,
 /obj/effect/mapping_helpers/no_lava,
@@ -8125,7 +8133,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/lava/mapping_lava,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "Yv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8183,10 +8191,13 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/mine/outpost/quartermaster)
 "Yz" = (
-/obj/structure/closet/walllocker/medlocker/directional/north,
 /obj/machinery/light/directional/north,
+/obj/structure/closet/walllocker/medlocker/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffel{
+	pixel_y = 6
+	},
 /obj/effect/spawner/random/dirt/often,
-/obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "dark"
@@ -8379,7 +8390,7 @@
 /obj/effect/mapping_helpers/no_lava,
 /obj/item/pickaxe,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "ZK" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
@@ -8399,7 +8410,7 @@
 "ZV" = (
 /obj/structure/lattice/catwalk/mining,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/outpost/catwalk)
+/area/lavaland/surface/outdoors/outpost/no_boulder)
 "ZZ" = (
 /obj/item/mounted/frame/intercom,
 /obj/item/stack/cable_coil{
@@ -12589,7 +12600,7 @@ lR
 lR
 oO
 oO
-oO
+VE
 TY
 dL
 Bg
@@ -15822,9 +15833,9 @@ Yr
 Yr
 Yr
 Yr
-Yr
-Yr
 IJ
+IJ
+Da
 Dh
 Vx
 tv
@@ -15978,14 +15989,14 @@ lR
 lR
 lR
 lR
-IJ
+oO
 Yr
 Yr
 oO
 oO
 oO
 oO
-IJ
+oO
 nL
 DR
 bk
@@ -16140,12 +16151,12 @@ zP
 oO
 oO
 oO
-IJ
 oO
 oO
 oO
-IJ
-IJ
+oO
+oO
+oO
 oO
 oO
 oO
@@ -16300,17 +16311,17 @@ lR
 IG
 zP
 oO
-zP
+oO
+aI
+oO
+oO
+oO
+oO
+IJ
 IJ
 IJ
 oO
 oO
-wg
-Ol
-Ol
-Ol
-Ol
-Iy
 cc
 eU
 bk
@@ -16463,16 +16474,16 @@ IG
 zP
 oO
 oO
-IJ
-IJ
+Yr
+Yr
 oO
 oO
-TY
-CM
-Xp
-Xp
-Qe
-EU
+wg
+Ol
+Ol
+Ol
+Ol
+Iy
 xs
 oO
 IJ
@@ -16626,16 +16637,16 @@ zP
 oO
 oO
 oO
-IJ
+Bv
 oO
-IJ
+oO
 TY
 vQ
-mC
+KT
 KT
 KK
-LV
-lL
+EU
+xs
 oO
 IJ
 oj
@@ -16792,11 +16803,11 @@ oO
 oO
 IJ
 TY
-vQ
+JS
 mC
 cZ
 Jp
-EU
+HF
 lE
 oO
 oj
@@ -16952,14 +16963,14 @@ oO
 oO
 oO
 oO
-oO
+IJ
 TY
-NX
-SV
+JS
+mC
 SV
 DW
 EU
-lE
+aG
 oO
 oj
 lf
@@ -17112,15 +17123,15 @@ zP
 zP
 oO
 oO
-zP
 oO
 oO
-yY
-Vy
-Vy
-Vy
-Vy
-PL
+IJ
+TY
+bR
+Ua
+Ua
+Dr
+EU
 VM
 oO
 tB
@@ -17274,15 +17285,15 @@ zP
 zP
 oO
 oO
-Yr
-Yr
-aI
 oO
-IJ
-IJ
 oO
-IJ
 oO
+yY
+Vy
+Vy
+Vy
+Vy
+PL
 VM
 oO
 tB
@@ -17309,7 +17320,7 @@ mN
 sa
 Oi
 CL
-RM
+rp
 MC
 ea
 fy
@@ -17434,16 +17445,16 @@ Tu
 Tu
 zP
 zP
-zP
-oO
-oO
-Bv
 oO
 oO
 oO
 oO
 oO
 oO
+IJ
+IJ
+oO
+IJ
 oO
 VM
 oO
@@ -17607,7 +17618,7 @@ oO
 oO
 oO
 oO
-lE
+aG
 oO
 oj
 fl
@@ -17633,7 +17644,7 @@ sa
 bT
 ld
 mp
-Bb
+CL
 wq
 pz
 Za
@@ -17768,17 +17779,17 @@ oO
 oO
 oO
 oO
-IJ
-lE
 oO
-RM
-fh
-fh
-fh
+aG
+UO
+Hz
+oj
+oj
+oj
 Gy
-fh
-fh
-fh
+oj
+oj
+oj
 Xs
 Un
 rj

--- a/code/game/area/areas/mining_areas.dm
+++ b/code/game/area/areas/mining_areas.dm
@@ -61,7 +61,7 @@
 	icon_state = "mining"
 
 /area/lavaland/surface/outdoors/outpost/no_boulder
-	name = "Mining Station"
+	name = "Внешная Площадка Шахтерского Аванпоста"
 	icon_state = "mining"
 
 /area/mine/outpost/comms

--- a/modular_ss220/maps220/code/RandomRuins/lavaland/lavaland_areas.dm
+++ b/modular_ss220/maps220/code/RandomRuins/lavaland/lavaland_areas.dm
@@ -8,3 +8,7 @@
 
 /area/ruin/powered/cheesus
 	icon_state = "yellow"
+
+/area/mine/outpost/maintenance/north
+	name = "Северные Технические Тоннели Шахтерского Аванпоста"
+	icon_state = "fmaint"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

- Дает камерам более корректные тэги;
- Передвигает пару камер для лучшего покрытия;
- Чуть перестраивает зону допплеровского радара, чтобы края платформ не падали в чазмы и не горели в лаве;
- Покрывает многие турфы, в том числе на каторге на всяк случай, маркерами no_lava. Надеюсь, поможет от спавна лавы там, которая сжигает все объекты на себе;
- Добавяет на аванпост забытый ЖПС-маяк, в отсек телекомов;
- Убирает из шкафчика КМа лишний ЖПС;
- Заменяет зону восточных техов на северные, для более подходящего имени;
- Заменяет зону внешней площадки на ее другой тип no_boulder, на который не падают метеориты. Немодульный перевод в комплекте;
- На шахтерском шаттле убрал пару ламп с окон.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Покумекай...

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Мапдифф

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Тестировал на локальном сервере:
- Камеры переименовались как надо;
- Платформы не горят/падают;
- Маяк аванпоста работает;
- Зона северных техов поставилась как надо;
- Хз как проверить зону без падения валунов. Сколько бы ни ждал на локалке, вулканических выбросов все нет и нет. А кнопки щитспавна погоды кроме шторма я не нашел. Но по коду будто бы должно работать.

## Changelog

:cl:
tweak: Перемещены несколько внешних камер шахтерского аванпоста для лучшего покрытия;
fix: Внешним камерам шахтерского аванпоста даны более корректные тэги;
fix: На шахтерский аванпост добавлен недостающий GPS-маяк;
fix: Из шкафчика квартирмейстера в офисе шахтерского аванпоста убран лишний GPS;
tweak: Убраны пара ламп с окон шахтерского шаттла;
tweak: В раздевалке шахтерского аванпоста произошла небольшая перестановка;
fix: Северные технические тоннели шахтерского аванпоста больше не называются восточными;
tweak: По внешней площадке шахтерского аванпоста больше не должны прилетать вулканические булыжники, в теории;
fix: Некоторые части внешней площадки шахтерского аванпоста больше не должны гореть в лаве или падать в пропасти.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
