### PR TITLE
TWEAK: Mapping light helper

### DIFF
--- a/modular_ss220/maps220/code/directions.dm
+++ b/modular_ss220/maps220/code/directions.dm
@@ -181,7 +181,6 @@ MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/nightshifted)
 
 MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/small/nightshifted)
 
-MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/small/nightshifted)
 MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light)
 MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/spot)
 MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/built)

--- a/modular_ss220/maps220/code/directions.dm
+++ b/modular_ss220/maps220/code/directions.dm
@@ -146,31 +146,49 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 24, 24)
 	dir = 8
 
 /* Light Fixtures */
+
+#define MAPPING_DIRECTIONAL_LIGHT_HELPERS(path) \
+##path/directional/north {\
+	dir = NORTH; \
+	pixel_x = 0; \
+	pixel_y = 20; \
+} \
+##path/directional/south {\
+	dir = SOUTH; \
+	pixel_x = 0; \
+	pixel_y = 0; \
+} \
+##path/directional/east {\
+	dir = EAST; \
+	pixel_x = 8; \
+	pixel_y = 4; \
+} \
+##path/directional/west {\
+	dir = WEST; \
+	pixel_x = -8; \
+	pixel_y = 4; \
+}
+
 /obj/machinery/light/nightshifted
 	nightshift_allowed = FALSE
 	nightshift_enabled = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/nightshifted, 0, 0)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/nightshifted)
 
 /obj/machinery/light/small/nightshifted
 	nightshift_allowed = FALSE
 	nightshift_enabled = TRUE
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/nightshifted, 0, 0)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/small/nightshifted)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light, 0, 0)
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/spot, 0, 0)
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/built, 0, 0)
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small, 0, 0)
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/built, 0, 0)
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_construct, 0, 0)
-
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_construct/small, 0, 0)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/small/nightshifted)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/spot)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/built)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/small)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light/small/built)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light_construct)
+MAPPING_DIRECTIONAL_LIGHT_HELPERS(/obj/machinery/light_construct/small)
 
 /* Extinguisher */
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/extinguisher_cabinet, 32, 32)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

Мб фигово сделал, но вроде это работает. Сделал дефайн (заменяя оффовский) на изменение осей светильников при маппинге.

## Почему это хорошо для игры

Сразу видно где фигня получается

## Изображения изменений
<img width="1107" height="807" alt="image" src="https://github.com/user-attachments/assets/afb24a66-8968-4421-9007-26e7c981cc48" />


<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
