### PR TITLE
Фикс типа снарядов у gategun

### DIFF
--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -36,6 +36,7 @@
 
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	w_class = WEIGHT_CLASS_NORMAL
+	ammo_type = list(/obj/item/ammo_casing/energy/laser) //correсt projectile type
 
 //lasergun change
 /obj/item/ammo_casing/energy/lasergun_hs

--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -36,7 +36,7 @@
 
 /obj/item/gun/energy/laser/awaymission_aeg/rnd
 	w_class = WEIGHT_CLASS_NORMAL
-	ammo_type = list(/obj/item/ammo_casing/energy/laser) //correсt projectile type
+	ammo_type = list(/obj/item/ammo_casing/energy/laser)
 
 //lasergun change
 /obj/item/ammo_casing/energy/lasergun_hs


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Ещё один фикс гейт гана, теперь более явно указан тип снаряда.

<!-- Вкратце опишите изменения, которые вносите. -->
Ранее задал корректный тип снаряда для объекта /obj/item/gun/energy/laser/awaymission_aeg, который не являлся гейтганом. Теперь корректноый тип снаряда присвоен и для /obj/item/gun/energy/laser/awaymission_aeg/rnd.
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Фикс бага.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<img width="614" height="680" alt="image" src="https://github.com/user-attachments/assets/b59f6c0d-ef54-4f2d-997b-c45fa50c3df6" />

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Проверил на локалке, тип снаряда изменился.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Гейтганы теперь ТОЧНО стреляют правильным типом снаряда.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
