### PR TITLE
Senior as respawnable NPC

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -46561,10 +46561,7 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage/eva)
 "euu" = (
-/mob/living/basic/nian_caterpillar{
-	name = "Сеньйор";
-	desc = "Мотылёк. Обожает светочи. Знает всю атмосферику, но из-за своего скверного характера не расскажет, даже если бы мог говорить."
-	},
+/mob/living/basic/nian_caterpillar/senior,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},

--- a/_maps/map_files220/stations/deltastation.dmm
+++ b/_maps/map_files220/stations/deltastation.dmm
@@ -4738,10 +4738,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/mob/living/basic/nian_caterpillar{
-	name = "Сеньйор";
-	desc = "Мотылёк. Обожает светочи. Знает всю атмосферику, но из-за своего скверного характера не расскажет, даже если бы мог говорить."
-	},
+/mob/living/basic/nian_caterpillar/senior,
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos/control)

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -37986,10 +37986,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/mob/living/basic/nian_caterpillar{
-	name = "Сеньйор";
-	desc = "Мотылёк. Обожает светочи. Знает всю атмосферику, но из-за своего скверного характера не расскажет, даже если бы мог говорить."
-	},
+/mob/living/basic/nian_caterpillar/senior,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
 "fQQ" = (

--- a/modular_ss220/mobs/code/simple_animal/named_animals.dm
+++ b/modular_ss220/mobs/code/simple_animal/named_animals.dm
@@ -154,3 +154,10 @@
 	health = 20
 	unique_pet = TRUE
 	gold_core_spawnable = NO_SPAWN
+
+/mob/living/basic/nian_caterpillar/senior
+	name = "Сеньор"
+	desc = "Мотылёк. Обожает светочи. Знает всю атмосферику, но из-за своего скверного характера не расскажет, даже если бы мог говорить."
+
+/mob/living/basic/nian_caterpillar/senior/valid_respawn_target_for(mob/user)
+	return TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Делает питомца-моль атмосферников доступным для вселения через Respawn as NPC.

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Больше мобов для гостов это круто. Моли это круто.

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений

<img width="526" height="414" alt="image" src="https://github.com/user-attachments/assets/df22ba10-a4ee-432f-a5a5-4af4d963bfa6" />
<img width="171" height="120" alt="image" src="https://github.com/user-attachments/assets/1dfa9e02-4581-42c7-a6c1-86fc4811a50f" />

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Картинки все доказывают

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Сеньор теперь доступен для выбора через меню "Respawn as NPC"
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
