### PR TITLE
Fix conflict between ID cards and a guest pass

### DIFF
--- a/modular_ss220/objects/code/id_skins/_id_skins_base.dm
+++ b/modular_ss220/objects/code/id_skins/_id_skins_base.dm
@@ -23,9 +23,9 @@
 /obj/item/card/id/examine(mob/user)
 	. = ..()
 	if(skin_applied)
-		. += span_notice("Нажмите <b>Alt-Click</b> на карту, чтобы снять наклейку.")
+		. += span_notice("Нажмите <b>Ctrl-Shift-Click</b> на карту, чтобы снять наклейку.")
 
-/obj/item/card/id/AltClick(mob/living/carbon/user)
+/obj/item/card/id/CtrlShiftClick(mob/living/carbon/user)
 	if(!iscarbon(user))
 		return
 


### PR DESCRIPTION
## Что этот PR делает
Фиксит конфликт сочетания клавиш.
Скин для ID карты и гостевой пропуск использовали одинаковое сочетание клавиш для открепления от ID карты.
Сделал скину ID карты снятие на Ctrl-Shift-Click (ранее было Alt-Click), изменил IC описание действия.

## Почему это хорошо для игры
Фиксы мы любим.

## Тестирование
В разном порядке ставил/снимал на ID карту гостевой пропуск и наклейку, всё работает корректно.

## Changelog
:cl:
fix: Теперь ID карты корректно работают с гостевыми пропусками и наклейками
/:cl: