### PR TITLE
Fixing mouse remains

### DIFF
--- a/modular_ss220/mobs/code/simple_animal/items.dm
+++ b/modular_ss220/mobs/code/simple_animal/items.dm
@@ -49,7 +49,6 @@
 	desc = "Некогда бывшая мышь. Её останки. Больше не будет пищать..."
 	icon = 'modular_ss220/mobs/icons/items.dmi'
 	icon_state = "mouse_skeleton"
-	anchored = FALSE
 	move_resist = MOVE_FORCE_EXTREMELY_WEAK
 
 /obj/effect/decal/remains/mouse/water_act(volume, temperature, source, method)

--- a/modular_ss220/mobs/code/simple_animal/items.dm
+++ b/modular_ss220/mobs/code/simple_animal/items.dm
@@ -49,7 +49,6 @@
 	desc = "Некогда бывшая мышь. Её останки. Больше не будет пищать..."
 	icon = 'modular_ss220/mobs/icons/items.dmi'
 	icon_state = "mouse_skeleton"
-	move_resist = MOVE_FORCE_EXTREMELY_WEAK
 
 /obj/effect/decal/remains/mouse/water_act(volume, temperature, source, method)
 	. = ..()


### PR DESCRIPTION
## Что этот PR делает

Останки мыши более нельзя помещать в кокон паукам, в соответствии с другими останками

## Тестирование

Проверил на сервере Black

## Changelog

:cl:
fix: Пауки больше не могут помещать останки мыши в кокон
/:cl: