### PR TITLE
Fix Unrepairable APC In Central Hallway On Box

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -15268,7 +15268,10 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "bdD" = (
-/obj/item/radio/intercom/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -16111,7 +16114,7 @@
 /turf/simulated/floor/wood/cherry,
 /area/station/public/mrchangs)
 "bgU" = (
-/obj/machinery/status_display/directional/north,
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -16526,9 +16529,6 @@
 	},
 /area/station/ai_monitored/storage/eva)
 "biO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L13"
 	},
@@ -17644,12 +17644,6 @@
 	},
 /area/station/hallway/primary/central/north)
 "bnk" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17658,6 +17652,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "L14"
@@ -41688,8 +41685,8 @@
 /area/station/hallway/primary/central/north)
 "dix" = (
 /obj/item/kirbyplants/large,
-/obj/machinery/alarm/directional/north,
 /obj/machinery/light/directional/north,
+/obj/machinery/status_display/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -41880,11 +41877,8 @@
 /area/space/nearstation)
 "dje" = (
 /obj/item/kirbyplants/large,
-/obj/machinery/power/apc/directional/north,
 /obj/machinery/light/directional/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/item/radio/intercom/directional/north,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -56035,14 +56029,11 @@
 	},
 /area/station/maintenance/fsmaint)
 "hit" = (
-/obj/structure/sign/securearea,
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/structure/sign/securearea,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "hiw" = (
@@ -70557,9 +70548,6 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/assembly_line)
 "maF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -70568,6 +70556,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/north)
@@ -91477,13 +91471,6 @@
 /obj/effect/landmark/start/uncertain,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/aft)
-"sSa" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/ai_monitored/storage/eva)
 "sSf" = (
 /obj/structure/chair/stool{
 	dir = 1
@@ -135732,7 +135719,7 @@ biu
 fdC
 beg
 daT
-sSa
+aRw
 bnP
 wOF
 bky


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

- Переставляет некоторые настенные штуки в центральной секции коридора над мостиком так, чтобы АПЦ и воздушная сигнализация не были на одних тайлах с лампами;
- Убрал один тайл окна у хранилища ВКД для симметрии.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Были жалобы, что лампы мешают чинить сломанные штуки на стенах. Теперь жаловаться не должны.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Мапдифф

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Должно быть норм.

## Changelog

:cl:
fix: Некоторые настенные объекты в центральной части коридора над мостиком Кибериады были переставлены так, чтобы лампы не мешали починке сломанного АПЦ.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
