### PR TITLE
[FIX] Convert gateway simple hostile animals to basic type

### DIFF
--- a/_maps/map_files220/RandomZLevels/caves.dmm
+++ b/_maps/map_files220/RandomZLevels/caves.dmm
@@ -865,9 +865,7 @@
 	},
 /area/awaymission/caves/build/reqpower_build)
 "ea" = (
-/mob/living/simple_animal/hostile/asteroid/hivelord{
-	wander = 0
-	},
+/mob/living/basic/mining/hivelord,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves)
 "ed" = (
@@ -2039,7 +2037,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/caves/build)
 "ko" = (
-/mob/living/basic/scarybat,
+/mob/living/basic/scarybat/caves,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves)
 "kp" = (
@@ -3882,9 +3880,7 @@
 /turf/simulated/floor/plasteel,
 /area/awaymission/caves/build)
 "uW" = (
-/mob/living/simple_animal/hostile/asteroid/basilisk{
-	wander = 0
-	},
+/mob/living/basic/mining/basilisk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves)
 "uX" = (
@@ -5129,9 +5125,7 @@
 /area/awaymission/caves/build/reqpower_build)
 "BU" = (
 /obj/structure/flora/rock,
-/mob/living/simple_animal/hostile/asteroid/basilisk{
-	wander = 0
-	},
+/mob/living/basic/mining/basilisk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves)
 "BW" = (
@@ -9348,9 +9342,7 @@
 /area/awaymission/caves/build/reqpower_build)
 "Zq" = (
 /obj/structure/flora/rock/pile,
-/mob/living/simple_animal/hostile/asteroid/basilisk{
-	wander = 0
-	},
+/mob/living/basic/mining/basilisk,
 /turf/simulated/floor/plating/asteroid/basalt/lava_land_surface,
 /area/awaymission/caves)
 "Zr" = (

--- a/modular_ss220/antagonists/code/guns/biogun_ammo.dm
+++ b/modular_ss220/antagonists/code/guns/biogun_ammo.dm
@@ -5,7 +5,7 @@
 	icon_state = "biocore"
 	item_state = "cottoncandy_purple"
 
-	var/mob/living/mob_spawner_type = /mob/living/simple_animal/hostile/creature
+	var/mob/living/mob_spawner_type = /mob/living/basic/creature
 	var/spawn_amount = 1	// сколько в одном ядре
 	var/is_spin = TRUE
 

--- a/modular_ss220/maps220/code/spawners.dm
+++ b/modular_ss220/maps220/code/spawners.dm
@@ -184,7 +184,7 @@
 	spawn_loot_chance = 65
 	loot = list(
 		/mob/living/basic/netherworld/faithless = 30,
-		/mob/living/simple_animal/hostile/creature = 20,
+		/mob/living/basic/creature = 20,
 		/mob/living/basic/netherworld = 10,
 		/mob/living/basic/netherworld/migo = 10,
 		/mob/living/basic/hellhound = 5,
@@ -195,7 +195,7 @@
 /mob/living/basic/netherworld/faithless/wildwest
 	faction = list("wildwest")
 
-/mob/living/simple_animal/hostile/creature/wildwest
+/mob/living/basic/creature/wildwest
 	faction = list("wildwest")
 
 /mob/living/basic/netherworld/wildwest
@@ -213,7 +213,7 @@
 /obj/effect/spawner/random/hostile_fauna/wildwest
 	loot = list(
 		/mob/living/basic/netherworld/faithless/wildwest = 30,
-		/mob/living/simple_animal/hostile/creature/wildwest = 20,
+		/mob/living/basic/creature/wildwest = 20,
 		/mob/living/basic/netherworld/wildwest = 10,
 		/mob/living/basic/netherworld/migo/wildwest = 10,
 		/mob/living/basic/hellhound/wildwest = 5,
@@ -221,13 +221,13 @@
 		/mob/living/basic/hellhound/tear/wildwest,
 	)
 
-/mob/living/simple_animal/hostile/creature/caves
-	maxbodytemp = 1500
+/mob/living/basic/creature/caves
+	maximum_survivable_temperature = 1500
 
 /obj/effect/spawner/random/hostile_fauna/caves
 	loot = list(
 		/mob/living/basic/netherworld/faithless = 30,
-		/mob/living/simple_animal/hostile/creature/caves = 20,
+		/mob/living/basic/creature/caves = 20,
 		/mob/living/basic/netherworld = 10,
 		/mob/living/basic/netherworld/migo = 10,
 		/mob/living/basic/hellhound = 5,
@@ -238,26 +238,29 @@
 /obj/effect/spawner/random/hostile_fauna/spider
 	name = "hostile spider spawner"
 	loot = list(
-		/mob/living/simple_animal/hostile/poison/giant_spider = 6,
-		/mob/living/simple_animal/hostile/poison/giant_spider/hunter = 3,
-		/mob/living/simple_animal/hostile/poison/giant_spider/nurse,
+		/mob/living/basic/giant_spider = 6,
+		/mob/living/basic/giant_spider/hunter = 3,
+		/mob/living/basic/giant_spider/nurse,
 	)
 
-/mob/living/simple_animal/hostile/poison/giant_spider/caves
-	maxbodytemp = 1500
+/mob/living/basic/giant_spider/caves
+	maximum_survivable_temperature = 1500
 
-/mob/living/simple_animal/hostile/poison/giant_spider/hunter/caves
-	maxbodytemp = 1500
+/mob/living/basic/giant_spider/hunter/caves
+	maximum_survivable_temperature = 1500
 
-/mob/living/simple_animal/hostile/poison/giant_spider/nurse/caves
-	maxbodytemp = 1500
+/mob/living/basic/giant_spider/nurse/caves
+	maximum_survivable_temperature = 1500
 
 /obj/effect/spawner/random/hostile_fauna/spider/caves
 	loot = list(
-		/mob/living/simple_animal/hostile/poison/giant_spider/caves = 6,
-		/mob/living/simple_animal/hostile/poison/giant_spider/hunter/caves = 3,
-		/mob/living/simple_animal/hostile/poison/giant_spider/nurse/caves,
+		/mob/living/basic/giant_spider/caves = 6,
+		/mob/living/basic/giant_spider/hunter/caves = 3,
+		/mob/living/basic/giant_spider/nurse/caves,
 	)
+
+/mob/living/basic/scarybat/caves
+	maximum_survivable_temperature = 1500
 
 // MARK: Misc
 /obj/effect/spawner/random/trash

--- a/tools/UpdatePaths/Scripts/ss220/2057_gateway_simple_animals.txt
+++ b/tools/UpdatePaths/Scripts/ss220/2057_gateway_simple_animals.txt
@@ -1,0 +1,2 @@
+/mob/living/simple_animal/hostile/asteroid/hivelord/@SUBTYPES : /mob/living/basic/mining/hivelord/@SUBTYPES{@OLD}
+/mob/living/simple_animal/hostile/asteroid/basilisk/@SUBTYPES : /mob/living/basic/mining/basilisk/@SUBTYPES{@OLD}


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Актуализирует перевод мобов с `/simple_animal/` на `/basic/` в наших модулях. 
Добавляем подтип космическим мышам, дабы они преждевременно не погибали от температры в гейте Caves.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Избавляемся от невидимых пацифированных мобов в гейтах.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

- [x] Пауки, хайвлорды, базилиски заспаунились. AI отрабатывал.
- [x] Космические мыши не померли от температур, пока гейт калибровался.
- [x] Поспаунил ядра воксов, проверил работоспособность.

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Furgar
fix: Исправлены невидимые мобы в гейтах Caves и Lizard.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
