### PR TITLE
[WIP] Cerebron atmospherics remake

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -42826,6 +42826,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"hmI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "hmQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48990,10 +48994,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/north)
-"jGw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
 "jGD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -64684,6 +64684,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/service/bar)
+"pje" = (
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "pji" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes{
@@ -76293,6 +76298,19 @@
 	},
 /turf/space,
 /area/space/nearstation)
+"tFQ" = (
+/obj/structure/window/plasmareinforced{
+	dir = 1
+	},
+/obj/machinery/power/rad_collector{
+	anchored = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/supermatter)
 "tGc" = (
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
@@ -76661,11 +76679,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
-"tPn" = (
-/obj/effect/spawner/window/reinforced/plasma/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
 "tPv" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -132563,7 +132576,7 @@ lJX
 aRf
 rwh
 aTV
-kRX
+tFQ
 oLB
 kGw
 mVG
@@ -133582,16 +133595,16 @@ aaa
 aaa
 aef
 szY
-tPn
+pje
 fBW
 uDi
 pSf
-jGw
+hmI
 pSf
 sID
 aRe
 hok
-jGw
+hmI
 nME
 fFL
 vUB

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -1077,7 +1077,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -1574,7 +1574,7 @@
 "apK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -40248,7 +40248,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -41409,7 +41409,7 @@
 /area/station/maintenance/fore)
 "gKl" = (
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -54939,7 +54939,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -55868,7 +55868,7 @@
 	sort_type_txt = "8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -71000,7 +71000,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -71651,7 +71651,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -79917,7 +79917,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -81721,7 +81721,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 10;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/security/brig)

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -36848,10 +36848,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "fbR" = (
+/obj/effect/turf_decal/stripes/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "fbS" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -30453,10 +30453,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
-"cZD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/station/maintenance/starboard)
 "cZY" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/server/coldroom)
@@ -126680,7 +126676,7 @@ oNy
 bqx
 aoG
 aoG
-cZD
+aoG
 dSv
 bSU
 dfg

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -64678,8 +64678,8 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "pje" = (
-/obj/effect/spawner/window/reinforced/plasma/grilled,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/spawner/window/reinforced/plasma/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "pji" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -62794,9 +62794,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "oBh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/airlock/atmos/glass,
@@ -126682,7 +126679,7 @@ bnp
 oNy
 bqx
 aoG
-cZD
+aoG
 cZD
 dSv
 bSU

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -132,10 +132,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "acr" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/portable/pump,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4;
+	name = "Portable Air Pump Connector"
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
 /area/station/engineering/atmos)
 "acv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -246,9 +250,12 @@
 /area/station/security/permabrig)
 "adj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "adk" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -1069,7 +1076,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -1566,7 +1573,7 @@
 "apK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -1874,17 +1881,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "arE" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 0;
-	name = "Air to Mix"
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "green"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "arI" = (
 /obj/structure/lattice/catwalk,
@@ -3096,14 +3096,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "ayE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -4610,12 +4610,13 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/interrogation)
 "aHE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/turf/space,
+/area/space/nearstation)
 "aHH" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/portable/canister/oxygen,
@@ -4996,6 +4997,9 @@
 /area/station/engineering/hardsuitstorage)
 "aIT" = (
 /obj/effect/landmark/start/atmospheric,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "aIV" = (
@@ -5800,20 +5804,10 @@
 /turf/simulated/wall,
 /area/station/legal/lawoffice)
 "aMp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("tox_sensor");
-	inlet_injector_autolink_ids = list("tox_in");
-	outlet_autolink_ids = list("tox_outlet_scrubber");
-	name = "Plasma Supply Control"
-	},
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "purple"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "aMr" = (
@@ -6873,18 +6867,14 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
 "aRK" = (
-/obj/machinery/atmospherics/portable/pump,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4;
-	name = "Portable Air Pump Connector"
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port";
 	dir = 4;
 	network = list("SS13","Engineering")
 	},
+/obj/machinery/suit_storage_unit/atmos/secure,
 /turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
+	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
 "aRO" = (
@@ -8122,6 +8112,9 @@
 	},
 /area/station/turret_protected/ai)
 "aXJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "darkyellow"
@@ -10390,11 +10383,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
-"bhv" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/control)
 "bhw" = (
 /turf/simulated/wall/r_wall,
 /area/station/command/office/captain/bedroom)
@@ -11036,12 +11024,6 @@
 /turf/simulated/wall/r_wall,
 /area/station/science/genetics)
 "bjM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -11967,8 +11949,8 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/secure_storage)
 "bnU" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	name = "External to Filter"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -12644,7 +12626,9 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "bqT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "bqX" = (
@@ -12702,12 +12686,16 @@
 	},
 /area/station/aisat)
 "brg" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/meter,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/distribution)
 "brh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15728,10 +15716,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "bEK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/trinary/tvalve/digital/flipped{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -15772,9 +15757,6 @@
 /area/station/aisat/service)
 "bFh" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15975,8 +15957,11 @@
 	},
 /area/station/science/research)
 "bGE" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -16032,11 +16017,14 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/telecomms/computer)
 "bGV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/green,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "green"
+	},
 /area/station/engineering/atmos/distribution)
 "bHb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -16212,13 +16200,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
-"bHN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
 "bHO" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/woodsiding{
@@ -17294,11 +17275,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/bridge)
 "bNe" = (
-/obj/machinery/atmospherics/unary/thermomachine/freezer{
-	dir = 8
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/turf/space,
+/area/space/nearstation)
 "bNf" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
@@ -18493,9 +18475,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -18991,12 +18970,12 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
 "bVN" = (
+/obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/portable/pump,
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 4;
 	name = "Portable Air Pump Connector"
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -19795,12 +19774,9 @@
 	},
 /area/station/maintenance/asmaint)
 "bZA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "caution"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
 /area/station/engineering/atmos)
 "bZB" = (
@@ -20595,9 +20571,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
@@ -20615,9 +20588,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -20628,10 +20598,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
-"cdw" = (
-/obj/item/beacon,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "cdB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -21058,11 +21024,25 @@
 /turf/simulated/wall,
 /area/station/science/research)
 "cfy" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("tox_sensor");
+	inlet_injector_autolink_ids = list("tox_in");
+	outlet_autolink_ids = list("tox_outlet_scrubber");
+	name = "Plasma Supply Control"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "purple"
+	},
+/area/station/engineering/atmos)
 "cfz" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -21136,11 +21116,8 @@
 /area/station/science/robotics/showroom)
 "cfK" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -21152,7 +21129,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/atmos,
@@ -21449,7 +21425,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -21471,9 +21446,6 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=13.3-Engineering-Central";
 	location = "13.2-Tcommstore"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
@@ -21754,9 +21726,6 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -21796,7 +21765,6 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21846,7 +21814,6 @@
 	},
 /area/station/command/office/ce)
 "ciH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -22648,9 +22615,11 @@
 /area/space/nearstation)
 "cmL" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/unary/outlet_injector/on{
+	dir = 8
+	},
 /turf/space,
-/area/space/nearstation)
+/area/station/engineering/atmos)
 "cmM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -22658,13 +22627,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
-"cmN" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
-/turf/space,
-/area/space/nearstation)
 "cmO" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -22691,14 +22653,11 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/atmos)
 "cmR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
+/area/station/engineering/atmos)
 "cmX" = (
 /turf/simulated/wall,
 /area/station/medical/exam_room)
@@ -23773,8 +23732,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "csp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/trinary/tvalve/digital{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -31630,13 +31589,6 @@
 	icon_state = "brown"
 	},
 /area/station/supply/lobby)
-"dhW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "dhZ" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -31766,13 +31718,11 @@
 	},
 /area/station/aisat)
 "dkG" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/machinery/atmospherics/meter{
-	autolink_id = "dloop_atm_meter";
-	name = "Distribution Loop"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos/control)
 "dkM" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
@@ -31870,9 +31820,6 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore/east)
 "dmN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellowcorners"
 	},
@@ -33255,11 +33202,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "dRt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6
+/obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "dRN" = (
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/plasteel/dark,
@@ -33565,6 +33513,9 @@
 "dWq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "dWN" = (
@@ -33674,10 +33625,10 @@
 /area/station/maintenance/disposal)
 "dYi" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "dYn" = (
@@ -34487,7 +34438,6 @@
 /turf/simulated/floor/wood,
 /area/station/public/vacant_office)
 "emS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -34585,13 +34535,6 @@
 	icon_state = "white"
 	},
 /area/station/science/research)
-"epn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "epF" = (
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/light/directional/east,
@@ -34976,9 +34919,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -35198,11 +35138,13 @@
 	},
 /area/station/medical/virology)
 "exZ" = (
-/obj/machinery/suit_storage_unit/atmos/secure,
 /obj/machinery/light/directional/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/important/directional/north,
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "eyo" = (
 /obj/structure/rack,
@@ -35321,13 +35263,13 @@
 	},
 /area/station/engineering/break_room)
 "ezp" = (
-/obj/structure/closet/fireaxecabinet{
-	pixel_y = 32
+/obj/effect/turf_decal/delivery/red/hollow,
+/obj/machinery/shower/directional/east{
+	name = "emergency shower";
+	dir = 1
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkyellow"
-	},
+/obj/structure/curtain/open/shower/engineering,
+/turf/simulated/floor/noslip,
 /area/station/engineering/atmos/control)
 "ezq" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -35852,15 +35794,6 @@
 	icon_state = "brown"
 	},
 /area/station/supply/storage)
-"eJh" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	name = "Waste In"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "eJG" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
@@ -36287,8 +36220,8 @@
 	},
 /area/station/science/toxins/mixing)
 "eSE" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/trinary/mixer{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -36800,7 +36733,6 @@
 /area/station/engineering/break_room)
 "fbq" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -36808,6 +36740,7 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "fbr" = (
@@ -37464,15 +37397,14 @@
 	},
 /area/station/maintenance/fsmaint)
 "fmo" = (
-/obj/machinery/alarm/directional/north,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "fmB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37698,14 +37630,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "frC" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 4
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("waste_sensor");
+	inlet_injector_autolink_ids = list("waste_in");
+	outlet_autolink_ids = list("waste_outlet_scrubber");
+	name = "Gas Mix Tank Control"
 	},
-/obj/machinery/atmospherics/meter,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "green"
+	},
 /area/station/engineering/atmos/distribution)
 "frX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -39065,9 +39003,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -39087,6 +39022,9 @@
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -39216,7 +39154,7 @@
 	},
 /area/station/legal/lawoffice)
 "fTF" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
+/obj/machinery/atmospherics/trinary/tvalve/digital,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "fTT" = (
@@ -39249,7 +39187,6 @@
 /obj/structure/chair/office/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -40113,12 +40050,7 @@
 	},
 /area/station/science/break_room)
 "giA" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "gjc" = (
@@ -40215,15 +40147,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "glf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	autolink_sensors = list("o2_sensor");
+	inlet_injector_autolink_ids = list("o2_in");
+	outlet_autolink_ids = list("o2_outlet_scrubber");
+	name = "Oxygen Supply Control"
 	},
-/area/station/engineering/atmos/distribution)
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "blue"
+	},
+/area/station/engineering/atmos)
 "glh" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -40284,7 +40222,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -40783,12 +40721,6 @@
 	},
 /turf/simulated/floor/greengrid,
 /area/station/science/robotics/chargebay)
-"gyK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos/control)
 "gyN" = (
 /obj/machinery/economy/vending/coffee,
 /obj/machinery/camera{
@@ -41451,7 +41383,7 @@
 /area/station/maintenance/fore)
 "gKl" = (
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -41642,7 +41574,6 @@
 	},
 /area/station/security/brig)
 "gNA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -41812,7 +41743,7 @@
 	anchored = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plating,
+/turf/space,
 /area/station/engineering/atmos/control)
 "gRu" = (
 /mob/living/simple_animal/mouse/brown/tom,
@@ -42379,10 +42310,13 @@
 	},
 /area/station/engineering/break_room)
 "hbU" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Fuel Pipe to Filter"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "hci" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -43013,7 +42947,14 @@
 	name = "Gas filter (CO2 tank)";
 	on = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "black"
+	},
 /area/station/engineering/atmos)
 "hpp" = (
 /obj/machinery/light/directional/south,
@@ -43047,7 +42988,6 @@
 	},
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
 "hqc" = (
@@ -43616,9 +43556,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "hCg" = (
@@ -43746,12 +43683,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "hEA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -44049,10 +43986,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/armory/secure)
 "hKM" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/alarm/directional/north,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "caution"
 	},
-/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "hKO" = (
 /obj/machinery/disposal,
@@ -44205,8 +44143,9 @@
 	},
 /area/station/hallway/supply/aft)
 "hNv" = (
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "hNy" = (
@@ -44548,7 +44487,6 @@
 	},
 /area/station/security/permabrig)
 "hTD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "hTM" = (
@@ -44672,13 +44610,6 @@
 	},
 /area/station/engineering/equipmentstorage)
 "hWE" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("co2_sensor");
-	inlet_injector_autolink_ids = list("co2_in");
-	outlet_autolink_ids = list("co2_outlet_scrubber");
-	name = "Carbon Dioxide Supply Control"
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -44920,11 +44851,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "ibh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "arrival"
+	},
 /area/station/engineering/atmos)
 "ibj" = (
 /obj/machinery/light/small/directional/north,
@@ -45123,8 +45061,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "ieP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/turf/simulated/wall/r_wall,
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "ieT" = (
 /obj/structure/disposalpipe/segment,
@@ -45492,14 +45433,19 @@
 	},
 /area/station/maintenance/asmaint)
 "ims" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "N2O to Pure"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
+	dir = 5;
+	icon_state = "escape"
 	},
 /area/station/engineering/atmos)
 "imC" = (
@@ -45627,12 +45573,8 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "iqd" = (
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
@@ -45666,12 +45608,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
 "iqE" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Mix to Filter"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "arrival"
+	},
+/area/station/engineering/atmos)
 "iqP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -45945,17 +45896,12 @@
 /turf/simulated/floor/carpet/purple,
 /area/station/service/library)
 "iuU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/turf/space,
+/area/space/nearstation)
 "iuW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46308,16 +46254,6 @@
 /obj/item/clothing/head/welding,
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
-"iBc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
 "iBq" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
@@ -46725,9 +46661,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "iHO" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/beacon,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/break_room)
 "iHW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46897,15 +46833,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "iKZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/purple{
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("co2_sensor");
+	inlet_injector_autolink_ids = list("co2_in");
+	outlet_autolink_ids = list("co2_outlet_scrubber");
+	name = "Carbon Dioxide Supply Control"
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "black"
 	},
-/area/station/hallway/primary/starboard/east)
+/area/station/engineering/atmos)
 "iLm" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -46916,17 +46859,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Fore-Starboard";
 	dir = 9;
 	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "purple"
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "iLI" = (
@@ -47101,12 +47041,6 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
@@ -47831,10 +47765,9 @@
 /turf/simulated/floor/grass/no_creep,
 /area/station/maintenance/medmaint)
 "jgH" = (
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8;
-	name = "Port to Turbine"
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -48597,15 +48530,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/bridge)
-"jAf" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
 "jAh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48749,14 +48673,14 @@
 	},
 /area/station/supply/expedition)
 "jCT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -50166,13 +50090,19 @@
 	},
 /area/station/supply/storage)
 "jVQ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	autolink_sensors = list("air_sensor");
+	inlet_injector_autolink_ids = list("air_in");
+	outlet_autolink_ids = list("air_outlet_scrubber");
+	name = "Air Supply Control"
+	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
+	icon_state = "arrival"
 	},
 /area/station/engineering/atmos)
 "jWg" = (
@@ -50302,8 +50232,7 @@
 "jYj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "arrival"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "jYm" = (
@@ -50619,13 +50548,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "kdZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
@@ -50682,9 +50612,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -51373,13 +51300,22 @@
 	},
 /area/station/science/xenobiology)
 "kto" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("n2o_sensor");
+	inlet_injector_autolink_ids = list("n2o_in");
+	outlet_autolink_ids = list("n2o_outlet_scrubber");
+	name = "Nitrous Oxide Supply Control"
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/space,
-/area/space/nearstation)
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "escape"
+	},
+/area/station/engineering/atmos)
 "ktD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51609,8 +51545,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "escape"
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "kzx" = (
@@ -51922,14 +51858,6 @@
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft2)
-"kEy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos/control)
 "kEz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52129,12 +52057,6 @@
 /area/station/aisat)
 "kIP" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -52456,15 +52378,8 @@
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
 "kOd" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 1;
-	autolink_sensors = list("air_sensor");
-	inlet_injector_autolink_ids = list("air_in");
-	outlet_autolink_ids = list("air_outlet_scrubber");
-	name = "Air Supply Control"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "kOe" = (
@@ -52552,13 +52467,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
-"kPp" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Mix to Distro"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
 "kPK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53058,14 +52966,6 @@
 	icon_state = "cult"
 	},
 /area/station/legal/magistrate)
-"kYQ" = (
-/obj/effect/turf_decal/stripes/end,
-/obj/machinery/power/apc/important/directional/north,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
 "kYX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -53887,12 +53787,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/prison/cell_block/a)
 "lmJ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "lmP" = (
@@ -54293,10 +54191,10 @@
 	},
 /area/station/security/permabrig)
 "ltm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "ltB" = (
@@ -54573,14 +54471,8 @@
 /area/station/aisat)
 "lCE" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -54718,11 +54610,9 @@
 	},
 /area/station/supply/miningdock)
 "lEZ" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Mix to Engine"
+/obj/machinery/atmospherics/trinary/tvalve/digital/flipped{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "lFm" = (
@@ -54991,7 +54881,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -55323,12 +55213,12 @@
 /area/station/maintenance/starboard2)
 "lPv" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
-	},
 /obj/machinery/door/poddoor/preopen{
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
@@ -55486,12 +55376,9 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "lSg" = (
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Oxygen Outlet Valve"
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "blue"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "lSh" = (
@@ -55514,18 +55401,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "lSy" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	name = "Oxygen Outlet Valve"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "lSG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55622,10 +55504,10 @@
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "lVr" = (
 /obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "lVy" = (
@@ -55635,7 +55517,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/belt/utility,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/item/radio{
 	pixel_x = 7;
 	pixel_y = 4
@@ -55794,10 +55675,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
 "lZz" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -55931,7 +55812,7 @@
 	sort_type_txt = "8"
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -56016,15 +55897,8 @@
 /area/station/medical/morgue)
 "mcs" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 1;
-	autolink_sensors = list("o2_sensor");
-	inlet_injector_autolink_ids = list("o2_in");
-	outlet_autolink_ids = list("o2_outlet_scrubber");
-	name = "Oxygen Supply Control"
-	},
 /turf/simulated/floor/plasteel{
-	icon_state = "blue"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "mcw" = (
@@ -56343,13 +56217,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/lockerroom)
-"mhW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
-	},
-/area/station/engineering/atmos)
 "mic" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/classic/reversed{
@@ -56443,7 +56310,8 @@
 	},
 /area/station/security/armory)
 "mjX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/atmospheric,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "mkb" = (
@@ -56615,16 +56483,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"mmD" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
 "mmK" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_x = -32
@@ -57178,20 +57036,17 @@
 /turf/simulated/floor/grass/no_creep,
 /area/station/science/research)
 "mzf" = (
-/obj/structure/window/plasmareinforced{
-	dir = 1
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/power/rad_collector{
-	anchored = 1
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/supermatter)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/distribution)
 "mzF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57270,15 +57125,12 @@
 /turf/space,
 /area/space/nearstation)
 "mAZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/binary/valve/digital{
-	color = "";
-	dir = 4;
-	name = "Gas Mix Inlet Valve"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "green"
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos/distribution)
 "mBb" = (
@@ -57508,13 +57360,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "mEu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "caution"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "mEA" = (
 /obj/structure/table,
@@ -57575,16 +57425,17 @@
 "mFU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/atmos/control)
 "mGk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/trinary/mixer{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
-/area/station/hallway/primary/starboard/east)
+/area/station/engineering/atmos)
 "mGK" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/simulated/floor/plasteel{
@@ -57613,8 +57464,10 @@
 	},
 /area/station/science/lobby)
 "mHs" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "mHF" = (
@@ -58021,9 +57874,6 @@
 	},
 /area/station/service/bar)
 "mOQ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -58551,10 +58401,10 @@
 	},
 /area/station/medical/break_room)
 "mXQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "mYa" = (
@@ -58891,9 +58741,6 @@
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
 "ncA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -59100,10 +58947,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
 "nfk" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 1;
-	name = "Air to External"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
@@ -59684,13 +59531,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "npx" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/station/engineering/atmos)
 "npB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -59736,6 +59590,9 @@
 "nqJ" = (
 /obj/machinery/light/directional/east,
 /obj/structure/reagent_dispensers/watertank/firetank,
+/obj/structure/closet/fireaxecabinet{
+	pixel_y = 32
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "darkyellow"
@@ -59857,10 +59714,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "nuo" = (
-/obj/machinery/economy/vending/atmosdrobe,
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/portable/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4;
+	name = "Portable Scrubber Connector"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "dark"
+	icon_state = "darkpurplefull"
 	},
 /area/station/engineering/atmos)
 "nup" = (
@@ -60117,9 +59978,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "nyM" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -60153,9 +60016,6 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -60208,18 +60068,10 @@
 	},
 /area/station/engineering/control)
 "nzX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -60263,10 +60115,12 @@
 	},
 /area/station/maintenance/aft2)
 "nBp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "nBF" = (
 /obj/structure/disposalpipe/segment,
@@ -60800,13 +60654,13 @@
 	},
 /area/station/engineering/atmos/distribution)
 "nMx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/space,
-/area/space/nearstation)
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos/control)
 "nMC" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/secure_storage)
@@ -62061,13 +61915,12 @@
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
 "oje" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/turf/space,
+/area/space/nearstation)
 "oji" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -62364,18 +62217,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
-"oqp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "oqG" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -62584,8 +62425,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "escape"
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "ova" = (
@@ -62763,9 +62604,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "ozJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 10
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "oAs" = (
@@ -62811,6 +62649,9 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -62905,13 +62746,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/break_room)
 "oCC" = (
-/obj/machinery/atmospherics/binary/volume_pump/on{
-	dir = 8;
-	name = "Mix to Filter"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "oCU" = (
@@ -63392,9 +63227,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -63414,8 +63246,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
 "oNd" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "oNg" = (
@@ -63652,10 +63484,7 @@
 /area/station/service/library)
 "oPO" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8;
-	name = "Distro to Waste"
-	},
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -64471,11 +64300,20 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "peo" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "blue"
+	},
 /area/station/engineering/atmos)
 "pep" = (
 /obj/effect/decal/cleanable/dirt,
@@ -64538,11 +64376,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
 "pfp" = (
-/obj/machinery/shower/directional/east{
-	name = "emergency shower"
+/obj/machinery/economy/vending/atmosdrobe,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "darkyellow"
 	},
-/obj/effect/turf_decal/delivery/red/hollow,
-/turf/simulated/floor/noslip,
 /area/station/engineering/atmos/control)
 "pfH" = (
 /obj/machinery/door/airlock/engineering/glass,
@@ -64632,13 +64470,11 @@
 	},
 /area/station/engineering/control)
 "pig" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "cautioncorner"
+/obj/machinery/atmospherics/trinary/mixer{
+	dir = 4
 	},
-/area/station/hallway/primary/starboard/east)
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "pii" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -65178,9 +65014,10 @@
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "ptX" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "pue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65907,7 +65744,14 @@
 	name = "Gas filter (N2 tank)";
 	on = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/station/engineering/atmos)
 "pJt" = (
 /obj/machinery/door/airlock,
@@ -66320,15 +66164,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medmaint)
-"pRI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "arrival"
-	},
-/area/station/engineering/atmos)
 "pRL" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard Corner";
@@ -66789,7 +66624,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/controlroom)
 "pYs" = (
@@ -67653,23 +67487,6 @@
 /obj/machinery/requests_console/directional/west,
 /turf/simulated/floor/wood,
 /area/station/service/library)
-"qqk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 10
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "cautioncorner"
-	},
-/area/station/hallway/primary/starboard/east)
-"qqC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
 "qqM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -68865,19 +68682,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"qNJ" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/meter{
-	autolink_id = "wloop_atm_meter";
-	name = "Waste Loop"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 9;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "qNN" = (
 /obj/structure/cable/cyan{
 	icon_state = "1-10"
@@ -69298,18 +69102,6 @@
 /mob/living/basic/chicken/clucky,
 /turf/simulated/floor/grass,
 /area/station/service/hydroponics)
-"qUA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "purple"
-	},
-/area/station/engineering/atmos)
 "qUX" = (
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -69442,15 +69234,11 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
 "qXK" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 1;
-	autolink_sensors = list("n2_sensor");
-	inlet_injector_autolink_ids = list("n2_in");
-	outlet_autolink_ids = list("n2_outlet_scrubber");
-	name = "Nitrogen Supply Control"
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	name = "Nitrogen Outlet Valve"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "qXW" = (
@@ -69559,9 +69347,6 @@
 /obj/item/tank/internals/emergency_oxygen{
 	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkbluecorners"
@@ -69594,6 +69379,7 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "rak" = (
@@ -70919,12 +70705,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
 "rAp" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "cautioncorner"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "rAu" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/checkpoint/south)
@@ -70967,9 +70752,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -70980,7 +70762,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -70999,7 +70781,6 @@
 /area/station/maintenance/port)
 "rCq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -71313,7 +71094,6 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -71384,9 +71164,6 @@
 /turf/simulated/floor/wood/fancy,
 /area/station/hallway/secondary/entry/lounge)
 "rJR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "darkyellowcorners"
@@ -71636,7 +71413,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -72156,9 +71933,6 @@
 	},
 /area/station/science/toxins/launch)
 "rXa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "rXf" = (
@@ -72864,12 +72638,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
-"snf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "sns" = (
 /obj/machinery/light/directional/west,
 /turf/simulated/floor/plasteel{
@@ -73582,8 +73350,7 @@
 "sEI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "sEL" = (
@@ -74111,24 +73878,6 @@
 	icon_state = "white"
 	},
 /area/station/science/xenobiology)
-"sNb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
 "sNi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -74157,9 +73906,6 @@
 /area/station/service/kitchen)
 "sNA" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
@@ -74194,10 +73940,6 @@
 "sOw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
-	},
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -74276,15 +74018,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/testrange)
 "sPY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "sQg" = (
@@ -74837,7 +74571,14 @@
 	name = "Gas filter (O2 tank)";
 	on = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 10;
+	icon_state = "blue"
+	},
 /area/station/engineering/atmos)
 "tbp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -74961,8 +74702,6 @@
 	},
 /area/station/command/bridge)
 "tdA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "tdI" = (
@@ -75393,16 +75132,6 @@
 /obj/effect/mapping_helpers/turfs/damage,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
-"tnr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
 "tnu" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/stripes/corner{
@@ -76154,14 +75883,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "tCE" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -76740,19 +76463,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"tQS" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("n2o_sensor");
-	inlet_injector_autolink_ids = list("n2o_in");
-	outlet_autolink_ids = list("n2o_outlet_scrubber");
-	name = "Nitrous Oxide Supply Control"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "escape"
-	},
-/area/station/engineering/atmos)
 "tRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77100,17 +76810,12 @@
 	},
 /area/station/hallway/primary/central/south)
 "tZG" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("waste_sensor");
-	inlet_injector_autolink_ids = list("waste_in");
-	outlet_autolink_ids = list("waste_outlet_scrubber");
-	name = "Gas Mix Tank Control"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "green"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos/distribution)
 "tZO" = (
@@ -77146,12 +76851,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandoned_garden)
-"uaJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "uaO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -77289,7 +76988,14 @@
 	name = "Gas filter (N2O tank)";
 	on = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "escape"
+	},
 /area/station/engineering/atmos)
 "ucO" = (
 /obj/machinery/light/small/directional/west,
@@ -78274,9 +77980,8 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "uxy" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 0;
-	name = "Pure to Ports"
+/obj/machinery/atmospherics/trinary/tvalve/digital{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -78307,7 +78012,17 @@
 	name = "Gas filter (Toxins tank)";
 	on = 1
 	},
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "purple"
+	},
 /area/station/engineering/atmos)
 "uxY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78774,9 +78489,6 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 5
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -79234,22 +78946,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/supply/warehouse)
-"uQj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
 "uQm" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/xenobiology)
@@ -79388,14 +79084,6 @@
 	icon_state = "white"
 	},
 /area/station/science/research)
-"uTp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "uTq" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/economy/vending/clothing,
@@ -79585,9 +79273,6 @@
 	},
 /area/station/hallway/secondary/entry/east)
 "uWK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
@@ -79917,7 +79602,6 @@
 /obj/effect/turf_decal/delivery/partial{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "caution"
@@ -79939,7 +79623,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
@@ -80238,10 +79922,9 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "vib" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "vih" = (
@@ -80295,12 +79978,23 @@
 	},
 /area/station/engineering/atmos/control)
 "vjC" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Plasma to Pure"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "purple"
+	},
 /area/station/engineering/atmos)
 "vjK" = (
 /obj/structure/chair/stool{
@@ -80562,12 +80256,20 @@
 	},
 /area/station/service/chapel)
 "vnQ" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "CO2 to Pure"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "black"
+	},
 /area/station/engineering/atmos)
 "vnT" = (
 /obj/machinery/hydroponics/soil,
@@ -81726,7 +81428,7 @@
 	dir = 2
 	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 10;
 	icon_state = "black"
 	},
 /area/station/security/brig)
@@ -81864,12 +81566,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
-"vPa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
 "vPk" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo";
@@ -82276,8 +81972,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "vYQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/wall/r_wall,
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "vZh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -83061,9 +82760,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
 "wrW" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "wrX" = (
@@ -83229,16 +82926,14 @@
 /turf/simulated/floor/plating,
 /area/station/supply/qm)
 "wul" = (
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Mixed Air Outlet Valve";
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Aft-Starboard";
 	dir = 1;
 	network = list("SS13","Engineering")
 	},
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "wum" = (
 /obj/effect/decal/cleanable/dirt,
@@ -83318,9 +83013,6 @@
 "wvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -83726,15 +83418,9 @@
 	},
 /area/station/medical/medbay)
 "wCp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "wDM" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -84110,14 +83796,6 @@
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
-"wKt" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
 "wKE" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -84383,9 +84061,6 @@
 "wQo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -85320,11 +84995,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "xfG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/station/engineering/controlroom)
+/area/station/engineering/atmos)
 "xgb" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -85997,9 +85672,6 @@
 	},
 /area/station/science/toxins/mixing)
 "xrD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 10
-	},
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 6;
@@ -86127,12 +85799,8 @@
 	},
 /area/station/security/checkpoint/south)
 "xtL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/pump{
-	dir = 1;
-	name = "O2 to Pure"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -86144,7 +85812,9 @@
 	},
 /area/station/supply/storage)
 "xux" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "cautioncorner"
@@ -86647,11 +86317,6 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/aft/south)
-"xDJ" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/control)
 "xEi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -86969,7 +86634,6 @@
 /area/station/hallway/supply/port)
 "xLa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/purple,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -87258,9 +86922,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "xPR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/purple{
-	dir = 5
-	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -87369,11 +87030,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "xTV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -87414,7 +87071,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "caution"
+	icon_state = "cautioncorner"
 	},
 /area/station/engineering/atmos)
 "xVR" = (
@@ -88160,13 +87817,6 @@
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/grass/no_creep,
 /area/station/medical/virology)
-"yif" = (
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "yih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -88230,11 +87880,19 @@
 	},
 /area/station/security/permabrig)
 "ykK" = (
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Nitrogen Outlet Valve"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	autolink_sensors = list("n2_sensor");
+	inlet_injector_autolink_ids = list("n2_in");
+	outlet_autolink_ids = list("n2_outlet_scrubber");
+	name = "Nitrogen Supply Control"
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
-	dir = 6;
 	icon_state = "red"
 	},
 /area/station/engineering/atmos)
@@ -128212,16 +127870,16 @@ bjH
 bam
 sft
 bsY
-mGk
-bHN
-bHN
-cmR
+hTD
+hTD
+hTD
+hTD
 chi
 hTD
 gNA
 gRq
 rJa
-gyK
+fQi
 fUl
 rJR
 mPo
@@ -128235,7 +127893,7 @@ fTV
 nXk
 aoG
 aAL
-cfy
+asJ
 lXW
 wFC
 cgW
@@ -128470,17 +128128,17 @@ bam
 ghF
 mPq
 xhF
-qqk
-iKZ
+xhF
+xhF
 xLa
-pig
-pig
+xhF
+xhF
 vbB
 hpR
 mFU
 rCq
 uIq
-kEy
+fQi
 gDW
 gDW
 pZe
@@ -128737,7 +128395,7 @@ ceF
 oJW
 ciE
 bFh
-kEy
+fQi
 bow
 bow
 ibu
@@ -129006,7 +128664,7 @@ ovR
 arr
 axh
 fcB
-iuU
+mOQ
 kgV
 bCU
 vPx
@@ -129263,7 +128921,7 @@ axh
 axh
 axh
 blr
-iuU
+mOQ
 fWW
 fWW
 fWW
@@ -129516,14 +129174,14 @@ biJ
 biJ
 aRK
 bVN
-aXz
+acr
 aXz
 nuo
 cDi
 mOQ
-etB
-hbU
-ikK
+fWW
+fWW
+fWW
 fhu
 bCM
 aaa
@@ -129757,7 +129415,7 @@ wEx
 sQg
 lZc
 faQ
-bpn
+iHO
 bRi
 nHB
 ndp
@@ -129766,20 +129424,20 @@ ceF
 chR
 kfn
 nyT
-xDJ
+bCu
 nfk
-jVQ
+eQo
 cka
+eQo
 eQo
 fMZ
 fLw
 pqK
 xXd
-jAf
 xux
 hBZ
 cnH
-cnH
+gTx
 mHs
 hTg
 bCM
@@ -130023,20 +129681,20 @@ kSA
 bil
 euG
 lVy
-bhv
+xaE
 bnU
 vib
-gTx
+cnH
 rAE
+cnH
 cnH
 cnH
 qTN
 fWW
 ptm
-fWW
 tCE
-vPa
-aIT
+fWW
+xfG
 pJi
 sEI
 vrO
@@ -130280,24 +129938,24 @@ ezp
 bHb
 bGK
 rao
-ceF
-kYQ
-sPY
-oje
+xaE
+bnU
+ptm
+skc
 skc
 skc
 mmB
 skc
 aAG
-uTp
+skc
 dWq
 ayE
 mjX
-uaJ
-rTX
+ltm
+ykK
 qXK
-kxI
-abq
+fmo
+bNe
 phu
 aeZ
 cqL
@@ -130537,24 +130195,24 @@ oCX
 oGB
 mlO
 nAM
-bCu
-uQj
-oqp
-ptm
-fWW
-fWW
-fWW
-fWW
-fWW
+xaE
+bnU
 lfX
+gTx
 ikK
+iil
+fWW
+fWW
+fWW
+vib
+sPY
 mXQ
-jDD
-ltm
-upE
-ykK
+fWW
+etE
+npx
+lSg
 ngh
-cmL
+iuU
 cTB
 ooX
 cqK
@@ -130790,28 +130448,28 @@ lmi
 rsq
 uxU
 bXA
-fQi
-fQi
+nMx
+dkG
 jCT
 eoD
 aLa
 rBn
-cnH
-fTF
-ikK
-iil
+ptm
+dOf
+vwt
 fWW
-fWW
-fWW
+uiY
+uiY
+uiY
 sGe
 vwt
-jgH
-kwm
-csp
-rTX
-fWW
-kxI
-abq
+xCT
+cNm
+ltm
+upE
+lSy
+fmo
+bNe
 bCM
 bCM
 bCM
@@ -131042,7 +130700,7 @@ lQJ
 hHE
 xyO
 fOv
-xfG
+ozJ
 iTB
 lho
 uxU
@@ -131052,23 +130710,23 @@ pfp
 fQQ
 pCg
 xaE
-sNb
-vPa
-dOf
-vwt
-fWW
-uiY
-uiY
-uiY
-tAd
+bnU
+ptm
 eow
+iHy
+ftm
+iHy
+aQU
+iHy
 xbw
+tAd
 kwm
-csp
+fWW
+ctt
 tbm
-mhW
+sEI
 vrO
-cmK
+aHE
 cTB
 xlS
 cqN
@@ -131303,29 +130961,29 @@ ozJ
 pYa
 xPR
 iRu
-iRu
-iRu
-iRu
 bvk
+vYQ
+iRu
+ieP
 aJb
 dYi
 nzX
-cdw
-eow
-iHy
-ftm
-iHy
-aQU
-iHy
-xbw
+qTN
 tAd
-jDD
+fWW
+fWW
+fWW
+fWW
+fWW
+fWW
+tAd
+kwm
 bqT
 csp
-rTX
+glf
 mcs
 kxI
-abq
+oje
 phu
 liL
 cqO
@@ -131559,9 +131217,9 @@ xyb
 bij
 bsC
 xrD
-ieP
-qNJ
-eJh
+iRu
+iNx
+bGE
 lZz
 bGE
 nyM
@@ -131576,13 +131234,13 @@ fWW
 fWW
 fWW
 tAd
+kwm
+pig
+wrW
 peo
-xCT
-npx
-upE
 lSg
 elQ
-cmL
+iuU
 cTB
 iKE
 cqN
@@ -131818,26 +131476,26 @@ uxU
 uxU
 iRu
 oPO
-hKM
-bNe
-iqE
+giA
+rXa
+rXa
 oCC
 kIP
 xTV
 xal
 oNd
-fWW
-fWW
-fWW
-fWW
-fWW
+wCp
+ftm
+pUY
+dRt
+pUY
 aIT
-tAd
-etE
+vnl
+kwm
 xtL
 bEK
 rTX
-fWW
+kOd
 kxI
 abq
 bCM
@@ -132073,25 +131731,25 @@ hPZ
 bly
 ari
 qZz
-vYQ
-fmo
+iRu
+ciD
 giA
-kPp
+rXa
 hNv
-iBc
+rXa
 lCE
 wQo
 pxj
 vnl
 fWW
-iil
 fWW
-fWW
-fWW
-fWW
-tAd
-epn
+gDu
+gDu
+gDu
+gDu
+kLw
 xbh
+cNm
 ltm
 ibh
 jYj
@@ -132309,7 +131967,7 @@ aTK
 aRf
 aSo
 aTV
-mzf
+kRX
 dqm
 kGw
 mVG
@@ -132331,26 +131989,26 @@ hEA
 emS
 ncA
 iRu
-yif
-rAp
-aHE
-qqC
-tnr
+nMt
+xBg
+rXa
+rXa
+rXa
 iOO
 sOw
 uxy
-iHy
-pUY
-ftm
-pUY
-brg
-pUY
-pUY
-vnl
-ctt
+fWW
 juS
-csp
-rTX
+iil
+fWW
+fWW
+fWW
+fWW
+fWW
+iil
+juS
+ctt
+jVQ
 kOd
 kxI
 abq
@@ -132588,27 +132246,27 @@ hJx
 uyN
 qkC
 iRu
-ciD
-dkG
+hKM
+iqd
 uWK
-iHO
-wCp
-mmD
+rXa
+rXa
+iOO
 cfK
 eSE
-juS
-tAd
 fWW
-gDu
-gDu
-gDu
-gDu
-kLw
-ctt
+bqT
+mGk
+cmR
 fWW
-acr
-rTX
-pRI
+bqT
+mGk
+cmR
+fWW
+jDD
+ltm
+iqE
+jYj
 ufv
 cmO
 wET
@@ -132846,24 +132504,24 @@ bQa
 fgj
 iRu
 xIt
-xBg
+iqd
 rXa
-dRt
-lSy
-wKt
+rXa
+rXa
+lCE
 xVJ
-etB
+fTF
 etB
 lEZ
 wrW
-etB
+fTF
 wmS
-etB
+lEZ
 wrW
+fTF
 etB
+mEu
 dMs
-fWW
-fWW
 rTX
 wul
 bCM
@@ -133102,27 +132760,27 @@ ybI
 jKj
 arT
 lwx
-iNx
+nMt
 iqd
 arE
 frC
 bGV
 lVr
 ims
-bRk
+kto
 ucA
-dhW
-vjC
 bRk
+vjC
+cfy
 uxV
 bRk
 vnQ
-bRk
+iKZ
 hpm
-bRk
+jgH
 bRk
 deX
-kwm
+bZA
 bCM
 abq
 abq
@@ -133359,27 +133017,27 @@ abq
 jKj
 bAd
 iRu
-nMt
+ptX
 adj
-glf
+mAZ
 tZG
 mAZ
-ptX
+iOO
 kzo
-tQS
+hWE
 ouF
-ctt
+hWE
 iLE
 aMp
-qUA
-fWW
-mEu
+ouF
 hWE
-bZA
-jDD
+kzo
+hWE
+ouF
+hbU
 nBp
-cNm
-snf
+rAp
+fWW
 bCM
 bCM
 abq
@@ -133617,15 +133275,15 @@ jKj
 arT
 iRu
 nan
-nan
+brg
 rag
-nan
+mzf
 kdZ
 lPv
 fbq
 cdJ
 gHw
-fbq
+fmo
 fbq
 cdJ
 gqq
@@ -133873,16 +133531,16 @@ pAO
 pAO
 iOr
 sMH
+abq
+abq
+bIu
 cmL
-cmL
-nMx
-cmL
-kto
-cmL
-nMx
-cmL
-kto
-cmN
+bIu
+abq
+bIu
+abq
+bMj
+abq
 bIu
 abq
 bMj

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -137,6 +137,7 @@
 	dir = 4;
 	name = "Portable Air Pump Connector"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -249,14 +250,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "adj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+/obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
 	},
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "adk" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -1881,11 +1882,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "arE" = (
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "green"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/area/station/engineering/atmos/distribution)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "red"
+	},
+/area/station/engineering/atmos)
 "arI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -3096,14 +3106,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "ayE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -3380,9 +3384,9 @@
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "aAG" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "aAH" = (
@@ -4996,11 +5000,22 @@
 	},
 /area/station/engineering/hardsuitstorage)
 "aIT" = (
-/obj/effect/landmark/start/atmospheric,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "aIV" = (
 /obj/machinery/power/apc/critical/directional/west{
@@ -5015,11 +5030,17 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/hardsuitstorage)
 "aJb" = (
-/obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/light_switch/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "aJc" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -5462,24 +5483,11 @@
 	},
 /area/station/public/toilet/lockerroom)
 "aLa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/door/airlock/atmos/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "dark"
-	},
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos/control)
 "aLc" = (
 /obj/effect/spawner/random/barrier/obstruction,
@@ -5767,11 +5775,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "aMh" = (
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/effect/turf_decal/delivery/white/hollow,
-/obj/effect/spawner/random/cobweb/left/frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "aMi" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5804,10 +5812,23 @@
 /turf/simulated/wall,
 /area/station/legal/lawoffice)
 "aMp" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("tox_sensor");
+	inlet_injector_autolink_ids = list("tox_in");
+	outlet_autolink_ids = list("tox_outlet_scrubber");
+	name = "Plasma Supply Control"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "caution"
+	icon_state = "purple"
 	},
 /area/station/engineering/atmos)
 "aMr" = (
@@ -6734,7 +6755,6 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "aRe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/turf_decal/stripes/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -6873,6 +6893,7 @@
 	network = list("SS13","Engineering")
 	},
 /obj/machinery/suit_storage_unit/atmos/secure,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7602,9 +7623,8 @@
 	},
 /area/station/engineering/engine_foyer)
 "aVi" = (
-/obj/structure/closet/secure_closet/atmos_personal,
 /turf/simulated/floor/plasteel{
-	dir = 9;
+	dir = 1;
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/atmos/control)
@@ -8072,6 +8092,7 @@
 	dir = 4;
 	name = "Portable Scrubber Connector"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkpurplefull"
 	},
@@ -8115,11 +8136,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkyellow"
-	},
-/area/station/engineering/atmos/control)
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/distribution)
 "aXK" = (
 /obj/machinery/porta_turret/ai_turret,
 /obj/machinery/computer/security/telescreen/minisat{
@@ -10260,15 +10279,13 @@
 /turf/space,
 /area/space/nearstation)
 "bgN" = (
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/portable/scrubber,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4;
-	name = "Portable Scrubber Connector"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkpurplefull"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "bgO" = (
 /obj/structure/rack,
@@ -10697,10 +10714,11 @@
 	},
 /area/station/security/checkpoint/secondary)
 "biB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
-/area/station/maintenance/turbine)
+/area/station/engineering/atmos)
 "biF" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -10715,6 +10733,7 @@
 /area/space)
 "biJ" = (
 /obj/machinery/suit_storage_unit/atmos/secure,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -11027,6 +11046,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "bjN" = (
@@ -11157,18 +11180,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
 "bkU" = (
-/obj/machinery/light/small/directional/west,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/portable/pump,
-/obj/machinery/atmospherics/unary/portables_connector{
-	name = "Portable Air Pump Connector";
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
-	},
+/obj/machinery/atmospherics/binary/volume_pump,
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "bkW" = (
 /turf/simulated/wall/r_wall,
@@ -11192,6 +11205,9 @@
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -11279,6 +11295,12 @@
 "blr" = (
 /obj/structure/closet/fireaxecabinet{
 	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -11952,6 +11974,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -12607,8 +12638,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/hallway/primary/starboard/east)
 "bqR" = (
@@ -12691,11 +12721,12 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "brh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -13035,11 +13066,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
@@ -13629,7 +13660,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "bvk" = (
-/obj/effect/spawner/window/reinforced/grilled,
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/important/directional/north,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "bvo" = (
@@ -15960,22 +15996,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
-	},
+/obj/machinery/atmospherics/binary/volume_pump,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "bGK" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -16017,15 +16048,11 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/telecomms/computer)
 "bGV" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "green"
-	},
-/area/station/engineering/atmos/distribution)
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "bHb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -17679,6 +17706,12 @@
 "bPg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/item/radio{
+	pixel_x = 7;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -18086,7 +18119,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "bRk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/trinary/mixer/flipped{
+	dir = 8;
+	name = "Mix to Turbine"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "bRl" = (
@@ -18976,6 +19012,10 @@
 	dir = 4;
 	name = "Portable Air Pump Connector"
 	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "whitebluefull"
 	},
@@ -19774,9 +19814,11 @@
 	},
 /area/station/maintenance/asmaint)
 "bZA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "bZB" = (
@@ -20596,6 +20638,9 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "cdB" = (
@@ -21024,24 +21069,11 @@
 /turf/simulated/wall,
 /area/station/science/research)
 "cfy" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("tox_sensor");
-	inlet_injector_autolink_ids = list("tox_in");
-	outlet_autolink_ids = list("tox_outlet_scrubber");
-	name = "Plasma Supply Control"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "purple"
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "cfz" = (
 /obj/structure/disposalpipe/segment/corner{
@@ -21115,13 +21147,11 @@
 /turf/simulated/floor/carpet,
 /area/station/science/robotics/showroom)
 "cfK" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	dir = 1;
-	icon_state = "caution"
+	icon_state = "cautioncorner"
 	},
 /area/station/engineering/atmos)
 "cfL" = (
@@ -21369,10 +21399,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/power/smes{
+	capacity = 9e+006;
+	charge = 10000
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -21436,6 +21469,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/structure/sign/electricshock{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
@@ -21651,12 +21687,11 @@
 	},
 /area/station/medical/reception)
 "chX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -21726,6 +21761,11 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Lockers";
+	network = list("SS13","Engineering");
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -21769,8 +21809,8 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -21792,7 +21832,12 @@
 	},
 /area/station/hallway/primary/central/se)
 "ciD" = (
-/obj/machinery/atmospherics/unary/thermomachine/heater/on,
+/obj/machinery/alarm/directional/north,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	name = "Air To Distro";
+	target_pressure = 303
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -21814,12 +21859,11 @@
 	},
 /area/station/command/office/ce)
 "ciH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "ciJ" = (
