### PR TITLE
remove any aobserver possibility for mentors

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -441,7 +441,7 @@ GLOBAL_LIST_INIT(view_logs_verbs, list(
 /client/proc/admin_observe()
 	set name = "Aobserve"
 	set category = "Admin"
-	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR))
+	if(!check_rights(R_ADMIN|R_MOD)) // SS220 EDIT - mentors aren't allowed
 		return
 
 	if(isnewplayer(mob))
@@ -486,7 +486,7 @@ GLOBAL_LIST_INIT(view_logs_verbs, list(
 	set name = "\[Admin\] Aobserve"
 	set category = null
 
-	if(!check_rights(R_ADMIN|R_MOD|R_MENTOR, mob))
+	if(!check_rights(R_ADMIN|R_MOD, mob)) // SS220 EDIT - mentors aren't allowed
 		return
 
 	var/full_admin = check_rights(R_ADMIN|R_MOD, FALSE, mob)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Ментор тикеты также больше не позволяют использовать админ обзёрв

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Менторы не должны использовать админ обзёрв, per someone's decision

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Зашёл на локалку с двух разных кукол с правами ментора, кинул ментор тикет, попытался заобзёрвить второго игрока будучи живым - не смог. Мёртвым тоже не смог. Ничего не смог, я же ментор, а не админ

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Исправлена ошибка, позволявшая менторам использовать админ обзёрв через ментор тикет.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
