### PR TITLE
Moved syndi operative away from cave and added barricade

### DIFF
--- a/_maps/map_files220/RandomZLevels/wildwest.dmm
+++ b/_maps/map_files220/RandomZLevels/wildwest.dmm
@@ -2071,6 +2071,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/awaymission/wildwest/wildwest_mines)
+"tT" = (
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/plating/ironsand,
+/area/awaymission/wildwest/wildwest_mines)
 "tW" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -14335,8 +14339,8 @@ wp
 em
 wp
 wp
-wp
-wp
+tT
+YI
 wp
 IL
 wK
@@ -14474,7 +14478,7 @@ em
 em
 wp
 wp
-YI
+wp
 wp
 em
 em


### PR DESCRIPTION
## Что этот PR делает
Хотфикс гейт-уровня Wild West

## Почему это хорошо для игры
Больше сервер не падает от миллионов гильз в одном тайле

## Изображения изменений
MapDiff

## Тестирование
Локальный сервер.
Синди оперативник больше не идёт "сражаться" с фауной.

## Changelog

:cl:
fix: Убрана "легендарная" битва синди оперативника с фауной на гейт-уровне "Wild West"
/:cl: