### PR TITLE
Fix: Починены двойные двери на картах.

### DIFF
--- a/_maps/map_files220/RandomRuins/SpaceRuins/sierra_1_4.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/sierra_1_4.dmm
@@ -155,7 +155,9 @@
 /turf/space,
 /area/space/nearstation)
 "bt" = (
-/obj/machinery/door/airlock/multi_tile,
+/obj/machinery/door/airlock/multi_tile{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/science/research,
 /obj/structure/cable/green{
@@ -308,7 +310,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/sierra/med)
 "cU" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/closed,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/simulated/floor/plasteel/dark,
@@ -951,9 +955,7 @@
 /turf/simulated/floor/plasteel/dark/airless,
 /area/ruin/space/sierra/med)
 "hW" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tiles/department/command/side,
@@ -2256,7 +2258,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/sierra/med)
 "tR" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
@@ -2735,9 +2739,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sierra/hall)
 "xm" = (
-/obj/machinery/door/airlock/multi_tile{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -4173,7 +4175,9 @@
 /turf/simulated/floor/plasteel/airless,
 /area/space/nearstation)
 "Lg" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/closed,
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -4515,9 +4519,7 @@
 /turf/simulated/floor/plasteel,
 /area/ruin/space/sierra/rnd)
 "NY" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/simulated/floor/plasteel/white,

--- a/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/map_files220/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2934,7 +2934,9 @@
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/spacehotelv1/guestroom3)
 "xl" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood/neutral{
 	dir = 1
 	},
@@ -4139,7 +4141,9 @@
 /turf/simulated/floor/carpet/grimey,
 /area/ruin/space/spacehotelv1/forehallway)
 "Gy" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/wood/neutral{
 	dir = 8
 	},
@@ -4283,7 +4287,9 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/forestarboardmaints)
 "HP" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/ruin/space/spacehotelv1/centralhallway)
@@ -4486,7 +4492,9 @@
 /turf/simulated/floor/plating,
 /area/ruin/space/spacehotelv1/guestroom1)
 "JO" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood/neutral{
 	dir = 8
@@ -6201,9 +6209,7 @@
 /turf/simulated/floor/carpet/arcade,
 /area/ruin/space/spacehotelv1/guestroom2)
 "XV" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/effect/turf_decal/siding/wood/neutral,
 /obj/effect/turf_decal/siding/wood/neutral{
 	dir = 4
@@ -6338,9 +6344,7 @@
 /turf/simulated/floor/wood/oak,
 /area/ruin/space/spacehotelv1/bar)
 "Zf" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},

--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -5626,7 +5626,8 @@
 "cFJ" = (
 /obj/machinery/status_display/directional/west,
 /obj/machinery/door/airlock/multi_tile/command/glass{
-	name = "Escape Shuttle Cockpit"
+	name = "Escape Shuttle Cockpit";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/simulated/floor/plasteel/dark,
@@ -8789,7 +8790,8 @@
 /area/centcom/ss220/supply)
 "dZw" = (
 /obj/machinery/door/airlock/multi_tile/command/glass{
-	name = "Escape Shuttle Cockpit"
+	name = "Escape Shuttle Cockpit";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /obj/effect/turf_decal/tiles/neutral,
@@ -9363,7 +9365,8 @@
 /area/syndicate_mothership/jail)
 "eoV" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Парк"
+	name = "Парк";
+	dir = 4
 	},
 /turf/simulated/floor/wood/oak,
 /area/centcom/ss220/park)
@@ -10500,8 +10503,7 @@
 "eMo" = (
 /obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "UNKNOWN";
-	dir = 4
+	name = "UNKNOWN"
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
@@ -16616,7 +16618,8 @@
 "hvB" = (
 /obj/machinery/door/airlock/multi_tile/command/glass{
 	name = "Командный Центр";
-	req_access = list(114)
+	req_access = list(114);
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/stairs/left{
 	color = "gray"
@@ -17885,9 +17888,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/centcom/ss220/supply)
 "hXt" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/wood/fancy/cherry,
 /area/trader_station/sol)
 "hXu" = (
@@ -18907,8 +18908,7 @@
 "itk" = (
 /obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Хранилище Канцелярии";
-	dir = 4
+	name = "Хранилище Канцелярии"
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/centcom/ss220/admin1)
@@ -20555,8 +20555,7 @@
 /area/shuttle/escape)
 "jgz" = (
 /obj/machinery/door/airlock/multi_tile/medical/glass{
-	name = "Escape Shuttle Infirmary";
-	dir = 4
+	name = "Escape Shuttle Infirmary"
 	},
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
@@ -23221,7 +23220,8 @@
 /area/shuttle/administration)
 "kuA" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Парк"
+	name = "Парк";
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8;
@@ -25939,7 +25939,8 @@
 /area/ghost_bar/indoor)
 "lAc" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Библиотека"
+	name = "Библиотека";
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/bar)
@@ -27977,7 +27978,8 @@
 /area/syndicate_mothership/control)
 "mwu" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Библиотека"
+	name = "Библиотека";
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/centcom/ss220/park)
@@ -36210,8 +36212,7 @@
 /area/centcom/ss220/admin3)
 "qtB" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	name = "Столовая ОБР";
-	dir = 4
+	name = "Столовая ОБР"
 	},
 /obj/effect/turf_decal/delivery/blue,
 /turf/simulated/floor/plasteel/dark,
@@ -37102,7 +37103,8 @@
 /area/centcom/ss220/supply)
 "qRj" = (
 /obj/machinery/door/airlock/multi_tile/medical/glass{
-	name = "Escape Shuttle Infirmary"
+	name = "Escape Shuttle Infirmary";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/shuttle/escape)
@@ -37659,7 +37661,6 @@
 /area/centcom/ss220/park)
 "rbJ" = (
 /obj/machinery/door/airlock/multi_tile/command/glass{
-	dir = 4;
 	name = "Зона ЦК"
 	},
 /turf/simulated/floor/plasteel/dark,
@@ -46130,7 +46131,6 @@
 /area/vox_base)
 "uUb" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
 	name = "Emergency Airlock Access"
 	},
 /turf/simulated/floor/plasteel,
@@ -47728,7 +47728,6 @@
 /area/vox_base)
 "vBp" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4;
 	name = "Shuttle Cargo Hatch"
 	},
 /turf/simulated/floor/plasteel,
@@ -75160,7 +75159,7 @@ osb
 osb
 osb
 dYg
-quL
+nQh
 osb
 osb
 osb
@@ -76191,7 +76190,7 @@ sZk
 sZk
 sZk
 sZk
-nQh
+quL
 vxs
 fUq
 odn

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -1161,7 +1161,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonershuttle)
@@ -2098,7 +2100,8 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /obj/machinery/door/airlock/multi_tile/security/glass{
-	id_tag = "BrigLeft"
+	id_tag = "BrigLeft";
+	dir = 4
 	},
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
@@ -5258,8 +5261,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /obj/machinery/door/airlock/multi_tile/security/glass{
-	id_tag = "BrigEast";
-	dir = 4
+	id_tag = "BrigEast"
 	},
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
@@ -5463,8 +5465,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /obj/machinery/door/airlock/multi_tile/security/glass{
-	id_tag = "BrigEast";
-	dir = 4
+	id_tag = "BrigEast"
 	},
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
@@ -5543,9 +5544,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/machinery/door/airlock/multi_tile/security/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/security/glass,
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/processing)
@@ -10394,9 +10393,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/multi_tile/engineering/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
@@ -16383,7 +16380,9 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/chapel/office)
 "bjs" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -19206,9 +19205,7 @@
 "bva" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "librarywindows"
 	},
@@ -19413,7 +19410,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/airlock/multi_tile/command,
+/obj/machinery/door/airlock/multi_tile/command{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
 	},
@@ -34294,7 +34293,8 @@
 "cJo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/engineering/glass{
-	id_tag = "englobby"
+	id_tag = "englobby";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/poddoor{
@@ -39051,9 +39051,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/multi_tile/engineering/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/engineering/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/station_engineering,
 /turf/simulated/floor/plasteel/dark,
@@ -40219,9 +40217,7 @@
 /area/station/engineering/control)
 "dgP" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/atmospheric/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/atmospheric/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id_tag = "engsm2";
@@ -50599,7 +50595,9 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/command,
+/obj/machinery/door/airlock/multi_tile/command{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
@@ -52469,7 +52467,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/atmospheric/glass,
+/obj/machinery/door/airlock/multi_tile/atmospheric/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
@@ -53398,7 +53398,9 @@
 /area/station/aisat/service)
 "gQs" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/engineering/glass,
+/obj/machinery/door/airlock/multi_tile/engineering/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -55636,8 +55638,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood/cherry,
 /obj/machinery/door/airlock/multi_tile/command{
-	id_tag = "captainofficedoor";
-	dir = 4
+	id_tag = "captainofficedoor"
 	},
 /turf/simulated/floor/wood/fancy/cherry,
 /area/station/command/office/captain)
@@ -55962,8 +55963,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/machinery/door/airlock/multi_tile/command/glass{
-	id_tag = "conference_bolt";
-	dir = 4
+	id_tag = "conference_bolt"
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/meeting_room)
@@ -55978,7 +55978,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "hGo" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/tiles/neutral/side{
@@ -56186,7 +56188,9 @@
 /area/station/engineering/atmos)
 "hJQ" = (
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -60316,7 +60320,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/multi_tile/security/glass{
-	id_tag = "BrigRight"
+	id_tag = "BrigRight";
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/tiles/department/security,
@@ -72670,7 +72675,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/atmospheric/glass,
+/obj/machinery/door/airlock/multi_tile/atmospheric/glass{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -73311,7 +73318,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/polarized{
@@ -74235,7 +74244,9 @@
 /area/station/supply/miningdock)
 "nNq" = (
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/department/virology,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
@@ -74656,9 +74667,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/multi_tile/supply/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/supply/glass,
 /obj/effect/mapping_helpers/airlock/access/any/supply/cargo_bay,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/tiles/department/cargo,
@@ -77136,7 +77145,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "scene"
 	},
@@ -78478,15 +78489,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/access_button/directional/west{
 	autolink_id = "turbine_btn_int";
 	name = "Gas Turbine Airlock Control";
 	req_access = list(24)
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "pcF" = (
@@ -79119,7 +79130,9 @@
 "pnB" = (
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/engineering/glass,
+/obj/machinery/door/airlock/multi_tile/engineering/glass{
+	dir = 4
+	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -80264,9 +80277,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -86492,9 +86503,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/door/airlock/multi_tile/medical/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/medical/glass,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "rKV" = (
@@ -96966,9 +96975,7 @@
 /obj/effect/mapping_helpers/airlock/polarized{
 	id = "briefing"
 	},
-/obj/machinery/door/airlock/multi_tile/security/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/security/glass,
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/main)
@@ -100485,7 +100492,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "wny" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/siding/wood/cherry{
 	dir = 8
@@ -103798,9 +103807,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "xpV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/public/glass{
 	autoclose = 0;
 	heat_proof = 1;
@@ -103825,6 +103831,9 @@
 	req_access = list(24)
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/engine,
 /area/station/maintenance/turbine)
 "xqa" = (
@@ -136779,7 +136788,7 @@ amI
 hRY
 anJ
 aiX
-qwf
+mcD
 wyJ
 uAG
 atg
@@ -137805,7 +137814,7 @@ apS
 apS
 apS
 opa
-mcD
+qwf
 apS
 apS
 dej

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -16338,6 +16338,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/storage/fancy/cigars{
+	pixel_x = 5;
+	pixel_y = -8
+	},
 /turf/simulated/floor/carpet/black,
 /area/station/command/meeting_room)
 "bjg" = (

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -44753,9 +44753,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/security{
-	dir = 1
-	},
+/obj/machinery/door/airlock/multi_tile/security,
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
 /area/station/security/checkpoint/south)

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -5082,9 +5082,7 @@
 /area/station/maintenance/old_kitchen)
 "aym" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/security/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/security/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /obj/effect/turf_decal/tiles/department/security/corner{
@@ -11235,7 +11233,9 @@
 /turf/simulated/wall,
 /area/station/service/kitchen)
 "aZa" = (
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/wood/oak{
@@ -16721,7 +16721,9 @@
 	id = "cellprivacy"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/processing)
 "bxK" = (
@@ -18342,9 +18344,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "bEo" = (
@@ -38015,7 +38015,9 @@
 	id = "robotics"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/research/glass,
+/obj/machinery/door/airlock/multi_tile/research/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/dark/side{
 	dir = 4
 	},
@@ -40383,9 +40385,7 @@
 	id = "WardenD"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
-/obj/machinery/door/airlock/multi_tile/security/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/security/glass,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/warden)
@@ -43421,9 +43421,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/machinery/door/airlock/multi_tile/medical/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/medical/glass,
 /obj/effect/turf_decal/tiles/department/medical/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
@@ -44756,7 +44754,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/security{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel,
@@ -49915,9 +49913,7 @@
 	name = "Armory Lockdown"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
-/obj/machinery/door/airlock/multi_tile/security/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/security/glass,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
@@ -57075,7 +57071,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/aisat)
 "hAD" = (
@@ -62178,7 +62176,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /turf/simulated/floor/plasteel/dark,
@@ -68960,9 +68960,7 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "lkW" = (
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -73275,9 +73273,7 @@
 "mEd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -77856,9 +77852,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor/carpet,
 /area/station/service/bar/atrium)
 "nUQ" = (
@@ -80416,9 +80410,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/multi_tile/supply/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/supply/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining_station,
 /obj/effect/turf_decal/tiles/department/science,
@@ -80501,7 +80493,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -83001,7 +82995,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/science/robotics,
-/obj/machinery/door/airlock/multi_tile/research/glass,
+/obj/machinery/door/airlock/multi_tile/research/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/department/science,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/robotics/chargebay)
@@ -88678,7 +88674,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/doors,
 /obj/effect/turf_decal/tiles/department/security/corner,
@@ -89814,7 +89812,9 @@
 "rCN" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
@@ -97664,7 +97664,9 @@
 /area/station/maintenance/dormitory_maintenance)
 "ucc" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/multi_tile/glass,
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel/white,
 /area/station/public/sleep)
@@ -99604,7 +99606,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/machinery/door/airlock/multi_tile/supply,
+/obj/machinery/door/airlock/multi_tile/supply{
+	dir = 4
+	},
 /obj/effect/turf_decal/tiles/department/cargo,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
@@ -108433,7 +108437,9 @@
 /turf/simulated/floor/carpet/royalblack,
 /area/station/legal/courtroom)
 "xBs" = (
-/obj/machinery/door/airlock/multi_tile/security/glass,
+/obj/machinery/door/airlock/multi_tile/security/glass{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -109557,9 +109563,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
-/obj/machinery/door/airlock/multi_tile/command/glass{
-	dir = 4
-	},
+/obj/machinery/door/airlock/multi_tile/command/glass,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "xRD" = (
@@ -139499,7 +139503,7 @@ bxh
 bSy
 qVh
 euI
-mIC
+ctU
 cnl
 btc
 cnl
@@ -142590,7 +142594,7 @@ bYj
 bYj
 bYk
 txc
-ctU
+mIC
 bYk
 bYj
 bYj

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -16707,7 +16707,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/multi_tile/command/glass,
+/obj/machinery/door/airlock/multi_tile/command/glass{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/ai_monitored/storage/eva)
 "bNP" = (


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Фиксит двойные двери на картах. (+исправлена проводка в турбине)

## Почему это хорошо для игры
Патамучта

## Изображения изменений

не столь важно, но если надо - Мапдиф в помощь

## Тестирование

Проводилось. Изменения дира помогло.

## Changelog

:cl:
fix: Починены двойные двери на картах.
fix: Починена проводка в турбине на Кибериаде
/:cl:
