### PR TITLE
[FIX] Чинит загрузку конфига на сервере

### DIFF
--- a/config/example/config.toml
+++ b/config/example/config.toml
@@ -1007,6 +1007,10 @@ ffmpeg_cpuaffinity = ""
 
 
 ################################################################
+[ss220_unit_test]
+# Hey, do you know the secret answer to the Ultimate Question of Life, The Universe, and Everything?
+secret_number = 42
+
 
 [ss220_misc_configuration]
 # This section contains everything that should be in general_configuration

--- a/modular_ss220/_misc/code/ss220_general_config.dm
+++ b/modular_ss220/_misc/code/ss220_general_config.dm
@@ -16,5 +16,6 @@
 	safe_load(ss220_misc, "ss220_misc_configuration")
 
 /datum/configuration_section/ss220_misc_configuration/New()
-	GLOB.blocked_chems += list("serpadrone")
+	GLOB.blocked_chems |= list("serpadrone")
 	GLOB.wall_items |= typecacheof(list(/obj/structure/closet/walllocker))
+	..()

--- a/modular_ss220/_misc/code/ss220_general_config.dm
+++ b/modular_ss220/_misc/code/ss220_general_config.dm
@@ -7,9 +7,14 @@
 	/// Contains all the misc configuration values
 	var/datum/configuration_section/ss220_misc_configuration/ss220_misc
 
+/datum/server_configuration/load_configuration()
+	ss220_misc = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	ss220_misc = new()
 	safe_load(ss220_misc, "ss220_misc_configuration")
+
+/datum/configuration_section/ss220_misc_configuration/New()
 	GLOB.blocked_chems += list("serpadrone")
 	GLOB.wall_items |= typecacheof(list(/obj/structure/closet/walllocker))

--- a/modular_ss220/ai_integration/code/config.dm
+++ b/modular_ss220/ai_integration/code/config.dm
@@ -1,9 +1,12 @@
 /datum/server_configuration
 	var/datum/configuration_section/gpt_configuration/gpt
 
+/datum/server_configuration/load_configuration()
+	gpt = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	gpt = new()
 	safe_load(gpt, "gpt_configuration")
 
 /datum/configuration_section/gpt_configuration

--- a/modular_ss220/antagonists/code/antag_mix/antag_mix_configuration.dm
+++ b/modular_ss220/antagonists/code/antag_mix/antag_mix_configuration.dm
@@ -11,9 +11,12 @@
 	/// Assoc list of antag scenario config tag -> list of parameters of this scenarios
 	var/list/params_by_scenario = list()
 
+/datum/server_configuration/load_configuration()
+	antag_mix_gamemode = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	antag_mix_gamemode = new()
 	safe_load(antag_mix_gamemode, "antag_mix_gamemode_configuration")
 
 /datum/configuration_section/antag_mix_gamemode_configuration/load_data(list/data)

--- a/modular_ss220/gateway/code/gateway_config.dm
+++ b/modular_ss220/gateway/code/gateway_config.dm
@@ -2,9 +2,12 @@
 	/// Holder for the gateway configuration datum
 	var/datum/configuration_section/gateway_configuration/gateway
 
+/datum/server_configuration/load_configuration()
+	gateway = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	gateway = new()
 	safe_load(gateway, "gateway_configuration")
 
 /datum/configuration_section/gateway_configuration

--- a/modular_ss220/jobs/code/configuration.dm
+++ b/modular_ss220/jobs/code/configuration.dm
@@ -28,7 +28,10 @@
 		return TRUE
 	CRASH("Race [race_name] mentioned in config of job_configuration_restriction for job [job_name] not found in global var of all species GLOB.all_species")
 
+/datum/server_configuration/load_configuration()
+	jobs_restrict = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	jobs_restrict = new()
 	safe_load(jobs_restrict, "job_configuration_restriction")

--- a/modular_ss220/metaserver/code/ss_central.dm
+++ b/modular_ss220/metaserver/code/ss_central.dm
@@ -9,9 +9,12 @@
 	var/server_type = ""
 	var/force_discord_verification = FALSE
 
+/datum/server_configuration/load_configuration()
+	central = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	central = new()
 	safe_load(central, "central_configuration")
 
 /datum/configuration_section/central/load_data(list/data)

--- a/modular_ss220/metaserver/code/ss_central.dm
+++ b/modular_ss220/metaserver/code/ss_central.dm
@@ -32,7 +32,8 @@ SUBSYSTEM_DEF(central)
 	init_order = INIT_ORDER_DBCORE
 
 /datum/controller/subsystem/central/Initialize()
-	if(!(GLOB.configuration.central.api_url && GLOB.configuration.central.api_token))
+	// If this is not a real server, we dont want to load the whitelist and get a rintime error because of the missing api_url
+	if(!(GLOB.configuration.central.api_url == "https://central.ss220.club/v1"))
 		return
 	load_whitelist()
 	// TODO: Preload links

--- a/modular_ss220/species_ban/code/species_ban_configuration.dm
+++ b/modular_ss220/species_ban/code/species_ban_configuration.dm
@@ -2,9 +2,12 @@
 	/// Holder for the gateway configuration datum
 	var/datum/configuration_section/species_ban_configuration/species_ban
 