@@ -21827,8 +21871,12 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -21948,13 +21996,8 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
-/obj/item/pen{
-	pixel_y = 8
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -22034,9 +22077,8 @@
 	},
 /area/station/medical/medbay)
 "cjB" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -22122,11 +22164,17 @@
 	},
 /area/station/service/hydroponics)
 "cka" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/meter,
-/turf/simulated/floor/plasteel{
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
-	icon_state = "caution"
+	autolink_sensors = list("n2o_sensor");
+	inlet_injector_autolink_ids = list("n2o_in");
+	outlet_autolink_ids = list("n2o_outlet_scrubber");
+	name = "Nitrous Oxide Supply Control"
+	},
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "escape"
 	},
 /area/station/engineering/atmos)
 "ckb" = (
@@ -22513,12 +22561,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "cmg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/firecloset,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/cobweb/right/rare,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
+	},
+/turf/space,
+/area/space/nearstation)
 "cmi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -22910,6 +22958,14 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
@@ -23770,12 +23826,11 @@
 	},
 /area/station/service/chapel)
 "csB" = (
-/obj/structure/rack,
-/obj/item/radio{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/obj/effect/spawner/random/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "csG" = (
@@ -26106,6 +26161,12 @@
 	},
 /area/station/medical/surgery/observation)
 "cDi" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -26356,6 +26417,13 @@
 "cEC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/meter,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -30386,10 +30454,7 @@
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "cZD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/firealarm/directional/north,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/maintenance/starboard)
 "cZY" = (
 /turf/simulated/wall/r_wall,
@@ -31718,7 +31783,10 @@
 	},
 /area/station/aisat)
 "dkG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/atmos_personal,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -32520,6 +32588,12 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/south)
+"dAS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "dBe" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
@@ -32607,7 +32681,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -33080,12 +33153,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/construction)
 "dOf" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 4;
-	name = "Waste to Port"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/area/station/hallway/primary/starboard/east)
 "dOt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -33202,10 +33272,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "dRt" = (
-/obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "dRN" = (
@@ -33511,9 +33581,7 @@
 	},
 /area/station/supply/storage)
 "dWq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -33624,11 +33692,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "dYi" = (
-/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "dYn" = (
@@ -33723,6 +33791,11 @@
 	icon_state = "dark"
 	},
 /area/station/medical/medbay)
+"dZA" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "dZB" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -34136,26 +34209,8 @@
 	},
 /area/station/engineering/equipmentstorage)
 "eht" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/hacking{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/book/manual/wiki/engineering_guide{
-	pixel_x = -2;
-	pixel_y = 3
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/camera{
-	c_tag = "Engineering - Desk";
-	dir = 1;
-	network = list("SS13","Engineering")
-	},
-/obj/item/storage/firstaid/regular,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "yellow"
-	},
+/turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "ehC" = (
 /obj/structure/cable{
@@ -34520,11 +34575,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "eoD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -34907,17 +34959,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint2)
 "euG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
@@ -35263,13 +35315,10 @@
 	},
 /area/station/engineering/break_room)
 "ezp" = (
-/obj/effect/turf_decal/delivery/red/hollow,
-/obj/machinery/shower/directional/east{
-	name = "emergency shower";
-	dir = 1
+/obj/machinery/economy/vending/atmosdrobe,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
 	},
-/obj/structure/curtain/open/shower/engineering,
-/turf/simulated/floor/noslip,
 /area/station/engineering/atmos/control)
 "ezq" = (
 /obj/effect/spawner/window/reinforced/grilled,
@@ -36220,11 +36269,11 @@
 	},
 /area/station/science/toxins/mixing)
 "eSE" = (
-/obj/machinery/atmospherics/trinary/mixer{
+/obj/machinery/atmospherics/unary/thermomachine/freezer/on{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/distribution)
 "eSG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/power/apc/directional/east,
@@ -36436,11 +36485,10 @@
 	},
 /area/station/hallway/primary/central/se)
 "eVJ" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plasteel,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cautioncorner"
+	},
 /area/station/maintenance/starboard)
 "eVM" = (
 /obj/effect/turf_decal/stripes/white/line{
@@ -36854,6 +36902,7 @@
 /area/station/maintenance/fore2)
 "fcB" = (
 /obj/machinery/firealarm/directional/north,
+/obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plasteel{
 	dir = 9;
 	icon_state = "caution"
@@ -37630,21 +37679,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "frC" = (
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("waste_sensor");
-	inlet_injector_autolink_ids = list("waste_in");
-	outlet_autolink_ids = list("waste_outlet_scrubber");
-	name = "Gas Mix Tank Control"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/binary/valve/digital,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "frX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
@@ -38712,6 +38749,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -38760,6 +38800,10 @@
 "fMZ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
+	},
+/obj/machinery/atmospherics/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -39016,21 +39060,12 @@
 	},
 /area/station/engineering/atmos/control)
 "fQQ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/refill_station/nitrogen,
+/obj/structure/sign/poster/official/air1/directional/north,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkyellow"
+	icon_state = "white"
 	},
-/area/station/engineering/atmos/control)
+/area/station/hallway/primary/starboard/east)
 "fQV" = (
 /obj/effect/decal/cleanable/glass,
 /turf/simulated/floor/plating,
@@ -40050,7 +40085,7 @@
 	},
 /area/station/science/break_room)
 "giA" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "gjc" = (
@@ -40147,20 +40182,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "glf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 1;
-	autolink_sensors = list("o2_sensor");
-	inlet_injector_autolink_ids = list("o2_in");
-	outlet_autolink_ids = list("o2_outlet_scrubber");
-	name = "Oxygen Supply Control"
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	icon_state = "blue"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "glh" = (
 /obj/structure/chair/sofa/right{
@@ -41743,7 +41769,7 @@
 	anchored = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/space,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
 "gRu" = (
 /mob/living/simple_animal/mouse/brown/tom,
@@ -42310,6 +42336,7 @@
 	},
 /area/station/engineering/break_room)
 "hbU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -42656,9 +42683,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
@@ -42941,19 +42970,21 @@
 /turf/simulated/floor/plating,
 /area/station/security/prisonlockers)
 "hpm" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 1;
-	filter_type = 3;
-	name = "Gas filter (CO2 tank)";
-	on = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "black"
+	dir = 1;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "hpp" = (
@@ -43556,6 +43587,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "hCg" = (
@@ -43986,12 +44020,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/armory/secure)
 "hKM" = (
-/obj/machinery/alarm/directional/north,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	dir = 1;
+	dir = 9;
 	icon_state = "caution"
 	},
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "hKO" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -44143,9 +44179,7 @@
 	},
 /area/station/hallway/supply/aft)
 "hNv" = (
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "hNy" = (
@@ -44352,6 +44386,21 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/public/toilet/lockerroom)
+"hRI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	autolink_sensors = list("air_sensor");
+	inlet_injector_autolink_ids = list("air_in");
+	outlet_autolink_ids = list("air_outlet_scrubber");
+	name = "Air Supply Control"
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "arrival"
+	},
+/area/station/engineering/atmos)
 "hRR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -44467,8 +44516,10 @@
 	dir = 1;
 	network = list("SS13","Engineering")
 	},
-/obj/structure/closet/firecloset/full,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -44610,6 +44661,12 @@
 	},
 /area/station/engineering/equipmentstorage)
 "hWE" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Fore-Starboard";
+	dir = 9;
+	network = list("SS13","Engineering")
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -44851,19 +44908,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "ibh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "arrival"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/light/small/directional/east,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ibj" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/emcloset,
@@ -45061,11 +45112,12 @@
 /turf/simulated/floor/plating,
 /area/station/security/permabrig)
 "ieP" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
 	},
-/turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "ieT" = (
 /obj/structure/disposalpipe/segment,
@@ -45334,10 +45386,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "ikK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 5
-	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "ikU" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -45433,20 +45484,8 @@
 	},
 /area/station/maintenance/asmaint)
 "ims" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "escape"
-	},
+/obj/effect/landmark/start/atmospheric,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "imC" = (
 /turf/simulated/wall,
@@ -45573,11 +45612,14 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "iqd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "iqe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -45608,19 +45650,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
 "iqE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/trinary/filter{
+	dir = 4;
+	filter_type = 2;
+	name = "Gas filter (N2 tank)";
+	on = 1
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "arrival"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/station/engineering/atmos)
 "iqP" = (
@@ -46833,20 +46874,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "iKZ" = (
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("co2_sensor");
-	inlet_injector_autolink_ids = list("co2_in");
-	outlet_autolink_ids = list("co2_outlet_scrubber");
-	name = "Carbon Dioxide Supply Control"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "black"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "iLm" = (
@@ -46856,17 +46888,19 @@
 	},
 /area/station/science/robotics)
 "iLE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Fore-Starboard";
-	dir = 9;
-	network = list("SS13","Engineering")
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	dir = 5;
+	icon_state = "purple"
 	},
 /area/station/engineering/atmos)
 "iLI" = (
@@ -46983,12 +47017,13 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "iNx" = (
-/obj/effect/turf_decal/stripes/end,
-/obj/machinery/power/apc/important/directional/north,
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "iNH" = (
 /turf/simulated/floor/plasteel{
@@ -47329,6 +47364,12 @@
 	icon_state = "white"
 	},
 /area/station/science/xenobiology)
+"iUq" = (
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	name = "Nitrogen Outlet Valve"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "iUs" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -47765,11 +47806,15 @@
 /turf/simulated/floor/grass/no_creep,
 /area/station/maintenance/medmaint)
 "jgH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+/obj/machinery/atmospherics/binary/volume_pump{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "green"
+	},
 /area/station/engineering/atmos)
 "jgJ" = (
 /turf/simulated/floor/plasteel{
@@ -48673,13 +48718,9 @@
 	},
 /area/station/supply/expedition)
 "jCT" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
@@ -50090,21 +50131,19 @@
 	},
 /area/station/supply/storage)
 "jVQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/portable/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4;
+	name = "Portable Scrubber Connector"
 	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 1;
-	autolink_sensors = list("air_sensor");
-	inlet_injector_autolink_ids = list("air_in");
-	outlet_autolink_ids = list("air_outlet_scrubber");
-	name = "Air Supply Control"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	icon_state = "arrival"
+	icon_state = "darkpurplefull"
 	},
-/area/station/engineering/atmos)
+/area/station/maintenance/starboard)
 "jWg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50230,9 +50269,18 @@
 	},
 /area/station/security/defusal)
 "jYj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution"
+	dir = 6;
+	icon_state = "arrival"
 	},
 /area/station/engineering/atmos)
 "jYm" = (
@@ -50548,17 +50596,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "kdZ" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/obj/machinery/light/floor,
+/obj/effect/landmark/start/atmospheric,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "ken" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
@@ -51300,22 +51341,10 @@
 	},
 /area/station/science/xenobiology)
 "kto" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 8;
-	autolink_sensors = list("n2o_sensor");
-	inlet_injector_autolink_ids = list("n2o_in");
-	outlet_autolink_ids = list("n2o_outlet_scrubber");
-	name = "Nitrous Oxide Supply Control"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "escape"
-	},
-/area/station/engineering/atmos)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "ktD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51541,12 +51570,16 @@
 	},
 /area/station/hallway/primary/aft/south)
 "kzo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	dir = 5;
+	icon_state = "black"
 	},
 /area/station/engineering/atmos)
 "kzx" = (
@@ -52056,12 +52089,12 @@
 	},
 /area/station/aisat)
 "kIP" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "kIS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -52378,6 +52411,10 @@
 /turf/simulated/floor/carpet,
 /area/station/legal/courtroom)
 "kOd" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -52472,6 +52509,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/turbine)
 "kQf" = (
@@ -52583,7 +52623,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "kRZ" = (
@@ -53393,8 +53435,8 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "lfX" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 1
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -54261,9 +54303,12 @@
 /turf/simulated/floor/wood,
 /area/station/service/cafeteria)
 "lwx" = (
-/obj/effect/spawner/airlock/w_to_e,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "lwN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel{
@@ -54317,6 +54362,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/aft/south)
+"lzD" = (
+/obj/machinery/atmospherics/portable/scrubber,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4;
+	name = "Portable Scrubber Connector"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	icon_state = "darkpurplefull"
+	},
+/area/station/maintenance/starboard)
 "lzO" = (
 /obj/machinery/light/directional/east,
 /obj/structure/disposalpipe/segment,
@@ -54387,9 +54444,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
 "lAW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -54399,10 +54453,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "lAX" = (
@@ -54471,12 +54528,13 @@
 /area/station/aisat)
 "lCE" = (
 /obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "lCO" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -55212,16 +55270,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "lPv" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos)
 "lPM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -55376,9 +55427,18 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "lSg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution"
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
 "lSh" = (
@@ -55401,9 +55461,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "lSy" = (
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Oxygen Outlet Valve"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -55503,13 +55564,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "lVr" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "lVy" = (
 /obj/structure/table,
 /obj/item/t_scanner,
@@ -55675,14 +55732,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
 "lZz" = (
-/obj/item/radio/intercom/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 10
 	},
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "lZS" = (
 /obj/structure/closet/firecloset,
@@ -55896,9 +55952,19 @@
 	},
 /area/station/medical/morgue)
 "mcs" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	autolink_sensors = list("o2_sensor");
+	inlet_injector_autolink_ids = list("o2_in");
+	outlet_autolink_ids = list("o2_outlet_scrubber");
+	name = "Oxygen Supply Control"
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution"
+	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
 "mcw" = (
@@ -56310,10 +56376,14 @@
 	},
 /area/station/security/armory)
 "mjX" = (
-/obj/effect/landmark/start/atmospheric,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/distribution)
 "mkb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/large,
@@ -56388,6 +56458,7 @@
 /area/station/maintenance/fore2)
 "mkX" = (
 /obj/machinery/alarm/directional/north,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "cautioncorner"
@@ -56450,13 +56521,16 @@
 	},
 /area/station/public/sleep)
 "mlO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -56478,11 +56552,12 @@
 	},
 /area/station/science/research)
 "mmB" = (
-/obj/effect/landmark/start/atmospheric,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
+	},
+/turf/space,
+/area/space/nearstation)
 "mmK" = (
 /obj/machinery/door_timer/cell_3{
 	pixel_x = -32
@@ -57046,7 +57121,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "mzF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57125,14 +57200,17 @@
 /turf/space,
 /area/space/nearstation)
 "mAZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	dir = 5;
+	icon_state = "green"
 	},
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "mBb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -57465,8 +57543,8 @@
 /area/station/science/lobby)
 "mHs" = (
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/visible/purple{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -57880,6 +57958,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "mOW" = (
@@ -57929,14 +58011,14 @@
 	dir = 8;
 	sort_type_txt = "6"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -58401,9 +58483,14 @@
 	},
 /area/station/medical/break_room)
 "mXQ" = (
-/obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -58590,8 +58677,11 @@
 	id_tag = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "naq" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -58816,6 +58906,21 @@
 /area/station/hallway/supply/aft)
 "ndp" = (
 /obj/item/radio/intercom/directional/south,
+/obj/structure/table/reinforced,
+/obj/machinery/camera{
+	c_tag = "Engineering - Desk";
+	dir = 1;
+	network = list("SS13","Engineering")
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/book/manual/wiki/engineering_guide{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/hacking{
+	pixel_x = 2;
+	pixel_y = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "yellow"
 	},
@@ -59045,6 +59150,17 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/secondary)
+"nhh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "nhi" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -59534,16 +59650,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "red"
+	dir = 10;
+	icon_state = "arrival"
 	},
 /area/station/engineering/atmos)
 "npB" = (
@@ -59720,6 +59833,7 @@
 	dir = 4;
 	name = "Portable Scrubber Connector"
 	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkpurplefull"
 	},
@@ -59891,13 +60005,21 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "nxh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/stack/cable_coil,
-/obj/item/reagent_containers/glass/rag,
-/obj/item/lighter/zippo,
-/obj/item/storage/fancy/candle_box/eternal,
-/turf/simulated/floor/plating,
+/obj/machinery/camera{
+	c_tag = "Starboard Primary Hallway - Atmospherics";
+	dir = 4;
+	network = list("SS13","Engineering")
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/portable/pump,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/unary/portables_connector{
+	name = "Portable Air Pump Connector";
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	icon_state = "whitebluefull"
+	},
 /area/station/maintenance/starboard)
 "nxr" = (
 /obj/structure/cable{
@@ -59981,13 +60103,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plasteel{
-	dir = 8;
-	icon_state = "caution"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "nyR" = (
 /obj/structure/cable{
@@ -60071,7 +60194,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -60084,6 +60215,14 @@
 	},
 /area/station/service/bar)
 "nAM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	icon_state = "darkyellow"
 	},
@@ -60117,6 +60256,7 @@
 "nBp" = (
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
 	dir = 4;
 	icon_state = "caution"
@@ -60128,6 +60268,14 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/medbay)
+"nBN" = (
+/obj/structure/rack,
+/obj/item/storage/fancy/candle_box/eternal,
+/obj/item/lighter/zippo,
+/obj/item/stack/cable_coil,
+/obj/item/reagent_containers/glass/rag,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "nCf" = (
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/turfs/damage,
@@ -60648,11 +60796,12 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/supply/qm)
 "nMt" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "caution"
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
 	},
-/area/station/engineering/atmos/distribution)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "nMx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -61199,6 +61348,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "nWZ" = (
@@ -61916,9 +62068,7 @@
 /area/station/supply/qm)
 "oje" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/space,
 /area/space/nearstation)
 "oji" = (
@@ -62066,17 +62216,10 @@
 	},
 /area/station/science/rnd)
 "oob" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/portable/scrubber,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 4;
-	name = "Portable Scrubber Connector"
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "darkpurplefull"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "ood" = (
 /obj/machinery/door_control{
@@ -62421,12 +62564,18 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
 "ouF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/machinery/atmospherics/trinary/filter{
+	dir = 1;
+	name = "Gas filter (Toxins tank)";
+	on = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "caution"
+	dir = 6;
+	icon_state = "purple"
 	},
 /area/station/engineering/atmos)
 "ova" = (
@@ -62653,6 +62802,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -62747,6 +62898,9 @@
 /area/station/supply/break_room)
 "oCC" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/distribution)
 "oCU" = (
@@ -62756,11 +62910,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "oCX" = (
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "darkyellowcorners"
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
 	},
-/area/station/engineering/atmos/control)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "oCZ" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the medbay foyer.";
@@ -62963,6 +63118,10 @@
 /area/station/security/permabrig)
 "oGB" = (
 /obj/effect/landmark/start/atmospheric,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -63246,10 +63405,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
 "oNd" = (
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/distribution)
 "oNg" = (
 /turf/simulated/floor/plasteel{
 	dir = 4;
@@ -63484,7 +63645,9 @@
 /area/station/service/library)
 "oPO" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/unary/thermomachine/freezer/on,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -63790,9 +63953,26 @@
 /obj/effect/mapping_helpers/turfs/rust/probably,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/gravitygenerator)
+"oVy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "oVF" = (
-/obj/machinery/atmospherics/binary/pump{
-	name = "Mix to Turbine"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 6
+	},
+/obj/machinery/atmospherics/meter,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -64060,6 +64240,9 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
 /turf/space,
 /area/space/nearstation)
 "oYO" = (
@@ -64096,12 +64279,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/xenobio_south)
 "oZT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "cautioncorner"
+/obj/machinery/atmospherics/binary/valve/digital/open{
+	name = "Oxygen Outlet Valve"
 	},
-/area/station/hallway/primary/starboard/east)
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "oZX" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -64300,21 +64482,12 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "peo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 1
-	},
+/obj/structure/curtain/open/shower/engineering,
+/obj/machinery/shower/directional/north,
+/obj/effect/turf_decal/delivery/red/hollow,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "blue"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/noslip,
+/area/station/engineering/atmos/control)
 "pep" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -64376,12 +64549,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
 "pfp" = (
-/obj/machinery/economy/vending/atmosdrobe,
-/turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "darkyellow"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/engineering/atmos/control)
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/distribution)
 "pfH" = (
 /obj/machinery/door/airlock/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -64587,6 +64760,15 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"pku" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "cautioncorner"
+	},
+/area/station/hallway/primary/starboard/east)
 "pkw" = (
 /obj/structure/bed/roller,
 /obj/machinery/light/directional/north,
@@ -64844,8 +65026,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore2)
 "pqK" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
@@ -64980,8 +65165,13 @@
 	},
 /area/station/medical/paramedic)
 "ptm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -65014,11 +65204,14 @@
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
 "ptX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 5;
 	icon_state = "caution"
 	},
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "pue" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65376,15 +65569,19 @@
 	},
 /area/station/science/research)
 "pCg" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/unary/thermomachine/heater/on{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "darkyellow"
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/distribution)
+"pCi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/area/station/engineering/atmos/control)
+/obj/machinery/firealarm/directional/west,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "pCj" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -65738,29 +65935,23 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "pJi" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 4;
-	filter_type = 2;
-	name = "Gas filter (N2 tank)";
-	on = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "red"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "pJt" = (
-/obj/machinery/door/airlock,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/starboard)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "pJv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -66077,6 +66268,10 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/secondary/exit)
+"pQp" = (
+/obj/machinery/atmospherics/binary/volume_pump,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/distribution)
 "pQq" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -67238,7 +67433,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "qiK" = (
@@ -67264,6 +67458,15 @@
 	icon_state = "brown"
 	},
 /area/station/supply/office)
+"qjZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/distribution)
 "qkC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -67345,11 +67548,11 @@
 /area/station/science/genetics)
 "qlS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -68937,6 +69140,12 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/atmos/control)
+"qRJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/starboard/east)
 "qRR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
@@ -69076,8 +69285,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "qTN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -69131,6 +69342,13 @@
 /obj/machinery/alarm/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
+"qVt" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
+/turf/space,
+/area/space/nearstation)
 "qVA" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -69234,11 +69452,19 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
 "qXK" = (
-/obj/machinery/atmospherics/binary/valve/digital/open{
-	name = "Nitrogen Outlet Valve"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 1;
+	autolink_sensors = list("n2_sensor");
+	inlet_injector_autolink_ids = list("n2_in");
+	outlet_autolink_ids = list("n2_outlet_scrubber");
+	name = "Nitrogen Supply Control"
 	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution"
+	icon_state = "red"
 	},
 /area/station/engineering/atmos)
 "qXW" = (
@@ -69381,7 +69607,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "rak" = (
 /obj/effect/landmark/start/chemist,
 /obj/structure/chair/office,
@@ -70705,9 +70931,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/starboard2)
 "rAp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "rAu" = (
@@ -70720,8 +70947,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "rAE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/start/atmospheric,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "rAG" = (
@@ -70747,15 +70978,22 @@
 	},
 /area/station/medical/storage/secondary)
 "rBn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/purple{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "rBo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -71417,6 +71655,17 @@
 	icon_state = "black"
 	},
 /area/station/security/permabrig)
+"rNX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8;
+	initialize_directions = 11
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "rOc" = (
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
@@ -71594,11 +71843,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
 "rQt" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
+/obj/machinery/atmospherics/binary/pump{
+	name = "Mix to Turbine";
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -71733,11 +71983,12 @@
 /turf/simulated/floor/wood/fancy,
 /area/station/hallway/secondary/entry/lounge)
 "rTX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/area/station/maintenance/starboard)
 "rUd" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/iv_bag/blood/random,
@@ -71933,8 +72184,12 @@
 	},
 /area/station/science/toxins/launch)
 "rXa" = (
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "rXf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/barrier/grille_often,
@@ -72019,6 +72274,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/break_room)
+"rYJ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 9
+	},
+/turf/space,
+/area/space/nearstation)
 "rYO" = (
 /obj/machinery/status_display/directional/north,
 /obj/machinery/light/directional/south,
@@ -72470,8 +72732,10 @@
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
 "skc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "skd" = (
@@ -73348,9 +73612,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "sEI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/trinary/filter{
+	dir = 4;
+	filter_type = 1;
+	name = "Gas filter (O2 tank)";
+	on = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
-	icon_state = "caution"
+	dir = 10;
+	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
 "sEL" = (
@@ -73493,11 +73766,16 @@
 	},
 /area/station/science/xenobiology)
 "sGe" = (
-/obj/machinery/atmospherics/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/door/poddoor/preopen{
+	id_tag = "atmos";
+	name = "Atmospherics Blast Door"
 	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "sGp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -73600,7 +73878,6 @@
 	},
 /area/station/hallway/secondary/exit)
 "sID" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
@@ -73938,9 +74215,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "sOw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -74330,11 +74606,10 @@
 	},
 /area/station/hallway/primary/central/nw)
 "sWZ" = (
-/obj/machinery/atmospherics/refill_station/nitrogen,
-/obj/structure/sign/poster/official/air1/directional/west,
-/turf/simulated/floor/plasteel{
-	icon_state = "white"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "sXa" = (
 /obj/structure/table/wood,
@@ -74565,21 +74840,22 @@
 	},
 /area/station/hallway/secondary/bridge)
 "tbm" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 4;
-	filter_type = 1;
-	name = "Gas filter (O2 tank)";
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/atmos/glass,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel{
-	dir = 10;
-	icon_state = "blue"
+	icon_state = "dark"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/control)
 "tbp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -74670,16 +74946,9 @@
 	},
 /area/station/security/armory)
 "tcW" = (
-/obj/structure/closet/secure_closet/atmos_personal,
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Lockers";
-	network = list("SS13","Engineering")
-	},
-/turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "darkyellow"
-	},
-/area/station/engineering/atmos/control)
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "tdb" = (
 /obj/structure/bookcase,
 /turf/simulated/floor/plasteel{
@@ -74702,6 +74971,10 @@
 	},
 /area/station/command/bridge)
 "tdA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "tdI" = (
@@ -74975,6 +75248,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
@@ -75884,7 +76160,13 @@
 /area/station/maintenance/fore2)
 "tCE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -76810,14 +77092,21 @@
 	},
 /area/station/hallway/primary/central/south)
 "tZG" = (
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("waste_sensor");
+	inlet_injector_autolink_ids = list("waste_in");
+	outlet_autolink_ids = list("waste_outlet_scrubber");
+	name = "Gas Mix Tank Control"
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+	dir = 6
 	},
 /turf/simulated/floor/plasteel{
 	dir = 4;
-	icon_state = "caution"
+	icon_state = "green"
 	},
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "tZO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
@@ -76982,19 +77271,11 @@
 	},
 /area/station/maintenance/fsmaint)
 "ucA" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 1;
-	filter_type = 4;
-	name = "Gas filter (N2O tank)";
-	on = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/item/radio/intercom/directional/east,
 /turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "escape"
+	dir = 4;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "ucO" = (
@@ -77712,10 +77993,10 @@
 	},
 /area/station/service/hydroponics)
 "upE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "uqr" = (
@@ -77906,10 +78187,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "uwn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating,
-/area/station/engineering/control)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "uws" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -77980,11 +78266,12 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/gambling_den)
 "uxy" = (
-/obj/machinery/atmospherics/trinary/tvalve/digital{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/structure/closet/firecloset,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/cobweb/right/rare,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "uxE" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -78007,22 +78294,10 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/controlroom)
 "uxV" = (
-/obj/machinery/atmospherics/trinary/filter{
-	dir = 1;
-	name = "Gas filter (Toxins tank)";
-	on = 1
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plasteel{
-	dir = 6;
-	icon_state = "purple"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "uxY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78594,6 +78869,7 @@
 /area/station/hallway/secondary/entry/lounge)
 "uJG" = (
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -78673,6 +78949,19 @@
 /obj/structure/fans/tiny,
 /turf/simulated/floor/mineral/titanium/blue,
 /area/shuttle/pod_2)
+"uKZ" = (
+/obj/machinery/atmospherics/trinary/filter{
+	dir = 1;
+	filter_type = 3;
+	name = "Gas filter (CO2 tank)";
+	on = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plasteel{
+	dir = 6;
+	icon_state = "black"
+	},
+/area/station/engineering/atmos)
 "uLb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -79273,9 +79562,14 @@
 	},
 /area/station/hallway/secondary/entry/east)
 "uWK" = (
-/obj/effect/landmark/start/atmospheric,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "uWQ" = (
 /obj/machinery/door/window/classic/normal{
 	name = "Court Cell"
@@ -79922,8 +80216,16 @@
 /turf/simulated/floor/mineral/titanium,
 /area/shuttle/arrival/station)
 "vib" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -79978,24 +80280,19 @@
 	},
 /area/station/engineering/atmos/control)
 "vjC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/portable/pump,
+/obj/machinery/atmospherics/unary/portables_connector{
+	name = "Portable Air Pump Connector";
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "purple"
+	icon_state = "whitebluefull"
 	},
-/area/station/engineering/atmos)
+/area/station/maintenance/starboard)
 "vjK" = (
 /obj/structure/chair/stool{
 	dir = 8
@@ -80051,16 +80348,18 @@
 /turf/simulated/floor/plating,
 /area/station/command/teleporter)
 "vkR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "vkT" = (
@@ -80256,19 +80555,13 @@
 	},
 /area/station/service/chapel)
 "vnQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/binary/volume_pump{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
+/obj/machinery/light/directional/north,
 /turf/simulated/floor/plasteel{
-	dir = 5;
-	icon_state = "black"
+	dir = 1;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "vnT" = (
@@ -81803,6 +82096,13 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"vWc" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos)
 "vWd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
@@ -81926,6 +82226,15 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
+"vXh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/atmos_personal,
+/turf/simulated/floor/plasteel{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos/control)
 "vXo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81972,11 +82281,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore)
 "vYQ" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel{
+	dir = 8;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "vZh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -82566,10 +82877,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "wmS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/meter,
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos)
+/obj/effect/spawner/random/cobweb/left/frequent,
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/effect/turf_decal/delivery/white/hollow,
+/turf/simulated/floor/plating,
+/area/station/maintenance/starboard)
 "wnk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82931,6 +83243,9 @@
 	dir = 1;
 	network = list("SS13","Engineering")
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "caution"
 	},
@@ -83016,6 +83331,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
@@ -83418,8 +83736,17 @@
 	},
 /area/station/medical/medbay)
 "wCp" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/binary/volume_pump{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	dir = 5;
+	icon_state = "escape"
+	},
 /area/station/engineering/atmos)
 "wDM" = (
 /obj/structure/table/glass,
@@ -84059,8 +84386,9 @@
 /turf/simulated/floor/wood,
 /area/station/service/bar)
 "wQo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -85812,8 +86140,12 @@
 	},
 /area/station/supply/storage)
 "xux" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
@@ -86150,13 +86482,10 @@
 	},
 /area/station/security/brig)
 "xBg" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Air To Distro";
-	target_pressure = 303
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/atmos/distribution)
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "xBh" = (
 /obj/effect/landmark/start/chemist,
 /obj/structure/chair/office{
@@ -86253,20 +86582,10 @@
 /turf/simulated/floor/carpet,
 /area/station/procedure/trainer_office)
 "xCF" = (
-/obj/structure/window/reinforced,
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway - Atmospherics";
-	dir = 4;
-	network = list("SS13","Engineering")
-	},
-/obj/machinery/atmospherics/portable/pump,
-/obj/machinery/atmospherics/unary/portables_connector{
-	name = "Portable Air Pump Connector";
+/obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/turf/simulated/floor/plasteel{
-	icon_state = "whitebluefull"
-	},
+/turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/east)
 "xCJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -86483,12 +86802,14 @@
 	c_tag = "Atmospherics - Distro Loop";
 	network = list("SS13","Engineering")
 	},
-/obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/station/engineering/atmos/distribution)
+/area/station/engineering/atmos)
 "xIx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/peppermill{
@@ -86633,15 +86954,18 @@
 	},
 /area/station/hallway/supply/port)
 "xLa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/trinary/filter{
+	dir = 1;
+	filter_type = 4;
+	name = "Gas filter (N2O tank)";
+	on = 1
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel{
-	dir = 4;
-	icon_state = "cautioncorner"
+	dir = 6;
+	icon_state = "escape"
 	},
-/area/station/hallway/primary/starboard/east)
+/area/station/engineering/atmos)
 "xLd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -87030,8 +87354,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard2)
 "xTV" = (
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	dir = 1;
 	icon_state = "caution"
@@ -87068,12 +87393,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/brig)
 "xVJ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/turf/simulated/floor/plasteel{
-	dir = 1;
-	icon_state = "cautioncorner"
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8;
+	initialize_directions = 11
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plasteel,
+/area/station/engineering/atmos/distribution)
 "xVR" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/cleanable/dirt,
@@ -87180,9 +87505,11 @@
 	},
 /area/station/science/research)
 "xXd" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/purple{
-	dir = 4
+/obj/machinery/atmospherics/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/purple,
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "caution"
@@ -87202,9 +87529,19 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/west)
 "xXv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/engine,
-/area/station/engineering/control)
+/obj/machinery/computer/general_air_control/large_tank_control{
+	dir = 8;
+	autolink_sensors = list("co2_sensor");
+	inlet_injector_autolink_ids = list("co2_in");
+	outlet_autolink_ids = list("co2_outlet_scrubber");
+	name = "Carbon Dioxide Supply Control"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor/plasteel{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/engineering/atmos)
 "xXD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -87880,22 +88217,12 @@
 	},
 /area/station/security/permabrig)
 "ykK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/computer/general_air_control/large_tank_control{
-	dir = 1;
-	autolink_sensors = list("n2_sensor");
-	inlet_injector_autolink_ids = list("n2_in");
-	outlet_autolink_ids = list("n2_outlet_scrubber");
-	name = "Nitrogen Supply Control"
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plasteel{
-	icon_state = "red"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
-/area/station/engineering/atmos)
+/area/station/maintenance/starboard)
 "ylu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel{
@@ -126073,12 +126400,12 @@ iHk
 xfn
 syJ
 mEm
+pCi
 eqI
-eqI
-eqI
+ibh
 eqI
 aQT
-azp
+dZA
 aoG
 aOz
 fFl
@@ -126331,11 +126658,11 @@ oNy
 bqx
 aoG
 cZD
-nxh
-nOF
+cZD
+dSv
 bSU
 dfg
-coQ
+nBN
 aoG
 qYT
 cFG
@@ -126584,17 +126911,17 @@ bam
 bam
 bam
 mkX
-fQt
+oVy
 bqx
 aoG
-aoG
-aoG
-dSv
-asJ
+wmS
+pVi
+csB
+cOJ
 nWJ
+aoG
+aoG
 oXK
-aoG
-aoG
 aoG
 aoG
 oXK
@@ -126840,14 +127167,14 @@ bgu
 bmm
 bnM
 bam
-dSN
-fQt
-bqx
+sft
+oNy
+lDD
 aoG
-aMh
-pVi
-pJt
-cOJ
+bSG
+gRz
+aoG
+uxy
 hjg
 kmO
 cNc
@@ -127098,18 +127425,18 @@ bhU
 aGX
 bam
 dSN
-fQt
-lDD
+oNy
+pBB
 aoG
-bSG
-gRz
 aoG
-cmg
-asJ
-asJ
+aoG
+aoG
+aoG
+rTX
+aoG
 mfJ
-csB
-bSU
+azp
+kto
 mfJ
 lJt
 asJ
@@ -127354,14 +127681,14 @@ bgw
 bhU
 bom
 bam
-oZT
+dSN
 vkR
-pBB
-aoG
-aoG
-aoG
-aoG
-aoG
+pku
+jVQ
+lzD
+ykK
+vjC
+nxh
 eVJ
 axh
 axh
@@ -127613,7 +127940,7 @@ bob
 bam
 jCd
 lAW
-bqx
+lVr
 oob
 bgN
 bkU
@@ -127643,7 +127970,7 @@ ciu
 ciH
 tdA
 oVF
-biB
+cly
 bul
 kij
 iPT
@@ -127868,11 +128195,11 @@ cfd
 bhU
 bjH
 bam
-sft
+fQQ
 bsY
-hTD
-hTD
-hTD
+lVr
+dOf
+qRJ
 hTD
 chi
 hTD
@@ -128130,7 +128457,7 @@ mPq
 xhF
 xhF
 xhF
-xLa
+xhF
 xhF
 xhF
 vbB
@@ -128664,7 +128991,7 @@ ovR
 arr
 axh
 fcB
-mOQ
+mXQ
 kgV
 bCU
 vPx
@@ -128922,12 +129249,12 @@ axh
 axh
 blr
 mOQ
-fWW
-fWW
-fWW
+tcW
+tcW
+tcW
 uJG
-bCM
-aaa
+lCE
+cmg
 aaa
 aaa
 aaa
@@ -129178,8 +129505,8 @@ acr
 aXz
 nuo
 cDi
-mOQ
-fWW
+pJi
+biB
 fWW
 fWW
 fhu
@@ -129427,7 +129754,7 @@ nyT
 bCu
 nfk
 eQo
-cka
+eQo
 eQo
 eQo
 fMZ
@@ -129437,7 +129764,7 @@ xXd
 xux
 hBZ
 cnH
-gTx
+cnH
 mHs
 hTg
 bCM
@@ -129682,21 +130009,21 @@ bil
 euG
 lVy
 xaE
-bnU
-vib
-cnH
-rAE
-cnH
-cnH
-cnH
+hpm
 qTN
-fWW
+qTN
+rAE
+uwn
+qTN
+rNX
+qTN
+nhh
 ptm
 tCE
+aAG
 fWW
 xfG
-pJi
-sEI
+iqE
 vrO
 cmK
 cTB
@@ -129933,26 +130260,26 @@ hHE
 bNg
 uxU
 uxU
-ceF
+peo
 ezp
 bHb
 bGK
 rao
 xaE
-bnU
-ptm
+aIT
+gTx
+gTx
+cnH
+lwx
+cnH
 skc
-skc
-skc
-mmB
-skc
-aAG
-skc
+gTx
+sPY
 dWq
-ayE
-mjX
+fWW
+jDD
+iUq
 ltm
-ykK
 qXK
 fmo
 bNe
@@ -130191,26 +130518,26 @@ bvt
 oIb
 uxU
 aVi
-oCX
+nMx
 oGB
 mlO
 nAM
-xaE
-bnU
-lfX
-gTx
-ikK
-iil
-fWW
-fWW
-fWW
+tbm
 vib
-sPY
-mXQ
+lfX
+vwt
+juS
+pJt
 fWW
+ayE
+vwt
+vwt
+dWq
+juS
+kwm
+ims
 etE
-npx
-lSg
+arE
 ngh
 iuU
 cTB
@@ -130448,25 +130775,25 @@ lmi
 rsq
 uxU
 bXA
-nMx
+vXh
 dkG
 jCT
 eoD
 aLa
 rBn
-ptm
-dOf
-vwt
-fWW
+uxV
+vnl
+iil
 uiY
 uiY
 uiY
-sGe
-vwt
+tAd
+tAd
+dWq
+iil
 xCT
-cNm
+oZT
 ltm
-upE
 lSy
 fmo
 bNe
@@ -130704,26 +131031,26 @@ ozJ
 iTB
 lho
 uxU
-tcW
+iRu
 aXJ
 pfp
-fQQ
-pCg
-xaE
+iRu
+iRu
+oNd
 bnU
-ptm
+fWW
 eow
-iHy
 ftm
 iHy
 aQU
 iHy
 xbw
 tAd
-kwm
+dWq
 fWW
-ctt
-tbm
+kwm
+bqT
+csp
 sEI
 vrO
 aHE
@@ -130963,26 +131290,26 @@ xPR
 iRu
 bvk
 vYQ
-iRu
+vYQ
 ieP
 aJb
 dYi
 nzX
-qTN
-tAd
-fWW
-fWW
-fWW
-fWW
-fWW
 fWW
 tAd
-kwm
-bqT
-csp
+fWW
+fWW
+fWW
+fWW
+fWW
+tAd
+bRk
+tcW
+vWc
+glf
 glf
 mcs
-kxI
+lCE
 oje
 phu
 liL
@@ -131219,25 +131546,25 @@ bsC
 xrD
 iRu
 iNx
-bGE
+qjZ
 lZz
 bGE
 nyM
 oBh
 bjM
+biB
+upE
+fWW
+fWW
+fWW
+ims
 fWW
 tAd
+dWq
 fWW
-fWW
-fWW
-fWW
-fWW
-fWW
-tAd
 kwm
 pig
 wrW
-peo
 lSg
 elQ
 iuU
@@ -131477,26 +131804,26 @@ uxU
 iRu
 oPO
 giA
-rXa
-rXa
+xVJ
+pQp
 oCC
-kIP
+iOO
 xTV
-xal
-oNd
-wCp
+fWW
+eow
 ftm
+pUY
 pUY
 dRt
 pUY
-aIT
 vnl
+dWq
+fWW
 kwm
 xtL
 bEK
-rTX
 kOd
-kxI
+bCM
 abq
 bCM
 bCM
@@ -131733,26 +132060,26 @@ ari
 qZz
 iRu
 ciD
-giA
-rXa
+eSE
+pCg
 hNv
-rXa
-lCE
+mjX
+iOO
 wQo
-pxj
-vnl
-fWW
+aAG
+tAd
 fWW
 gDu
 gDu
 gDu
 gDu
 kLw
+dWq
+fWW
 xbh
 cNm
 ltm
-ibh
-jYj
+npx
 ufv
 cmO
 dTW
@@ -131988,28 +132315,28 @@ tNQ
 hEA
 emS
 ncA
-iRu
+bCM
 nMt
 xBg
-rXa
-rXa
-rXa
-iOO
+xBg
+ikK
+oCX
+oCX
 sOw
-uxy
+xal
+vnl
+iil
 fWW
-juS
+dAS
+tcW
+tcW
+tcW
+aMh
 iil
 fWW
 fWW
-fWW
-fWW
-fWW
-iil
-juS
 ctt
-jVQ
-kOd
+hRI
 kxI
 abq
 phu
@@ -132245,27 +132572,27 @@ bxx
 hJx
 uyN
 qkC
-iRu
+bCM
 hKM
 iqd
 uWK
 rXa
 rXa
-iOO
+rXa
 cfK
-eSE
+pxj
+xbw
+juS
 fWW
-bqT
-mGk
-cmR
+dWq
 fWW
-bqT
-mGk
-cmR
 fWW
+fWW
+fWW
+juS
 jDD
+cNm
 ltm
-iqE
 jYj
 ufv
 cmO
@@ -132502,27 +132829,27 @@ mkf
 avH
 bQa
 fgj
-iRu
+bCM
 xIt
-iqd
-rXa
-rXa
-rXa
-lCE
-xVJ
-fTF
-etB
-lEZ
-wrW
-fTF
-wmS
-lEZ
-wrW
-fTF
-etB
-mEu
-dMs
-rTX
+fWW
+ctt
+juS
+kdZ
+bqT
+mGk
+cmR
+fWW
+bqT
+mGk
+cfy
+cmR
+bqT
+mGk
+cmR
+fWW
+kwm
+fWW
+ctt
 wul
 bCM
 abq
@@ -132759,27 +133086,27 @@ ybI
 ybI
 jKj
 arT
-lwx
-nMt
-iqd
-arE
+mhf
+vnQ
+bqT
+wrW
 frC
 bGV
-lVr
-ims
-kto
-ucA
-bRk
-vjC
+lEZ
+wrW
+fTF
+etB
+lEZ
+wrW
 cfy
-uxV
-bRk
-vnQ
-iKZ
-hpm
-jgH
-bRk
-deX
+fTF
+lEZ
+wrW
+fTF
+etB
+mEu
+etB
+dMs
 bZA
 bCM
 abq
@@ -133016,28 +133343,28 @@ abq
 abq
 jKj
 bAd
-iRu
+bCM
 ptX
 adj
 mAZ
 tZG
-mAZ
-iOO
-kzo
-hWE
-ouF
+jgH
+ucA
+wCp
+cka
+xLa
 hWE
 iLE
 aMp
 ouF
-hWE
+iKZ
 kzo
-hWE
-ouF
+xXv
+uKZ
 hbU
 nBp
 rAp
-fWW
+deX
 bCM
 bCM
 abq
@@ -133243,16 +133570,16 @@ aaa
 aaa
 aef
 szY
-uwn
+nYI
 fBW
 uDi
 pSf
-xXv
+vUb
 pSf
 sID
 aRe
 hok
-xXv
+vUb
 nME
 fFL
 vUB
@@ -133273,21 +133600,21 @@ aaa
 abq
 jKj
 arT
-iRu
+bCM
 nan
 brg
 rag
 mzf
-kdZ
+brg
 lPv
 fbq
 cdJ
 gHw
-fmo
+lPv
 fbq
-cdJ
+sGe
 gqq
-cdJ
+lPv
 fbq
 cdJ
 gqq
@@ -133531,8 +133858,8 @@ pAO
 pAO
 iOr
 sMH
-abq
-abq
+pAO
+mmB
 bIu
 cmL
 bIu
@@ -133541,8 +133868,8 @@ bIu
 abq
 bMj
 abq
-bIu
-abq
+qVt
+rYJ
 bMj
 abq
 bIu
@@ -133551,7 +133878,7 @@ bMj
 abq
 abq
 bCM
-fZt
+kIP
 mhf
 bCM
 aaa

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -6755,8 +6755,8 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "aRe" = (
-/obj/effect/turf_decal/stripes/red,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/turf_decal/stripes/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "aRf" = (
@@ -32678,13 +32678,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "dCx" = (
@@ -36848,10 +36848,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "fbR" = (
-/obj/effect/turf_decal/stripes/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/turf_decal/stripes/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "fbS" = (
@@ -73882,8 +73882,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "sID" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/turf_decal/stripes/line,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "sIF" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -6756,6 +6756,7 @@
 /area/station/engineering/engine/supermatter)
 "aRe" = (
 /obj/effect/turf_decal/stripes/red,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "aRf" = (
@@ -32687,6 +32688,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "dCx" = (
@@ -41768,7 +41770,6 @@
 	pixel_y = 7;
 	anchored = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)
 "gRu" = (
@@ -48989,6 +48990,10 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central/north)
+"jGw" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/engine,
+/area/station/engineering/control)
 "jGD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -67433,6 +67438,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "qiK" = (
@@ -73879,6 +73885,7 @@
 /area/station/hallway/secondary/exit)
 "sID" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "sIF" = (
@@ -76654,6 +76661,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft/south)
+"tPn" = (
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor/plating,
+/area/station/engineering/control)
 "tPv" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
@@ -133570,16 +133582,16 @@ aaa
 aaa
 aef
 szY
-nYI
+tPn
 fBW
 uDi
 pSf
-vUb
+jGw
 pSf
 sID
 aRe
 hok
-vUb
+jGw
 nME
 fFL
 vUB


### PR DESCRIPTION
## Что этот PR делает
Проведена глобальная оптимизация и улучшение атмосферики Цереброна.
Сделан отдельный контур подачи топлива на турбину.

## Почему это хорошо для игры
Меньше лабиринтов из труб, улучшение контура смешивания, приведение к базовой архитектуре атмосферики других карт.

## Изображения изменений
MapDiff

## Тестирование
Локальный сервер.
Все консоли и атмо-устройства работают корректно. 

## Changelog

:cl:
add: В контур смешивания атмосферики добавлены миксеры с байпассами (Цереброн)
tweak: Глобальное улучшение и оптимизация атмосферики (Цереброн)
add: Добавлена отдельная труба подачи смеси на турбину (Цереброн)
/:cl:
