### PR TITLE
TWEAK: Улучшения и фиксы электросети | Цереброн

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -6625,8 +6625,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/engine_foyer)
@@ -7430,18 +7430,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/ne)
-"aUR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/engine_foyer)
 "aUT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7725,10 +7713,10 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/obj/structure/cable/extra_insulated{
+/obj/machinery/power/apc/reinforced/directional/west,
+/obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/reinforced/directional/west,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine_foyer)
 "aWv" = (
@@ -8197,6 +8185,9 @@
 /obj/machinery/power/smes/engineering,
 /obj/effect/turf_decal/tiles/department/engineering/side,
 /obj/machinery/light/directional/south,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
 "aYW" = (
@@ -8298,6 +8289,10 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
 "aZJ" = (
@@ -18378,7 +18373,6 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "0-8"
 	},
-/obj/effect/mapping_helpers/turfs/damage,
 /obj/machinery/power/apc/reinforced/directional/east,
 /turf/simulated/floor/wood,
 /area/station/maintenance/starboard)
@@ -20757,6 +20751,10 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/empty,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "cgY" = (
@@ -20815,10 +20813,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "chf" = (
-/obj/machinery/power/smes{
-	capacity = 9e+006;
-	charge = 10000
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "0-8"
 	},
@@ -20829,6 +20823,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tiles/dark/corner,
+/obj/machinery/power/smes/empty,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "chi" = (
@@ -21038,8 +21033,14 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -21155,6 +21156,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "ciB" = (
@@ -21197,11 +21201,12 @@
 /area/station/command/office/ce)
 "ciH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
@@ -56510,9 +56515,6 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -56520,6 +56522,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
@@ -57460,9 +57465,6 @@
 /area/station/hallway/secondary/exit)
 "naG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/monitor{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -57474,6 +57476,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tiles/dark/corner,
+/obj/machinery/computer/monitor{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "naR" = (
@@ -62614,6 +62619,9 @@
 /obj/machinery/atmospherics/binary/pump{
 	name = "Mix to Turbine"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "oVI" = (
@@ -64726,8 +64734,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "pMD" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/smes)
 "pMT" = (
@@ -70390,6 +70401,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "rQB" = (
@@ -73521,6 +73535,7 @@
 "tdA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "tdI" = (
@@ -75436,12 +75451,12 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
 "tVa" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/power/apc/reinforced/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
 "tVd" = (
@@ -85566,14 +85581,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
@@ -127463,7 +127478,7 @@ axh
 cCr
 bVM
 bXt
-ovR
+fTV
 arr
 axh
 fcB
@@ -127686,7 +127701,7 @@ aGC
 hgN
 aGC
 czW
-aUR
+aGC
 aGC
 eTX
 ccz

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -7713,10 +7713,10 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/obj/machinery/power/apc/reinforced/directional/west,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/directional/west,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine_foyer)
 "aWv" = (
@@ -75450,10 +75450,10 @@
 "tVa" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/power/apc/reinforced/directional/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
 "tVd" = (

--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -8284,9 +8284,6 @@
 	dir = 5
 	},
 /obj/structure/cable/extra_insulated{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
 /obj/structure/cable/extra_insulated{

--- a/_maps/map_files220/stations/submaps/metastation.dmm
+++ b/_maps/map_files220/stations/submaps/metastation.dmm
@@ -4243,15 +4243,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/control)
-"Tu" = (
-/obj/machinery/power/apc/reinforced/directional/north,
-/obj/effect/turf_decal/stripes/end,
-/obj/machinery/firealarm/directional/west,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engimaint)
 "Tz" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Cooling Loop";
@@ -4417,10 +4408,10 @@
 "Vf" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/power/apc/reinforced/directional/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/apc/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
 "Vk" = (
@@ -6591,7 +6582,7 @@ qR
 qR
 we
 PQ
-Tu
+Vf
 in
 aP
 aP

--- a/_maps/map_files220/stations/submaps/metastation.dmm
+++ b/_maps/map_files220/stations/submaps/metastation.dmm
@@ -760,7 +760,7 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
 "in" = (
-/obj/structure/cable/extra_insulated{
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -4247,7 +4247,7 @@
 /obj/machinery/power/apc/reinforced/directional/north,
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/firealarm/directional/west,
-/obj/structure/cable/extra_insulated{
+/obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
@@ -4415,12 +4415,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space/nearstation)
 "Vf" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "0-2"
-	},
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/power/apc/reinforced/directional/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engimaint)
 "Vk" = (


### PR DESCRIPTION
## Что этот PR делает

Общие улучшения и исправления электросети Цереброна.
Добавлен один основной СМЕС в инженерный отдел для равномерного распределения питания по всей станции.
Добавлен СМЕС к турбине и оба переделаны в буферные (разряжены раундстартом).

## Почему это хорошо для игры

Улучшение карты и приведение к логике других карт.

## Изображения изменений

Mapdiff

## Тестирование

Локальный сервер.
Всё работает корректно.

## Changelog

:cl:
add: Добавлен основной инженерный СМЕС | Цереброн
add: Добавлен буферный СМЕС турбины | Цереброн
tweak: Исправлена проводка у инженерного ПОДа на обычную  | Цереброн
tweak: Развернута консоль на подстанции мед. отдела | Цереброн
tweak: ЛКП в фойе двигателя теперь подключен к СМЕСам | Цереброн
tweak: ЛКП в техах над турбиной теперь корректно подключен к сети | Цереброн
/:cl: