### PR TITLE
Fix xenobio and chem RnD on Delta

### DIFF
--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -30147,21 +30147,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/medical/virology/test_room)
-"cyE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/beakers{
-	pixel_y = 2;
-	pixel_x = -4
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = 14;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/glass/bottle/reagent/formaldehyde{
-	pixel_x = 6
-	},
-/turf/simulated/floor/plasteel/white,
-/area/station/science/xenobiology)
 "cyH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -33368,7 +33353,6 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 5
 	},
-/obj/structure/closet/secure_closet/xenobiologist,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "cNn" = (
@@ -45442,6 +45426,13 @@
 /obj/item/pen,
 /obj/item/reagent_containers/dropper,
 /obj/machinery/light/directional/west,
+/obj/item/storage/box/beakers{
+	pixel_y = 2;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/glass/bottle/reagent/formaldehyde{
+	pixel_x = 6
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "dWw" = (
@@ -51692,6 +51683,7 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 9
 	},
+/obj/structure/closet/bombcloset,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
 "fMZ" = (
@@ -93605,6 +93597,10 @@
 /obj/item/storage/box/monkeycubes,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
+/obj/item/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "tam" = (
@@ -138374,7 +138370,7 @@ cWD
 cNl
 cWA
 hfh
-cyE
+tZe
 iMO
 cVf
 rKq

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -51688,6 +51688,7 @@
 	dir = 9
 	},
 /obj/structure/closet/bombcloset,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
 "fMZ" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -33712,6 +33712,14 @@
 /obj/item/storage/box/monkeycubes{
 	pixel_y = -11
 	},
+/obj/item/reagent_containers/glass/bottle/reagent/formaldehyde{
+	pixel_x = 12;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_x = -6;
+	pixel_y = 10
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
 "cOT" = (
@@ -45424,14 +45432,10 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/item/reagent_containers/dropper,
 /obj/machinery/light/directional/west,
 /obj/item/storage/box/beakers{
-	pixel_y = 2;
-	pixel_x = -4
-	},
-/obj/item/reagent_containers/glass/bottle/reagent/formaldehyde{
-	pixel_x = 6
+	pixel_y = 5;
+	pixel_x = 14
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
@@ -93598,8 +93602,8 @@
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
 /obj/item/storage/box/syringes{
-	pixel_x = 5;
-	pixel_y = 3
+	pixel_x = 116;
+	pixel_y = 237
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Передвинул шкаф ксенобиолога заместо одного стола, вещи с оного перекинул на столы правее. Также добавлен саперский шкаф к химку РнД.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Шкаф находится внутри машины для анализатора органов - явно не должно такого быть. Саперский костюм - для защиты от разрабатываемых бомб в химии (по аналогии с Кибериадой и Цереброном).

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

Мапдифф, думаю, справится

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
На веру и славу
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: В химии РнД на Керберосе появился шкаф с саперским снаряжением.
fix: Шкаф ксенобиолога на Керберосе не выдержал близкого соседства с анализатором органов и ушел заместо стола южнее; вещи со стола передвинулись на столы восточнее. 
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