+/datum/server_configuration/load_configuration()
+	species_ban = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	species_ban = new()
 	safe_load(species_ban, "species_ban_configuration")
 
 /datum/configuration_section/species_ban_configuration

--- a/modular_ss220/text_to_speech/code/configuration.dm
+++ b/modular_ss220/text_to_speech/code/configuration.dm
@@ -2,9 +2,12 @@
 	/// Holder for the tts configuration datum
 	var/datum/configuration_section/tts_configuration/tts
 
+/datum/server_configuration/load_configuration()
+	tts = new()
+	. = ..()
+
 /datum/server_configuration/load_all_sections()
 	. = ..()
-	tts = new()
 	safe_load(tts, "tts_configuration")
 
 /datum/configuration_section/tts_configuration

--- a/modular_ss220/unit_tests/_unit_tests.dme
+++ b/modular_ss220/unit_tests/_unit_tests.dme
@@ -2,6 +2,7 @@
 
 #ifdef GAME_TESTS
 #include "code/job_defines.dm"
+#include "code/config_loading.dm"
 #endif
 
 #ifdef MAP_TESTS

--- a/modular_ss220/unit_tests/code/config_loading.dm
+++ b/modular_ss220/unit_tests/code/config_loading.dm
@@ -1,0 +1,34 @@
+#ifdef GAME_TESTS
+
+/datum/server_configuration
+	/// Contains all the misc configuration values
+	var/datum/configuration_section/ss220_unit_test/test
+
+
+/datum/configuration_section/ss220_unit_test
+	var/secret_number = -1
+
+/datum/server_configuration/load_all_sections()
+	. = ..()
+	safe_load(test, "ss220_unit_test")
+
+/datum/server_configuration/ss220_unit_test/load_configuration()
+	test = new()
+	. = ..()
+
+/datum/configuration_section/ss220_unit_test/load_data(list/data)
+	CONFIG_LOAD_NUM(secret_number, data["secret_number"])
+
+#endif
+
+/datum/game_test/config_loading
+
+/datum/game_test/config_loading/Run()
+	validate()
+
+/datum/game_test/config_loading/proc/validate()
+
+	var/secret_number = GLOB.configuration.test.secret_number
+	if(secret_number != 42)
+		Fail("Looks like we don't know the answer to the Ultimate Question of Life, The Universe, and Everything. Expected [42], got [secret_number], check if the config loading is working properly.")
+

--- a/modular_ss220/unit_tests/code/config_loading.dm
+++ b/modular_ss220/unit_tests/code/config_loading.dm
@@ -18,8 +18,6 @@
 /datum/configuration_section/ss220_unit_test/load_data(list/data)
 	CONFIG_LOAD_NUM(secret_number, data["secret_number"])
 
-#endif
-
 /datum/game_test/config_loading
 
 /datum/game_test/config_loading/Run()
@@ -30,3 +28,4 @@
 	if(secret_number != 42)
 		Fail("Looks like we don't know the answer to the Ultimate Question of Life, The Universe, and Everything. Expected [42], got [secret_number], check if the config loading is working properly.")
 
+#endif

--- a/modular_ss220/unit_tests/code/config_loading.dm
+++ b/modular_ss220/unit_tests/code/config_loading.dm
@@ -4,7 +4,6 @@
 	/// Contains all the misc configuration values
 	var/datum/configuration_section/ss220_unit_test/test
 
-
 /datum/configuration_section/ss220_unit_test
 	var/secret_number = -1
 
@@ -12,7 +11,7 @@
 	. = ..()
 	safe_load(test, "ss220_unit_test")
 
-/datum/server_configuration/ss220_unit_test/load_configuration()
+/datum/server_configuration/load_configuration()
 	test = new()
 	. = ..()
 
@@ -27,7 +26,6 @@
 	validate()
 
 /datum/game_test/config_loading/proc/validate()
-
 	var/secret_number = GLOB.configuration.test.secret_number
 	if(secret_number != 42)
 		Fail("Looks like we don't know the answer to the Ultimate Question of Life, The Universe, and Everything. Expected [42], got [secret_number], check if the config loading is working properly.")

--- a/modular_ss220/unit_tests/code/config_loading.dm
+++ b/modular_ss220/unit_tests/code/config_loading.dm
@@ -4,9 +4,6 @@
 	/// Contains all the misc configuration values
 	var/datum/configuration_section/ss220_unit_test/test
 
-/datum/configuration_section/ss220_unit_test
-	var/secret_number = -1
-
 /datum/server_configuration/load_all_sections()
 	. = ..()
 	safe_load(test, "ss220_unit_test")
@@ -14,6 +11,9 @@
 /datum/server_configuration/load_configuration()
 	test = new()
 	. = ..()
+
+/datum/configuration_section/ss220_unit_test
+	var/secret_number = -1
 
 /datum/configuration_section/ss220_unit_test/load_data(list/data)
 	CONFIG_LOAD_NUM(secret_number, data["secret_number"])


### PR DESCRIPTION

## Что этот PR делает

Исправляет порядок инициализации, модульных секций конфига так, чтобы при повторном вызове конфига, мы не теряли уже загруженные данные.

## Почему это хорошо для игры

У нас будет работать сервер нормально.

## Тестирование

Проверил фикс на локалке в antag_mix_gamemode секцию данные попали корректно.