### PR TITLE
Fix rust-utils calls

### DIFF
--- a/modular_ss220/_rust_utils/code/rust_utils.dm
+++ b/modular_ss220/_rust_utils/code/rust_utils.dm
@@ -17,25 +17,13 @@
 #define RUST_UTILS (__rust_utils || __detect_rust_utils())
 #endif
 
-#ifndef RUST_UTILS_API
-#define RUST_UTILS_API
-#define RUST_UTILS_CALL(func, args...) call_ext(RUST_UTILS, "byond:[#func]_ffi")(args)
+#define RUST_UTILS_CALL call_ext
 
-/// Gets the version of rust_utils
-/proc/rust_utils_get_version()
-	return RUST_UTILS_CALL(get_version)
+/proc/rust_utils_get_version() return RUST_UTILS_CALL(RUST_UTILS, "get_version")()
 
-/proc/rustutils_file_write_b64decode(text, fname)
-	return RUST_UTILS_CALL(file_write, text, fname, "true")
+#define rustutils_file_write_b64decode(text, fname) RUST_UTILS_CALL(RUST_UTILS, "file_write")(text, fname, "true")
 
-/proc/rustutils_regex_replace(text, re, re_params, replacement)
-	return RUST_UTILS_CALL(regex_replace, text, re, re_params, replacement)
+#define rustutils_regex_replace(text, re, re_params, replacement) RUST_UTILS_CALL(RUST_UTILS, "regex_replace")(text, re, re_params, replacement)
 
-/proc/rustutils_cyrillic_to_latin(text)
-	return RUST_UTILS_CALL(cyrillic_to_latin, "[text]")
-
-/proc/rustutils_latin_to_cyrillic(text)
-	return RUST_UTILS_CALL(latin_to_cyrillic, "[text]")
-
-#undef RUST_UTILS_CALL
-#endif
+#define rustutils_cyrillic_to_latin(text) RUST_UTILS_CALL(RUST_UTILS, "cyrillic_to_latin")("[text]")
+#define rustutils_latin_to_cyrillic(text) RUST_UTILS_CALL(RUST_UTILS, "latin_to_cyrillic")("[text]")

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -12,6 +12,24 @@ cd "$1"
 . _build_dependencies.sh
 cd "$original_dir"
 
+if [ ! -d "rust-utils" ]; then
+	echo "Cloning rust-utils..."
+	git clone https://github.com/ss220club/rust-utils
+	cd rust-utils
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
+else
+	echo "Fetching rust-utils..."
+	cd rust-utils
+	git fetch
+	~/.cargo/bin/rustup target add i686-unknown-linux-gnu
+fi
+
+echo "Deploying rustutils..."
+RUSTFLAGS="-C target-cpu=native"
+env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --all-features --target=i686-unknown-linux-gnu
+mv target/i686-unknown-linux-gnu/release/librust_utils.so "$1/librust_utils.so"
+cd ../../
+
 echo "Deploying Rustlibs..."
 cd $1/rust
 env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --features all --target=i686-unknown-linux-gnu


### PR DESCRIPTION
## Что этот PR делает
Возвращает rust-utils в PreCompile.sh, исправляет соответствующие вызовы, чтобы как раньше.

## Почему это хорошо для игры
Как минимум фильтр речи начнет работать.

## Тестирование
ээээээ йоло

## Changelog

:cl: Maxiemar
fix: Фильтр речи снова работает.
/:cl:
