### PR TITLE
FIX: Metastation intercom in the magistrate's office and keyauth in the office NT representative

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -18502,7 +18502,6 @@
 /obj/item/pen/multi/fountain,
 /obj/item/stamp/rep,
 /obj/machinery/requests_console/directional/west,
-/obj/machinery/keycard_auth/directional/south,
 /obj/machinery/phone{
 	pixel_y = 15;
 	pixel_x = -3
@@ -18804,6 +18803,7 @@
 /area/station/science/robotics/showroom)
 "bYo" = (
 /obj/structure/closet/secure_closet/ntrep,
+/obj/machinery/keycard_auth/directional/south,
 /turf/simulated/floor/carpet/royalblack,
 /area/station/command/office/ntrep)
 "bYp" = (
@@ -32347,11 +32347,6 @@
 /area/station/medical/virology)
 "dZd" = (
 /obj/machinery/light/directional/west,
-/obj/item/radio/intercom,
-/obj/item/radio/intercom/department/security{
-	pixel_x = -28;
-	pixel_y = -11
-	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/nanotrasen{
 	pixel_x = -6;
@@ -74481,6 +74476,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "uaU" = (
+/obj/item/radio/intercom/directional/north,
+/obj/item/radio/intercom/department/security{
+	pixel_y = 38;
+	pixel_x = 0
+	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "uba" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -51272,6 +51272,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/department/security{
+	pixel_x = 38;
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "cult"
 	},
@@ -74476,11 +74481,6 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "uaU" = (
-/obj/item/radio/intercom/directional/north,
-/obj/item/radio/intercom/department/security{
-	pixel_y = 38;
-	pixel_x = 0
-	},
 /turf/simulated/floor/carpet,
 /area/station/legal/magistrate)
 "uba" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

переставил криво стоящие интеркомы у магисраки
переставил считыватель у НТРа

## Почему это хорошо для игры

потому что так должно быть

## Изображения изменений

мне в падлу, дифф

## Тестирование

мьех

## Changelog

:cl:
fix: Metastation: В офисе магистрата интеркомы теперь стоят нормально. В офисе НТРа keyauth теперь стоит на стене.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
