### PR TITLE
[TM][DO NOT MERGE] FIX: DNA Machine disappeared after building in the wrong place

### DIFF
--- a/code/game/machinery/machine_frame.dm
+++ b/code/game/machinery/machine_frame.dm
@@ -249,6 +249,8 @@
 		return TRUE
 	I.play_tool_sound(src)
 	var/obj/machinery/new_machine = new circuit.build_path(loc)
+	if(QDELETED(new_machine))
+		return TRUE
 	new_machine.on_construction()
 	for(var/obj/O in new_machine.component_parts)
 		qdel(O)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

мэрда машина не исчезает. Крута. 
Это надо на апстрим

## Почему это хорошо для игры

Я не знаю

## Тестирование

DA

## Changelog

:cl:
fix: ДНК машина не исчезает после попытки установки в "неправильном" месте
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
