### PR TITLE
Fixing EVA On Metastation

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -13238,9 +13238,6 @@
 "buj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/airlock/command,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
 "bul" = (
@@ -14074,31 +14071,12 @@
 	},
 /area/station/science/robotics/showroom)
 "bxq" = (
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/light_switch/east,
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 2;
-	pixel_y = 2
-	},
+/obj/structure/closet/secure_closet/exile,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
@@ -17395,12 +17373,12 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/command,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/multi_tile/command/glass,
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
 "bNP" = (
@@ -17564,28 +17542,31 @@
 /area/station/ai_monitored/storage/eva)
 "bOS" = (
 /obj/machinery/firealarm/directional/east,
-/obj/structure/rack{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/obj/item/tank/jetpack/carbondioxide{
-	pixel_x = 3;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = -6;
+	pixel_y = -7
+	},
+/obj/item/storage/belt/utility{
+	pixel_y = -13
+	},
+/obj/item/multitool{
+	pixel_x = 6;
+	pixel_y = -9
+	},
+/obj/item/clothing/head/welding{
+	pixel_y = -8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
@@ -17667,20 +17648,33 @@
 /area/station/maintenance/starboard)
 "bPi" = (
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/multitool,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
+/obj/structure/shelf/command,
+/obj/item/clothing/shoes/magboots{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_y = -8
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_x = 7;
+	pixel_y = -8
+	},
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_y = 9
+	},
+/obj/item/tank/jetpack/carbondioxide{
+	pixel_x = 8;
+	pixel_y = 9
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
@@ -18112,11 +18106,11 @@
 /area/station/telecomms/chamber)
 "bRu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
@@ -18201,15 +18195,12 @@
 /turf/simulated/floor/wood,
 /area/station/command/office/ntrep)
 "bRQ" = (
-/obj/machinery/atmospherics/portable/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/directional/west,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/structure/window/reinforced,
+/obj/item/radio/intercom/directional/west,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
@@ -18231,13 +18222,6 @@
 	icon_state = "darkgrey"
 	},
 /area/station/medical/morgue)
-"bRX" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/ai_monitored/storage/eva)
 "bRY" = (
 /obj/machinery/gateway{
 	dir = 4
@@ -18292,10 +18276,23 @@
 /area/station/supply/expedition/gate)
 "bSi" = (
 /obj/machinery/requests_console/directional/east,
-/obj/structure/dispenser/oxygen,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/rglass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/rods{
+	amount = 50
 	},
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
@@ -19718,7 +19715,7 @@
 /obj/machinery/door_control{
 	id = "evashutter";
 	name = "E.V.A. Storage Shutter Control";
-	req_access = list(19);
+	req_access = list(18);
 	pixel_x = -24
 	},
 /turf/simulated/floor/plasteel,
@@ -28162,41 +28159,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "cNi" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50;
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/sheet/rglass{
-	amount = 50;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
+/obj/machinery/power/apc/directional/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/portable/canister/oxygen,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkgrey"
 	},
@@ -111659,7 +111629,7 @@ bMX
 bNM
 bRS
 bRu
-bRX
+fvJ
 fvJ
 fvJ
 uyQ


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

- Додает в хранилище ВКД шкаф с биочипами изгнания;
- Устанавливает на кнопощку южных створок в хранилище ВКД доступ собственно хранилища ВКД вместо общего командного.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

- Наличие необходимых для изгнания в гейт имплантов там, где им положено быть;
- Возможность заходить в хранилище ВКД с любой из сторон, если есть соответствующий доступ.

## Изображения изменений

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

Мапдифф.

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Шкаф появился, кнопощка на доступ работает.

## Changelog

:cl:
fix: В хранилище ВКД на Цереброне добавлен недостающий шкаф с био-чипами изгнания;
fix: Кнопка контроля южных створок в хранилище ВКД на Цереброне теперь требует, собственно, доступ в хранилище ВКД, а не на мостик.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
