### PR TITLE
Convert space simple xeno mobs to basic type

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/infected_ship.dmm
@@ -119,7 +119,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered/requires_power_space)
 "dI" = (
-/mob/living/simple_animal/hostile/alien,
+/mob/living/basic/alien,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/mineral/plastitanium,
@@ -348,7 +348,7 @@
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered/requires_power_space)
 "iS" = (
-/mob/living/simple_animal/hostile/alien,
+/mob/living/basic/alien,
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/requires_power_space)
 "jb" = (
@@ -397,7 +397,7 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/powered/requires_power_space)
 "jW" = (
-/mob/living/simple_animal/hostile/alien,
+/mob/living/basic/alien,
 /obj/effect/spawner/random/dirt/often,
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/requires_power_space)
@@ -559,7 +559,7 @@
 /turf/simulated/floor/mineral/plastitanium,
 /area/ruin/space/powered/requires_power_space)
 "nz" = (
-/mob/living/simple_animal/hostile/alien,
+/mob/living/basic/alien,
 /turf/simulated/floor/pod,
 /area/ruin/space/powered/requires_power_space)
 "nE" = (
@@ -824,7 +824,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/dirt/often,
-/mob/living/simple_animal/hostile/alien,
+/mob/living/basic/alien,
 /turf/simulated/floor/mineral/plastitanium/red,
 /area/ruin/space/powered/requires_power_space)
 "vk" = (

--- a/modular_ss220/text_to_speech/code/base_seeds/mobs/alien.dm
+++ b/modular_ss220/text_to_speech/code/base_seeds/mobs/alien.dm
@@ -12,8 +12,8 @@
 /mob/living/carbon/alien/humanoid/queen/add_tts_component()
 	AddComponent(/datum/component/tts_component, /datum/tts_seed/silero/queen)
 
-/mob/living/simple_animal/hostile/alien/add_tts_component()
+/mob/living/basic/alien/add_tts_component()
 	AddComponent(/datum/component/tts_component, /datum/tts_seed/silero/ladyvashj)
 
-/mob/living/simple_animal/hostile/alien/queen/add_tts_component()
+/mob/living/basic/alien/queen/add_tts_component()
 	AddComponent(/datum/component/tts_component, /datum/tts_seed/silero/queen)

--- a/tools/UpdatePaths/Scripts/ss220/2091_space_simple_xeno_mobs.txt
+++ b/tools/UpdatePaths/Scripts/ss220/2091_space_simple_xeno_mobs.txt
@@ -1,0 +1,1 @@
+/mob/living/simple_animal/hostile/alien/@SUBTYPES : /mob/living/basic/alien/@SUBTYPES{@OLD}


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Переводим пропущенных `alien` мобов на новый тип в нашей модульной космической руине. Актуализируем им также ТТС.
Скрип еще хотел отработать по гейту `BlackMarketPackers`, но, учитывая, что он сейчас вне ротации, на данном моменте скрип был прерван.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Исправляем невидимых animal.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование
Запустил локалку, посмотрел на мобов в руине.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: Furgar
fix: Исправлены невидимые alien мобы в космосе.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
