### PR TITLE
Добавление отдачи для кинетического оружия при стрельбе

### DIFF
--- a/modular_ss220/balance/code/items/projectiles.dm
+++ b/modular_ss220/balance/code/items/projectiles.dm
@@ -47,3 +47,9 @@
 
 /obj/projectile/beam/laser
 	icon_state = "laser_alt"
+
+/obj/projectile/beam/immolator
+	icon_state = "temp_8"
+
+/obj/projectile/beam/xray
+	icon_state = "temp_4"

--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -69,11 +69,17 @@
 /obj/item/gun/projectile/automatic
 	recoil = 0.7
 
+/obj/item/gun/projectile/automatic/lasercarbine
+	recoil = 0
+
 /obj/item/gun/projectile/automatic/c20r/toy
 	recoil = 0.2
 
 /obj/item/gun/projectile/automatic/l6_saw/toy
 	recoil = 0.3
+
+/obj/item/gun/projectile/revolver/capgun
+	recoil = 0.1
 
 /obj/item/gun/projectile/automatic/l6_saw/toy/riot
 	recoil = 0.4

--- a/modular_ss220/balance/code/items/weapons.dm
+++ b/modular_ss220/balance/code/items/weapons.dm
@@ -63,11 +63,38 @@
 /obj/item/gun/projectile/shotgun/automatic/combat
 	recoil = 1.1
 
+/obj/item/gun/projectile/automatic/shotgun/bulldog
+	recoil = 1
+
+/obj/item/gun/projectile/automatic
+	recoil = 0.7
+
+/obj/item/gun/projectile/automatic/c20r/toy
+	recoil = 0.2
+
+/obj/item/gun/projectile/automatic/l6_saw/toy
+	recoil = 0.3
+
+/obj/item/gun/projectile/automatic/l6_saw/toy/riot
+	recoil = 0.4
+
 /obj/item/gun/projectile/automatic/wt550
 	recoil = 0.8
 
-/obj/item/gun/projectile/automatic/pistol/beretta
+/obj/item/gun/projectile/automatic/tommygun
+	recoil = 0.6
+
+/obj/item/gun/projectile/automatic/l6_saw
+	recoil = 0.9
+
+/obj/item/gun/projectile/automatic/pistol
 	recoil = 0.5
+
+/obj/item/gun/projectile/revolver
+	recoil = 0.6
+
+/obj/item/gun/projectile/automatic/pistol/deagle
+	recoil = 0.7
 
 //changed sounds
 /obj/item/ammo_casing/energy/laser


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Добавляет больше видов отдачи для кинетического оружия. Также дополнительно изменяет внешний вид снаряда у x-ray gun и Immolator.
<!-- Вкратце опишите изменения, которые вносите. -->

В продолжение ПРа с переработкой стрельбы выкатываю этот, так как он нацелен на добавление отдачи для оружия, использующего кинетики, ранее только несколько видов конкретного оружия имели отдачу.
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры
Отдача добавляет больше иммерсивности в стрельбу, у некоторых пушек была отдача, у других нет, теперь они уравнены.
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
Нет.
<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование
Запустил на локалке, работает.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
add: Добавлена индивидуальная отдача при стрельбе практически для каждого кинетического оружия.
tweak: Изменён спрайт снаряда у x-ray gun 
tweak: Изменён спрайт снаряда у immolator
/:cl:

