### PR TITLE
Изменён урон кувалды по пожарным шлюзам.

### DIFF
--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -31,6 +31,7 @@
 	var/wall_damage = 25
 	var/window_damage = 50
 	var/airlock_damage = 100
+	var/firedoor_damage = 200
 
 	attack_verb = list(
 		"ломает",
@@ -81,6 +82,10 @@
 		var/obj/machinery/door/airlock/door = target
 		return breach_airlock(door, user)
 
+	if(istype(target, /obj/machinery/door/firedoor))
+		var/obj/machinery/door/firedoor/firedoor = target
+		return breach_firedoor(firedoor, user)
+
 
 /obj/item/tactical_sledgehammer/proc/breach_wall(turf/simulated/wall/wall, mob/living/user)
 	is_breaching = TRUE
@@ -95,6 +100,7 @@
 			SPAN_WARNING("[user] бросает затею ломать [wall]."),
 			SPAN_WARNING("Вы бросаете затею ломать [wall].")
 		)
+
 		is_breaching = FALSE
 		return FINISH_ATTACK
 
@@ -141,6 +147,18 @@
 	return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
 
 
+/obj/item/tactical_sledgehammer/proc/breach_firedoor(obj/machinery/door/firedoor/firedoor, mob/living/user)
+	user.do_attack_animation(firedoor)
+
+	user.visible_message(
+		SPAN_DANGER("[user] с размаху бьёт по [firedoor] кувалдой!"),
+		SPAN_DANGER("Вы наносите мощный удар по аварийному шлюзу!")
+	)
+
+	playsound(src.loc, 'sound/effects/bang.ogg', 50, TRUE)
+	firedoor.take_damage(firedoor_damage, BRUTE)
+	return FINISH_ATTACK | MELEE_COOLDOWN_PREATTACK
+
 /obj/item/tactical_sledgehammer/syndicate
 	name = "D-4S syndicate breaching hammer"
 	desc = "Усиленная версия тактической кувалды для диверсионных операций."
@@ -153,6 +171,7 @@
 	wall_damage = 100
 	window_damage = 150
 	airlock_damage = 150
+	firedoor_damage = 400
 
 
 /obj/item/tactical_sledgehammer/syndicate/Initialize(mapload)

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -152,7 +152,7 @@
 
 	user.visible_message(
 		SPAN_DANGER("[user] с размаху бьёт по [firedoor] кувалдой!"),
-		SPAN_DANGER("Вы наносите мощный удар по аварийному шлюзу!")
+		SPAN_DANGER("Вы наносите мощный удар по пожарному шлюзу!")
 	)
 
 	playsound(src.loc, 'sound/effects/bang.ogg', 50, TRUE)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает


Ранее кувалда не наносила значимый урон по пожарным шлюзам, теперь наносит в размере 200 единиц - 2 удара для сноса пожарного шлюза. Синди версия наносит 400 - 1 удар для сноса.
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Предмет лучше соответствует своей фантазии, когда ему не требуется 8 ударов, чтобы сломать пожарный шлюз.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Тестирование

Локалка.
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Тактическая кувалда уничтожает пожарные шлюзы с двух ударов, синдикат версия с одного.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
