### PR TITLE
Revert "Reagent Microdosing Removal"

### DIFF
--- a/code/modules/reagents/chemistry/reagents_holder.dm
+++ b/code/modules/reagents/chemistry/reagents_holder.dm
@@ -360,15 +360,6 @@
 			if(R.volume >= R.overdose_threshold && !R.overdosed && R.overdose_threshold > 0)
 				R.overdosed = TRUE
 				R.overdose_start(M)
-			// SS220 EDIT START - Prevent microdosing
-			var/total_depletion_rate = R.metabolization_rate * M.metabolism_efficiency
-			if(R.volume < total_depletion_rate)
-				if(R.overdosed)
-					R.overdosed = FALSE
-					R.overdose_end(M)
-				R.holder.remove_reagent(R.id, R.volume)
-				continue
-			// SS220 EDIT END
 			if(!R.overdosed || R.allowed_overdose_process)
 				update_flags |= R.on_mob_life(M)
 			else


### PR DESCRIPTION
## Что делает этот PR

Возвращение микродозинга после #2100. Я поспешил и не выяснил, что от микродозинга зависит нормальная работа патчей и сигарет. Для ограничения абуза нужно какое-то более оптимальное решение, которого у меня пока нет.

:cl: Maxiemar
tweak: Возвращение микродозинга из-за слишком большого числа затронутых предметов.
/:cl: