### PR TITLE
Доработка ТТСа

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -309,7 +309,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 	else //Turf, leave speech bubbles to the mob
 		speech_bubble("[bubble_icon][speech_bubble_test]", src, speech_bubble_recipients)
 
-	// SS220 EDIT START
+	// SS220 EDIT START - Для корректного воспроизведения ТТС
 	hear_message_obj(listening_obj, src, message_pieces, verb)
 	/*
 	for(var/obj/O in listening_obj)
@@ -434,7 +434,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		if(get_turf(M) in hearturfs)
 			listening |= M
 
-	// SS220 EDIT START
+	// SS220 EDIT START - Для корректного воспроизведения ТТС
 	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb)
 	/*pass on the message to objects that can hear us.
 	for(var/obj/O in view(message_range, whisper_loc))

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -309,7 +309,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 	else //Turf, leave speech bubbles to the mob
 		speech_bubble("[bubble_icon][speech_bubble_test]", src, speech_bubble_recipients)
 
-	hear_message_obj(listening_obj, src, message_pieces, verb) // SS220 EDIT - добавляет проверку, что радио канал ещё не был услышан, для воспроизведения звука
+	hear_message_obj(listening_obj, src, message_pieces, verb) // SS220 EDIT - Проверяет, что полученное в радиоканал сообщение мы слышим впервые.
 
 	return TRUE
 
@@ -427,7 +427,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		if(get_turf(M) in hearturfs)
 			listening |= M
 
-	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb) // SS220 EDIT - добавляет проверку, что радио канал ещё не был услышан, для воспроизведения звука
+	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb) // SS220 EDIT - Проверяет, что полученное в радиоканал сообщение мы слышим впервые.
 
 	var/list/eavesdropping = hearers(eavesdropping_range, whisper_loc)
 	eavesdropping -= src

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -309,14 +309,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 	else //Turf, leave speech bubbles to the mob
 		speech_bubble("[bubble_icon][speech_bubble_test]", src, speech_bubble_recipients)
 
-	// SS220 EDIT START - Для корректного воспроизведения ТТС
-	hear_message_obj(listening_obj, src, message_pieces, verb)
-	/*
-	for(var/obj/O in listening_obj)
-		spawn(0) // KILL THIS
-			if(O) //It's possible that it could be deleted in the meantime.
-				O.hear_talk(src, message_pieces, verb)
-	SS220 EDIT END */
+	hear_message_obj(listening_obj, src, message_pieces, verb) // SS220 EDIT - добавляет проверку, что радио канал ещё не был услышан, для воспроизведения звука
 
 	return TRUE
 
@@ -434,14 +427,7 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		if(get_turf(M) in hearturfs)
 			listening |= M
 
-	// SS220 EDIT START - Для корректного воспроизведения ТТС
-	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb)
-	/*pass on the message to objects that can hear us.
-	for(var/obj/O in view(message_range, whisper_loc))
-		spawn(0)
-			if(O)
-				O.hear_talk(src, message_pieces, verb)
-	SS220 EDIT END */
+	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb) // SS220 EDIT - добавляет проверку, что радио канал ещё не был услышан, для воспроизведения звука
 
 	var/list/eavesdropping = hearers(eavesdropping_range, whisper_loc)
 	eavesdropping -= src

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -309,10 +309,14 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 	else //Turf, leave speech bubbles to the mob
 		speech_bubble("[bubble_icon][speech_bubble_test]", src, speech_bubble_recipients)
 
+	// SS220 EDIT START
+	hear_message_obj(listening_obj, src, message_pieces, verb)
+	/*
 	for(var/obj/O in listening_obj)
 		spawn(0) // KILL THIS
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message_pieces, verb)
+	SS220 EDIT END */
 
 	return TRUE
 
@@ -430,11 +434,14 @@ GLOBAL_LIST_EMPTY(channel_to_radio_key)
 		if(get_turf(M) in hearturfs)
 			listening |= M
 
-	//pass on the message to objects that can hear us.
+	// SS220 EDIT START
+	hear_message_obj(view(message_range, whisper_loc), src, message_pieces, verb)
+	/*pass on the message to objects that can hear us.
 	for(var/obj/O in view(message_range, whisper_loc))
 		spawn(0)
 			if(O)
 				O.hear_talk(src, message_pieces, verb)
+	SS220 EDIT END */
 
 	var/list/eavesdropping = hearers(eavesdropping_range, whisper_loc)
 	eavesdropping -= src

--- a/modular_ss220/text_to_speech/_tts.dme
+++ b/modular_ss220/text_to_speech/_tts.dme
@@ -13,6 +13,7 @@
 #include "code/tts_component.dm"
 #include "code/tts_preferences.dm"
 #include "code/tts_provider.dm"
+#include "code/tts_radio.dm"
 #include "code/tts_seed.dm"
 #include "code/tts_subsystem.dm"
 #include "code/tts_surgery.dm"

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -1,15 +1,15 @@
-/obj/item/radio/talk_into(mob/living/M, list/message_pieces, channel, verbage)
+/obj/item/radio/talk_into(mob/living/Mob, list/message_pieces, channel, verbage)
 	return FALSE
 
-/proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
+/proc/hear_message_obj(list/listening_obj, mob/Mob, list/message_pieces, verbage)
 	var/list/transmited_channels = list()
 	for(var/obj/obj in listening_obj)
 		spawn(0) // KILL THIS
 			if(obj) // It's possible that it could be deleted in the meantime.
 				if(isradio(obj))
 					var/obj/item/radio/radio = obj
-					if(radio.broadcasting && get_dist(radio, M) <= radio.canhear_range && !(radio.frequency in transmited_channels))
-						if(radio.talk_into(M, message_pieces, null, verbage))
+					if(radio.broadcasting && get_dist(radio, Mob) <= radio.canhear_range && !(radio.frequency in transmited_channels))
+						if(radio.talk_into(Mob, message_pieces, null, verbage))
 							transmited_channels += radio.frequency
 				else
-					obj.hear_talk(M, message_pieces, verbage)
+					obj.hear_talk(Mob, message_pieces, verbage)

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -1,15 +1,15 @@
-/obj/item/radio/beacon/talk_into(verbage)
+/obj/item/radio/talk_into(mob/living/M, list/message_pieces, channel, verbage)
 	return FALSE
 
 /proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
 	var/list/transmited_channels = list()
-	for(var/obj/O in listening_obj)
+	for(var/obj/obj in listening_obj)
 		spawn(0) // KILL THIS
-			if(O) // It's possible that it could be deleted in the meantime.
-				if(isradio(O))
-					var/obj/item/radio/radio = O
+			if(obj) // It's possible that it could be deleted in the meantime.
+				if(isradio(obj))
+					var/obj/item/radio/radio = obj
 					if(radio.broadcasting && get_dist(radio, M) <= radio.canhear_range && !(radio.frequency in transmited_channels))
 						if(radio.talk_into(M, message_pieces, null, verbage))
 							transmited_channels += radio.frequency
 				else
-					O.hear_talk(M, message_pieces, verbage)
+					obj.hear_talk(M, message_pieces, verbage)

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -7,8 +7,9 @@
 /proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
 	var/list/transmited_channels = list()
 	for(var/obj/O in listening_obj)
-		if(!O)
-			continue
+		spawn(0)
+			if(!O)
+				continue
 
 		if(isradio(O))
 			var/obj/item/radio/radio = O

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -1,15 +1,15 @@
-/obj/item/radio/talk_into(mob/living/Mob, list/message_pieces, channel, verbage)
+/obj/item/radio/talk_into(mob/living/M, list/message_pieces, channel, verbage)
 	return FALSE
 
-/proc/hear_message_obj(list/listening_obj, mob/Mob, list/message_pieces, verbage)
+/proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
 	var/list/transmited_channels = list()
-	for(var/obj/obj in listening_obj)
+	for(var/obj/O in listening_obj)
 		spawn(0) // KILL THIS
-			if(obj) // It's possible that it could be deleted in the meantime.
-				if(isradio(obj))
-					var/obj/item/radio/radio = obj
-					if(radio.broadcasting && get_dist(radio, Mob) <= radio.canhear_range && !(radio.frequency in transmited_channels))
-						if(radio.talk_into(Mob, message_pieces, null, verbage))
+			if(O) // It's possible that it could be deleted in the meantime.
+				if(isradio(O))
+					var/obj/item/radio/radio = O
+					if(radio.broadcasting && get_dist(radio, M) <= radio.canhear_range && !(radio.frequency in transmited_channels))
+						if(radio.talk_into(M, message_pieces, null, verbage))
 							transmited_channels += radio.frequency
 				else
