### PR TITLE
Add designs for atmos holofan and electrolyzer

### DIFF
--- a/modular_ss220/designs/_designs.dm
+++ b/modular_ss220/designs/_designs.dm
@@ -1,0 +1,7 @@
+/datum/modpack/designs
+	/// A string name for the modpack. Used for looking up other modpacks in init.
+	name = "Designs"
+	/// A string desc for the modpack. Can be used for modpack verb list as description.
+	desc = "Модуль крафтов предметов, в который можно ссыпать все крафты, которым нету места в других модулях"
+	/// A string with authors of this modpack.
+	author = "Mirka-l"

--- a/modular_ss220/designs/_designs.dme
+++ b/modular_ss220/designs/_designs.dme
@@ -1,0 +1,3 @@
+#include "_designs.dm"
+
+#include "code/designs.dm"

--- a/modular_ss220/designs/code/designs.dm
+++ b/modular_ss220/designs/code/designs.dm
@@ -2,18 +2,18 @@
 	name = "ATMOS holofan projector"
 	desc = "A holographic projector that creates holographic barriers that prevent changes in atmosphere conditions."
 	id = "atmos_holofan"
-	req_tech = list("bluespace" = 5, "engineering" = 6)
+	req_tech = list("programming" = 3, "bluespace" = 5, "engineering" = 5)
 	build_type = PROTOLATHE
-	materials = list(MAT_GLASS = 3000, MAT_PLASMA = 3000, MAT_BLUESPACE = 200, MAT_DIAMOND = 100)
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 3000, MAT_PLASMA = 3000, MAT_DIAMOND = 100)
 	build_path = /obj/item/holosign_creator/atmos
 	construction_time = 10 SECONDS
 	category = list("Equipment")
 
 /datum/design/electrolyzer
 	name = "Machine Board (Gas electrolyzer)"
-	desc = "The circuit board that for a Gas electrolyzer."
+	desc = "The circuit board for a Gas electrolyzer."
 	id = "electrolyzer"
-	req_tech = list("programming" = 4, "engineering" = 6, "toxins" = 3)
+	req_tech = list("programming" = 4, "engineering" = 6, "toxins" = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 1000, MAT_GOLD = 150)
 	build_path = /obj/item/circuitboard/electrolyzer

--- a/modular_ss220/designs/code/designs.dm
+++ b/modular_ss220/designs/code/designs.dm
@@ -1,0 +1,20 @@
+/datum/design/holosign_atmos
+	name = "ATMOS holofan projector"
+	desc = "A holographic projector that creates holographic barriers that prevent changes in atmosphere conditions."
+	id = "atmos_holofan"
+	req_tech = list("bluespace" = 5, "engineering" = 6)
+	build_type = PROTOLATHE
+	materials = list(MAT_GLASS = 3000, MAT_PLASMA = 3000, MAT_BLUESPACE = 200, MAT_DIAMOND = 100)
+	build_path = /obj/item/holosign_creator/atmos
+	construction_time = 10 SECONDS
+	category = list("Equipment")
+
+/datum/design/electrolyzer
+	name = "Machine Board (Gas electrolyzer)"
+	desc = "The circuit board that for a Gas electrolyzer."
+	id = "electrolyzer"
+	req_tech = list("programming" = 4, "engineering" = 6, "toxins" = 3)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 1000, MAT_GOLD = 150)
+	build_path = /obj/item/circuitboard/electrolyzer
+	category = list("Engineering Machinery")

--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -54,6 +54,7 @@
 #include "credits/_credits.dme"
 #include "cyrillic_fixes/_cyrillic_fixes.dme"
 #include "debug/_debug.dme"
+#include "designs\_designs.dme"
 #include "discord_link/_discord_link.dme"
 #include "donor/_donor.dme"
 #include "emotes/_emotes.dme"

--- a/modular_ss220/modular_ss220.dme
+++ b/modular_ss220/modular_ss220.dme
@@ -54,7 +54,7 @@
 #include "credits/_credits.dme"
 #include "cyrillic_fixes/_cyrillic_fixes.dme"
 #include "debug/_debug.dme"
-#include "designs\_designs.dme"
+#include "designs/_designs.dme"
 #include "discord_link/_discord_link.dme"
 #include "donor/_donor.dme"
 #include "emotes/_emotes.dme"


### PR DESCRIPTION
## Что этот PR делает

Добавляет голофан атмосов и плату электролизера в протолат и принтер плат РнД

## Почему это хорошо для игры

Голофан теперь можно воспроизводить, а электролизер теперь доступный для инженеров

## Тестирование

Вера в то что все будет работать

## Changelog

:cl:
add: Добавлен голофан атмосов в раздел экипировки протолата
add: Добавлена плата электролизера в раздел инженерной машинерии принтера плат
/:cl: