### PR TITLE
[FIX] Чиним загрузку конфига на сервере

### DIFF
--- a/modular_ss220/text_to_speech/code/configuration.dm
+++ b/modular_ss220/text_to_speech/code/configuration.dm
@@ -4,7 +4,8 @@
 
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	tts = new()
+	if(!tts)
+		tts = new()
 	safe_load(tts, "tts_configuration")
 
 /datum/configuration_section/tts_configuration


### PR DESCRIPTION
## Что этот PR делает

Добавляет проверку на конфиг ТТС.

В недавнем мерже апстрима добавили тест мерж конфиг. Хоть он и не подключен, по коду он вызывает GLOB.configuration.load_overrides("config/tests/config_[TEST_CONFIG_OVERRIDE].toml"), и поскольку проверки в модульном конфиге ТТСа нету, а сам тест мерж конфиг пуст, конфиг ТТСа перезаписывает без нужных токенов, и система ТТСа на сервере автоматически выключается.