-					obj.hear_talk(Mob, message_pieces, verbage)
+					O.hear_talk(M, message_pieces, verbage)

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -5,11 +5,10 @@
 	return ..()
 
 /proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
-	var/list/transmited_channels = list()
+	var/list/transmitted_channels = list()
 	for(var/obj/O in listening_obj)
-		spawn(0)
-			if(!O)
-				continue
+		if(!O)
+			continue
 
 		if(isradio(O))
 			var/obj/item/radio/radio = O
@@ -17,9 +16,9 @@
 				continue
 			if(get_dist(radio, M) > radio.canhear_range)
 				continue
-			if(radio.frequency in transmited_channels)
+			if(radio.frequency in transmitted_channels)
 				continue
-			if(radio.talk_into(M, message_pieces, null, verbage))
-				transmited_channels += radio.frequency
+			transmitted_channels += radio.frequency
+			INVOKE_ASYNC(O, TYPE_PROC_REF(/obj/item/radio, talk_into), M, message_pieces, null, verbage)
 		else
-			O.hear_talk(M, message_pieces, verbage)
+			INVOKE_ASYNC(O, TYPE_PROC_REF(/obj, hear_talk), M, message_pieces, verbage)

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -1,0 +1,15 @@
+/obj/item/radio/beacon/talk_into(verbage)
+	return FALSE
+
+/proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
+	var/list/transmited_channels = list()
+	for(var/obj/O in listening_obj)
+		spawn(0) // KILL THIS
+			if(O) // It's possible that it could be deleted in the meantime.
+				if(isradio(O))
+					var/obj/item/radio/radio = O
+					if(radio.broadcasting && get_dist(radio, M) <= radio.canhear_range && !(radio.frequency in transmited_channels))
+						if(radio.talk_into(M, message_pieces, null, verbage))
+							transmited_channels += radio.frequency
+				else
+					O.hear_talk(M, message_pieces, verbage)

--- a/modular_ss220/text_to_speech/code/tts_radio.dm
+++ b/modular_ss220/text_to_speech/code/tts_radio.dm
@@ -1,15 +1,24 @@
 /obj/item/radio/talk_into(mob/living/M, list/message_pieces, channel, verbage)
-	return FALSE
+	if(!M || !message_pieces)
+		return FALSE
+
+	return ..()
 
 /proc/hear_message_obj(list/listening_obj, mob/M, list/message_pieces, verbage)
 	var/list/transmited_channels = list()
 	for(var/obj/O in listening_obj)
-		spawn(0) // KILL THIS
-			if(O) // It's possible that it could be deleted in the meantime.
-				if(isradio(O))
-					var/obj/item/radio/radio = O
-					if(radio.broadcasting && get_dist(radio, M) <= radio.canhear_range && !(radio.frequency in transmited_channels))
-						if(radio.talk_into(M, message_pieces, null, verbage))
-							transmited_channels += radio.frequency
-				else
-					O.hear_talk(M, message_pieces, verbage)
+		if(!O)
+			continue
+
+		if(isradio(O))
+			var/obj/item/radio/radio = O
+			if(!radio.broadcasting)
+				continue
+			if(get_dist(radio, M) > radio.canhear_range)
+				continue
+			if(radio.frequency in transmited_channels)
+				continue
+			if(radio.talk_into(M, message_pieces, null, verbage))
+				transmited_channels += radio.frequency
+		else
+			O.hear_talk(M, message_pieces, verbage)


### PR DESCRIPTION
## Что этот PR делает

Убирает двойное проигрывание ТТСа, от персонажа и частот

ПР - перенос закрытого ПРа с оффов

## Почему это хорошо для игры

Звучит приятнее, закрытие ишуя

## Изображения изменений

Нету

## Тестирование

Только проверил компиляцию игры, это изменение проблематично проверить локально

## Changelog

:cl:
tweak: Теперь не слышно голоса дважды, если ваш собеседник на частоте стоит перед вами
/:cl: