### PR TITLE
Tesla/Singulo power network separation from emitters

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -5739,7 +5739,7 @@
 	},
 /area/station/security/prison/cell_block/a)
 "axO" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -20363,6 +20363,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -22503,7 +22509,7 @@
 "bIK" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -24855,10 +24861,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -25642,7 +25650,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -26070,9 +26078,6 @@
 	id_tag = "eng_s_tesla_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/access_button{
 	autolink_id = "eng_s_tesla_btn_ext";
 	pixel_y = 24;
@@ -26081,6 +26086,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -27762,7 +27770,10 @@
 	},
 /area/station/hallway/primary/aft)
 "cfo" = (
-/obj/structure/cable/yellow{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -28457,7 +28468,7 @@
 	},
 /area/station/command/vault)
 "ciz" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -29021,7 +29032,7 @@
 	},
 /area/station/hallway/primary/central/se)
 "ckG" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -29470,9 +29481,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "cmg" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/door_control/shutter/north{
 	desc = "A remote control-switch for secure storage.";
 	id = "enginestorage";
@@ -29484,6 +29492,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -31340,11 +31351,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "cui" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -32100,11 +32110,12 @@
 	},
 /area/station/medical/virology)
 "cxd" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -33077,7 +33088,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -34007,14 +34018,12 @@
 /turf/simulated/wall,
 /area/station/maintenance/aft)
 "cEy" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering Singularity South Airlock";
 	dir = 8;
 	network = list("SS13","Singularity","Engineering")
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutral";
 	dir = 4
@@ -35286,7 +35295,7 @@
 /area/station/ai_monitored/storage/eva)
 "cJC" = (
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel{
@@ -35464,6 +35473,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"cKn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "cKr" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line{
@@ -36650,7 +36670,7 @@
 "cPG" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -37241,7 +37261,7 @@
 "cRz" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -38026,6 +38046,9 @@
 /area/station/engineering/equipmentstorage)
 "cTM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -38121,11 +38144,11 @@
 "cUd" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -38416,7 +38439,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -38429,7 +38452,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/white,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cVn" = (
@@ -39073,10 +39096,12 @@
 	},
 /area/station/engineering/break_room)
 "cXS" = (
-/obj/machinery/computer/security/engineering{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery/hollow,
+/obj/structure/cable/yellow,
+/obj/machinery/computer/monitor{
+	dir = 1;
+	name = "Engine Power Monitoring Computer"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "darkyellow"
@@ -39204,6 +39229,9 @@
 /area/station/maintenance/apmaint)
 "cYq" = (
 /obj/machinery/light_switch/east,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/stairs/left{
 	dir = 1;
 	color = "gray"
@@ -40128,9 +40156,6 @@
 	id_tag = "eng_s_tesla_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -40142,6 +40167,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -41074,7 +41102,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -43177,6 +43205,9 @@
 	},
 /area/station/turret_protected/ai)
 "dnG" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
@@ -43823,7 +43854,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -44235,7 +44266,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -44334,13 +44365,13 @@
 /area/station/command/office/ntrep)
 "dtp" = (
 /obj/machinery/computer/station_alert,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -44348,21 +44379,13 @@
 	},
 /area/station/engineering/control)
 "dtq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display/directional/north,
-/obj/machinery/computer/monitor{
-	name = "Engine Power Monitoring Computer"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/delivery/hollow,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/computer/security/engineering,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -44371,6 +44394,9 @@
 "dts" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -45006,14 +45032,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "dDB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/chair/stool,
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -45339,9 +45360,6 @@
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/command/office/ntrep)
 "dGn" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -45357,6 +45375,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -47292,6 +47313,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -49397,6 +49421,9 @@
 /area/station/supply/storage)
 "fbn" = (
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -49563,9 +49590,6 @@
 	},
 /area/station/engineering/hallway)
 "fdz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/airlock_controller/air_cycler{
 	ext_button_link_id = "eng_s_tesla_btn_ext";
 	ext_door_link_id = "eng_s_tesla_door_ext";
@@ -49574,6 +49598,12 @@
 	pixel_y = 25;
 	vent_link_id = "eng_s_tesla_vent";
 	req_access = list(10)
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutral";
@@ -50326,9 +50356,6 @@
 	},
 /area/station/maintenance/abandonedbar)
 "fsI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/light/directional/north,
 /obj/machinery/alarm/directional/north,
 /obj/machinery/camera{
@@ -50337,6 +50364,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -50428,10 +50458,10 @@
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
 "ftt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
@@ -52094,13 +52124,7 @@
 /area/station/medical/chemistry)
 "fWk" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -53124,11 +53148,12 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
 "gnB" = (
-/obj/structure/closet/coffin,
-/obj/structure/sign/holy{
-	pixel_y = 32
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
 /area/station/engineering/control)
 "gnG" = (
 /obj/structure/chair/sofa/corp/right,
@@ -53761,6 +53786,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -53968,7 +53996,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -54831,7 +54859,7 @@
 "gOm" = (
 /obj/structure/grille,
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -56944,6 +56972,17 @@
 	icon_state = "chapel"
 	},
 /area/station/service/chapel)
+"hxm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "hxo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -58656,6 +58695,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -59252,11 +59294,14 @@
 /turf/space,
 /area/space/nearstation)
 "ikS" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -60691,7 +60736,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -61660,12 +61705,10 @@
 /turf/simulated/wall,
 /area/station/science/xenobiology)
 "jeb" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
 /obj/structure/sign/vacuum/external{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutral";
 	dir = 8
@@ -63441,7 +63484,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "jGR" = (
+/obj/structure/closet/coffin,
 /obj/item/candle,
+/obj/structure/sign/holy{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "jGW" = (
@@ -64079,7 +64126,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -68192,6 +68239,16 @@
 /obj/structure/chair/stool,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/apmaint)
+"lno" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "lnp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -73649,6 +73706,17 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass/no_creep,
 /area/station/public/dorms)
+"ncp" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "ncs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/shelf/supply,
@@ -76147,7 +76215,7 @@
 	state = 2
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating/airless,
@@ -78099,7 +78167,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -80975,15 +81043,15 @@
 	},
 /area/station/command/office/cmo)
 "pon" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -81562,6 +81630,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -81738,6 +81809,9 @@
 "pAx" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -84143,6 +84217,9 @@
 "qrr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -84771,6 +84848,9 @@
 "qAU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -88667,11 +88747,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "rTZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutral";
 	dir = 6
@@ -88997,6 +89077,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -89127,9 +89210,6 @@
 	},
 /area/station/supply/miningdock)
 "scM" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -89789,6 +89869,9 @@
 	network = list("SS13","Singularity","Engineering")
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -91245,13 +91328,13 @@
 /turf/simulated/wall,
 /area/station/medical/patients_rooms)
 "sLe" = (
-/obj/structure/cable/yellow{
+/obj/machinery/light/small/directional/north,
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
-/obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutral";
 	dir = 5
@@ -91463,6 +91546,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"sPa" = (
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/control)
 "sPb" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "evamaint_vent";
@@ -93818,11 +93909,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -96027,11 +96118,11 @@
 	},
 /area/station/hallway/primary/central/se)
 "ulX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -97207,6 +97298,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "uES" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/stairs/right{
 	color = "gray"
 	},
@@ -98096,6 +98190,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -98814,9 +98911,6 @@
 	},
 /area/station/supply/office)
 "vgl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/airlock_controller/air_cycler{
 	ext_button_link_id = "eng_n_tesla_btn_ext";
 	ext_door_link_id = "eng_n_tesla_door_ext";
@@ -98828,6 +98922,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkneutral";
@@ -99406,7 +99503,10 @@
 "vrF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -100078,9 +100178,6 @@
 /turf/simulated/floor/carpet/black,
 /area/station/service/bar/atrium)
 "vDt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/external{
 	id_tag = "eng_n_tesla_door_ext"
 	},
@@ -100093,6 +100190,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkredfull"
 	},
@@ -104399,7 +104499,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
@@ -107878,11 +107978,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -132680,9 +132780,9 @@ mSo
 cSU
 cut
 ybL
-ftt
-cfo
-cfo
+feH
+ePY
+ePY
 fWk
 vrF
 rMZ
@@ -132694,9 +132794,9 @@ nlj
 khQ
 cyy
 scM
-cfo
-cfo
-dDB
+ePY
+ePY
+rnW
 bTa
 cSU
 cSU
@@ -132941,7 +133041,7 @@ pAx
 cTM
 cTM
 ulX
-rnW
+cKn
 cSU
 vuK
 ePY
@@ -132951,12 +133051,12 @@ diV
 cSU
 feH
 ePY
-ePY
-ePY
+sPa
+gnB
 cui
 cxd
+lno
 cSU
-gnB
 jGR
 hea
 drh
@@ -133455,7 +133555,7 @@ rna
 tdf
 cSU
 cmg
