### PR TITLE
Fix Morgue Cells Directions On Box

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -1148,6 +1148,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"agQ" = (
+/turf/simulated/floor/plasteel{
+	dir = 9;
+	icon_state = "whiteyellow"
+	},
+/area/station/medical/chemistry)
 "agS" = (
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/plasteel{
@@ -21855,7 +21861,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 8;
 	icon_state = "whiteyellow"
 	},
 /area/station/medical/chemistry)
@@ -142176,7 +142182,7 @@ sqU
 ogI
 aTT
 bCW
-bDf
+agQ
 bGi
 bJF
 bTI


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

- Ставит правильные направления трем нижним ячейкам морга в секции для лохов, не подлежащих реанимации, чтобы они не утыкались в окошки и их можно было нормально открывать;
- В химке пару тайлов перекрасил, да...

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Ячейки морга открываются, как им положено.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Не

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Зашел на локальный сервер, открыл ячейки.

## Changelog

:cl:
fix: Некоторые ячейки морга на Кибериаде больше не упираются в стены.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
