### PR TITLE
[TM] Blob balance tweaks

### DIFF
--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -2,6 +2,7 @@
 
 #include "code/access/access.dm"
 #include "code/config/config.dm"
+#include "code/events/blob.dm"
 #include "code/events/security_level.dm"
 #include "code/items/glasses.dm"
 #include "code/items/melee.dm"

--- a/modular_ss220/balance/code/events/blob.dm
+++ b/modular_ss220/balance/code/events/blob.dm
@@ -1,0 +1,4 @@
+// Increases announce time
+/datum/event/blob
+	announceWhen = 300
+	endWhen = 360


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Блоб больше не получает урон от флешек. Взамен время анонса с момента спавна блоба сокращено с 7 минут до 3 минут.

## Почему это хорошо для игры
Есть жалобы на выживаемость блоба, попробуем по-другому играть.

## Changelog

:cl: Maxiemar
tweak: Блоб больше не получает урон от флешек.
tweak: Время анонса о блобе после его спавна сокращено с 7 минут до 5 минут.
/:cl:
