### PR TITLE
FIX: Исправление привязки камер кузнеца и эксплореров | Цереброн

### DIFF
--- a/_maps/map_files220/stations/metastation.dmm
+++ b/_maps/map_files220/stations/metastation.dmm
@@ -32421,8 +32421,7 @@
 "dTf" = (
 /obj/machinery/camera{
 	c_tag = "Smith's Office";
-	dir = 4;
-	network = list("SS13","MiniSat")
+	dir = 4
 	},
 /obj/machinery/status_display/supply_display/directional/north,
 /obj/item/eftpos,
@@ -57912,8 +57911,7 @@
 /obj/machinery/suit_storage_unit/expedition,
 /obj/machinery/camera{
 	c_tag = "Expedition Room";
-	dir = 4;
-	network = list("SS13","MiniSat")
+	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tiles/department/cargo/side{


### PR DESCRIPTION
## Что этот PR делает

Исправляет привязку камер у кузнеца и эксплореров.

## Почему это хорошо для игры

[Фиксит данный багрепорт](https://discord.com/channels/1097181193939730453/1528377656062775399)

## Тестирование

Локальный сервер.
На MiniSat telescreen больше данные камеры не посмотреть.

## Changelog

:cl:
fix: Цереброн: инженеры больше не смогут смотреть реалити-шоу кузнеца и эксплореров на MiniSat телевизоре
/:cl: