### PR TITLE
Fix aobserve for mentors

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -225,8 +225,8 @@ GLOBAL_LIST_INIT(admin_verbs_mentor, list(
 	/client/proc/cmd_admin_pm_panel,	/*admin-pm list*/
 	/client/proc/cmd_admin_pm_by_key_panel,	/*admin-pm list by key*/
 	/client/proc/openMentorTicketUI,
-	/client/proc/admin_observe,  /* Allow mentors to observe as well, though they face some limitations */
-	/client/proc/admin_observe_target,
+	// /client/proc/admin_observe,  /* Allow mentors to observe as well, though they face some limitations */ // SS220 EDIT - mentors aren't allowed
+	// /client/proc/admin_observe_target, // SS220 EDIT - mentors aren't allowed
 	/client/proc/cmd_mentor_say,	/* mentor say*/
 	/client/proc/view_msays,
 	/client/proc/cmd_staff_say,
@@ -441,7 +441,7 @@ GLOBAL_LIST_INIT(view_logs_verbs, list(
 /client/proc/admin_observe()
 	set name = "Aobserve"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN|R_MOD)) // SS220 edit - removed R_MENTOR
+	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
 		return
 
 	if(isnewplayer(mob))

--- a/code/modules/mob/dead/observer/observer_base.dm
+++ b/code/modules/mob/dead/observer/observer_base.dm
@@ -196,7 +196,7 @@ Works together with spawning an observer, noted above.
 		GLOB.non_respawnable_keys[ckey] = 1
 
 	// mods, mentors, and the like will have admin observe anyway, so this is moot
-	if(((key in GLOB.antag_hud_users) || (key in GLOB.roundstart_observer_keys)) && !check_rights(R_MOD | R_ADMIN | R_MENTOR, FALSE, src))
+	if(((key in GLOB.antag_hud_users) || (key in GLOB.roundstart_observer_keys)) && !check_rights(R_MOD | R_ADMIN, FALSE, src)) // SS220 EDIT - removed R_MENTOR
 		ghost.verbs |= /mob/dead/observer/proc/do_observe
 		ghost.verbs |= /mob/dead/observer/proc/observe
 	if(user_color)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -183,7 +183,7 @@
 				if(GLOB.configuration.general.roundstart_observer_period == 0)
 					period_human_readable = "before the round started"
 				to_chat(src, "<span class='notice'>As you observed [period_human_readable], you can freely toggle antag-hud without losing respawnability, and can freely observe what other players see.</span>")
-				if(!check_rights(R_MOD | R_ADMIN | R_MENTOR, FALSE, src))
+				if(!check_rights(R_MOD | R_ADMIN, FALSE, src)) // SS220 EDIT - removed R_MENTOR
 					// admins always get aobserve
 					add_verb(observer, list(/mob/dead/observer/proc/do_observe, /mob/dead/observer/proc/observe))
 			observer.started_as_observer = 1

--- a/code/modules/tgui/modules/ghost_hud_panel.dm
+++ b/code/modules/tgui/modules/ghost_hud_panel.dm
@@ -82,7 +82,7 @@ GLOBAL_DATUM_INIT(ghost_hud_panel, /datum/ui_module/ghost_hud_panel, new)
 
 			GLOB.antag_hud_users |= ghost.ckey
 
-			if(!check_rights(R_MOD | R_ADMIN | R_MENTOR, FALSE))
+			if(!check_rights(R_MOD | R_ADMIN, FALSE)) // SS220 EDIT - removed R_MENTOR
 				// admins always get aobserve
 				add_verb(ghost, list(/mob/dead/observer/proc/do_observe, /mob/dead/observer/proc/observe))
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Легендарный Топор запретил менторам использовать админ обзёрв в неизвестном коммите при мерже апстрима, но он просчитался.. и на самом деле они могут его юзать при помощи ПКМ, ведь для обзёрва используется два верба, а запрещён всего один

ПР убирает вариант, при котором ментор может получить подобный верб при входе на сервер, взамен он будет получать обзёрв при том же раскладе событий, что его получает обычный игрок

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Людям с правами ментора будут выдаваться нормальные вербы для обзёрва как у обычных игроков, а не один сломанный верб и один рабочий

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Зашёл на локалку с правами ментора - получил нужные вербы, без администраторских

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Исправлена ошибка, позволявшая менторам использовать админ обзёрв через ПКМ и не позволявшая им использовать обычный обзёрв через ПКМ/стат панель
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