-cUz
+ncp
 cSU
 diK
 bpn
@@ -133973,13 +134073,13 @@ bzm
 dnG
 cYq
 enk
-dqE
+ftt
 uES
 dts
-ePY
+gnB
 hZN
-bzm
-nhm
+cfo
+dDB
 nBq
 dar
 dar
@@ -134225,7 +134325,7 @@ uDJ
 rac
 cXw
 cVb
-ikS
+hxm
 qAU
 dtt
 cSU
@@ -134483,7 +134583,7 @@ sfe
 uEL
 cSU
 dtp
-ePY
+dqE
 cXP
 cSU
 woK

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -24660,47 +24660,47 @@
 /area/station/engineering/control)
 "bZk" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZl" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZm" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZn" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZo" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "bZp" = (
@@ -25183,10 +25183,10 @@
 /area/station/engineering/control)
 "cbc" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cbd" = (
@@ -25197,25 +25197,28 @@
 /area/station/hallway/primary/central/ne)
 "cbe" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cbi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cbl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
@@ -25767,11 +25770,11 @@
 /area/station/engineering/control)
 "cdb" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -25793,15 +25796,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cdf" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
@@ -26264,9 +26261,6 @@
 	},
 /area/station/engineering/control)
 "ceX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -26319,6 +26313,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -26681,6 +26678,9 @@
 /area/station/engineering/control)
 "cgP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cgQ" = (
@@ -27060,22 +27060,21 @@
 	},
 /area/station/engineering/control)
 "cil" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "yellow"
+	icon_state = "yellowfull"
 	},
 /area/station/engineering/control)
 "cim" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/landmark/start/engineer,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cin" = (
@@ -27493,20 +27492,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cjN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cjO" = (
 /obj/machinery/power/apc/directional/east,
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -28150,14 +28146,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "cmT" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
@@ -28404,13 +28397,13 @@
 /area/space/nearstation)
 "coc" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -28426,7 +28419,6 @@
 /area/station/engineering/control)
 "cof" = (
 /obj/machinery/particle_accelerator/control_box,
-/obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "cog" = (
@@ -28438,10 +28430,10 @@
 /obj/machinery/power/smes{
 	charge = 2e+006
 	},
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/cable/white{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "coi" = (
@@ -29045,6 +29037,9 @@
 "cqX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -30923,9 +30918,6 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "czk" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
@@ -31281,15 +31273,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cAE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -31674,6 +31660,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cCf" = (
@@ -31695,40 +31684,28 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/control)
 "cCo" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/control)
 "cCp" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -31975,39 +31952,39 @@
 	dir = 1;
 	state = 2
 	},
-/obj/structure/cable/yellow{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cDu" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cDv" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "cDw" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -32036,12 +32013,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/portable/canister/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/structure/sign/vacuum{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cDG" = (
@@ -32058,13 +32033,19 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "cDH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "cDI" = (
@@ -42457,11 +42438,11 @@
 /area/station/medical/medbay)
 "dCx" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -45935,34 +45916,34 @@
 /area/space/nearstation)
 "dUG" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "dUH" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "dUI" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -46160,11 +46141,11 @@
 /area/station/command/bridge/checkpoint/south)
 "dVy" = (
 /obj/structure/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
@@ -46173,9 +46154,6 @@
 	id_tag = "enginen_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/access_button/directional/south{
 	autolink_id = "enginen_btn_int";
@@ -46187,6 +46165,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "dVX" = (
@@ -46601,6 +46582,20 @@
 	icon_state = "dark"
 	},
 /area/station/service/chapel)
+"dXG" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/control)
 "dXH" = (
 /obj/machinery/camera{
 	c_tag = "Port Aft Solars"
@@ -48304,7 +48299,7 @@
 	},
 /area/station/engineering/ai_transit_tube)
 "esw" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -50005,6 +50000,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"eSE" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/control)
 "eSL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -56925,7 +56928,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "hhD" = (
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating/airless,
@@ -58815,7 +58818,7 @@
 	vent_link_id = "enginen_vent";
 	req_access = list(10)
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -63669,9 +63672,6 @@
 	id_tag = "enginen_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/access_button/directional/north{
 	autolink_id = "enginen_btn_ext";
@@ -63680,6 +63680,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "jkP" = (
@@ -65860,11 +65863,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -70002,11 +70005,11 @@
 /turf/simulated/floor/grass,
 /area/station/security/permabrig)
 "llJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -75545,7 +75548,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "naq" = (
-/obj/structure/cable/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -75553,6 +75555,7 @@
 	anchored = 1;
 	state = 2
 	},
+/obj/structure/cable/white,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/control)
 "naA" = (
@@ -76259,9 +76262,6 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/mechanic)
 "nmg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/start/engineer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
@@ -77583,6 +77583,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -78920,6 +78923,9 @@
 /area/station/maintenance/old_kitchen)
 "nWg" = (
 /obj/effect/landmark/start/engineer,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
 	},
@@ -91751,6 +91757,18 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/wood/oak,
 /area/station/maintenance/starboard2)
+"rWH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
 "rWJ" = (
 /obj/item/cigbutt,
 /obj/item/cigbutt,
@@ -92586,9 +92604,6 @@
 	id_tag = "engines_door_int"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -92600,6 +92615,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "siY" = (
@@ -96634,9 +96652,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "neutralfull"
@@ -97264,7 +97279,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
@@ -99689,6 +99704,22 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"uuq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/control)
 "uuE" = (
 /obj/structure/chair{
 	dir = 4
@@ -101379,7 +101410,7 @@
 	vent_link_id = "engines_vent";
 	req_access = list(10)
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
@@ -105189,9 +105220,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -105340,9 +105368,6 @@
 	id_tag = "engines_door_ext"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/access_button/directional/north{
 	autolink_id = "engines_btn_ext";
@@ -105351,6 +105376,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/control)
 "woQ" = (
@@ -105864,9 +105892,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/medical/virology/test_room)
 "wyG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/start/engineer,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel{
@@ -105925,6 +105950,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -107341,11 +107369,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellowfull"
@@ -109197,6 +109225,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
+"xzA" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/control)
 "xzH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -134167,7 +134203,7 @@ bUp
 bWp
 cxE
 bZx
-cbo
+cil
 cdh
 ceY
 cig
@@ -134185,7 +134221,7 @@ cbn
 hfn
 czl
 cAF
-cbo
+cil
 cdh
 bXU
 tJR
@@ -134424,7 +134460,7 @@ blH
 bWq
 cxE
 bZx
-cbn
+xzA
 cdh
 ceY
 cih
@@ -134442,7 +134478,7 @@ cbn
 czr
 czl
 cAF
-cbn
+xzA
 cDD
 cEB
 wfC
@@ -134681,7 +134717,7 @@ bWI
 bOf
 cxF
 bZx
-cbo
+cil
 cdh
 ceZ
 cgM
@@ -134699,7 +134735,7 @@ cij
 cgM
 czm
 cAF
-cbo
+cil
 pdl
 bXU
 egM
@@ -134938,23 +134974,23 @@ bGz
 bGz
 bXU
 cbu
-cbn
+eSE
 cqX
 cfc
-bWK
-bWK
-bWK
-bWK
-bWK
+cjN
+cjN
+cjN
+cjN
+rWH
 nFa
 nWg
 cqX
-bWK
-bWK
-bWK
-bWK
-bWK
-bWK
+cjN
+cjN
+cjN
+cjN
+cjN
+cjN
 cCe
 cCo
 cDH
@@ -135202,7 +135238,7 @@ mMt
 jFV
 mMt
 jFV
-mMt
+dXG
 sWJ
 peH
 cfb
@@ -135214,7 +135250,7 @@ cgN
 bos
 cAG
 cCp
-cdh
+uuq
 bXU
 tuP
 drn
@@ -135456,7 +135492,7 @@ cbq
 cdk
 cfe
 boA
-cjN
+boA
 boA
 lwD
 coc
@@ -135713,7 +135749,7 @@ cbo
 cdl
 cfd
 cgO
-cil
+cgO
 qtJ
 bQr
 coh


### PR DESCRIPTION
## Что этот PR делает
Добавление отдельной сети питания эмиттеров Теслы/Сингуло от "пускового" СМЕСа

## Почему это хорошо для игры
Работа эмиттеров Теслы/Сингуло теперь зависит только от "пускового" СМЕСа.
Перегрузка сети двигателей больше не сможет обесточить визуально включенные эмиттеры из-за особенностей реализации питания устройств (приоритетность по времени постройки).

## Изображения изменений
MapDiff

## Тестирование
Локальный сервер.
Тесла была успешно запущена. Эмиттеры работают. "Пусковой" СМЕС заряжается.

## Changelog

:cl:
tweak: Эмиттеры Теслы/Сингуло отделены от сети двигателей в отдельную сеть питания через "пусковой" СМЕС (Кибериада, Керберос)
/:cl:
