### PR TITLE
Add: Captain's Wardrobe on maps

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -43151,6 +43151,7 @@
 /obj/effect/turf_decal/siding/wood/cherry{
 	dir = 5
 	},
+/obj/machinery/light_switch/north,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/command/office/captain/bedroom)
 "dtH" = (
@@ -43586,6 +43587,12 @@
 "dBg" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/machinery/firealarm/directional/west,
+/obj/item/clothing/under/towel/long/alt/blue{
+	pixel_y = -5
+	},
+/obj/item/clothing/head/towel/blue{
+	pixel_y = 5
+	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
 "dBt" = (
@@ -81757,18 +81764,11 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "qmW" = (
-/obj/machinery/light_switch/north,
-/obj/structure/dresser,
 /obj/machinery/power/apc/directional/west,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/clothing/under/towel/long/alt/blue{
-	pixel_y = -5
-	},
-/obj/item/clothing/head/towel/blue{
-	pixel_y = 5
-	},
+/obj/structure/dresser/wardrobe/captain,
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain/bedroom)
 "qmX" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -25580,6 +25580,10 @@
 /obj/item/disk/nuclear{
 	pixel_y = 2
 	},
+/obj/item/megaphone{
+	pixel_y = 6;
+	pixel_x = -12
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain/bedroom)
 "cdV" = (
@@ -25618,10 +25622,7 @@
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain/bedroom)
 "cea" = (
-/obj/structure/dresser,
-/obj/item/megaphone{
-	pixel_y = 8
-	},
+/obj/structure/dresser/wardrobe/captain,
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain/bedroom)
 "cei" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -11115,7 +11115,17 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/important/directional/west,
-/obj/item/card/id/captains_spare,
+/obj/item/card/id/captains_spare{
+	pixel_y = -8
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/toy/figure/crew/captain{
+	pixel_x = 7;
+	pixel_y = 12
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain/bedroom)
 "bmq" = (
@@ -11690,15 +11700,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/teleporter)
 "boM" = (
-/obj/structure/dresser,
-/obj/item/flashlight/lamp/green{
-	pixel_x = -4;
-	pixel_y = 14
-	},
-/obj/item/toy/figure/crew/captain{
-	pixel_x = 7;
-	pixel_y = 12
-	},
+/obj/structure/dresser/wardrobe/captain,
 /turf/simulated/floor/carpet/black,
 /area/station/command/office/captain/bedroom)
 "boN" = (

--- a/modular_ss220/clothing/code/garment_bag.dm
+++ b/modular_ss220/clothing/code/garment_bag.dm
@@ -1,4 +1,4 @@
-/obj/item/storage/bag/garment/captain/populate_contents()
+/obj/structure/dresser/wardrobe/captain/Initialize(mapload)
 	. = ..()
 	new /obj/item/clothing/head/caphat/beret_black(src)
 	new /obj/item/clothing/neck/cloak/captain_mantle/black(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Добавляет на карты шкаф-гардероб капитана, заместо сумки для одежды, которые оффы вырезали с одним из мержей апстрима. Снэйл сказал что добавит модульную одежду кэпа. 
Ну и в связи с этим слегка перетасовал предметы (лампа на шкафу смотрелась бы отстойно).

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Капитан снова сможет менять одежду

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
Мапдифф
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Зашёл в раунд, взял из шкафа капитана модульную шмотку
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: На все наши карты в каюту капитана добавлен его шкаф-гардероб.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
