### PR TITLE
REMAP: OmegaStation | Disposals fixes and some tweaks

### DIFF
--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -1303,13 +1303,11 @@
 /area/station/hallway/primary/aft)
 "adZ" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "aea" = (
@@ -1437,7 +1435,6 @@
 /turf/simulated/wall,
 /area/station/maintenance/starboard)
 "aek" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -1446,6 +1443,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
@@ -1718,6 +1718,9 @@
 /obj/effect/turf_decal/siding/wood/oak/corner,
 /obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
 	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
@@ -2028,6 +2031,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/supply/qm)
 "afP" = (
@@ -2292,7 +2296,20 @@
 "agw" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "agx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2927,7 +2944,7 @@
 "aie" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor/west{
-	id = "QMLoad2";
+	id = "QMLoad3";
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3116,7 +3133,7 @@
 /area/station/engineering/solar/aft_port)
 "aiM" = (
 /obj/machinery/conveyor/west{
-	id = "QMLoad2";
+	id = "QMLoad3";
 	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3391,6 +3408,8 @@
 	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "ajs" = (
@@ -3402,7 +3421,6 @@
 	dir = 5
 	},
 /obj/structure/largecrate,
-/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "ajt" = (
@@ -3697,6 +3715,12 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel/side,
 /area/station/hallway/primary/central/north)
+"akl" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 6
+	},
+/turf/simulated/floor/wood/parquet/oak,
+/area/station/security/detective)
 "akn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -3848,7 +3872,7 @@
 /area/station/supply/miningdock)
 "akQ" = (
 /obj/machinery/conveyor/southwest/ccw{
-	id = "QMLoad2"
+	id = "QMLoad3"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3951,6 +3975,7 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "alh" = (
@@ -4836,21 +4861,8 @@
 	},
 /area/station/supply/lobby)
 "aog" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
+/turf/simulated/wall,
 /area/station/maintenance/aft)
 "aoh" = (
 /obj/machinery/photocopier,
@@ -5162,6 +5174,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/maintcentral)
 "apc" = (
@@ -5705,7 +5718,6 @@
 "aqN" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6443,11 +6455,11 @@
 "att" = (
 /obj/structure/dresser,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 5
-	},
 /obj/item/storage/lockbox/spy_kit{
 	pixel_y = 10
+	},
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
 	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
@@ -6815,17 +6827,10 @@
 /area/station/science/robotics/chargebay)
 "aul" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/conveyor/east{
-	id = "QMLoad2";
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "auo" = (
@@ -6847,9 +6852,6 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
 "auu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/structure/table/wood,
 /obj/machinery/computer/secure_data/laptop{
 	dir = 1;
@@ -6896,6 +6898,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "auB" = (
@@ -6936,10 +6941,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	sort_type_txt = "9"
-	},
 /obj/effect/turf_decal/tiles/department/virology/side,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "auM" = (
@@ -7112,6 +7117,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
+	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "avp" = (
@@ -7186,17 +7194,15 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "avz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
@@ -7204,12 +7210,12 @@
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
@@ -7220,11 +7226,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
 "avD" = (
-/obj/machinery/economy/vending/detdrobe,
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "avF" = (
@@ -7240,6 +7249,9 @@
 /obj/item/detective_scanner,
 /obj/effect/turf_decal/siding/wood/oak,
 /obj/machinery/alarm/directional/south,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "avH" = (
@@ -7254,7 +7266,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/directional/south,
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "avJ" = (
@@ -7694,7 +7708,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/storage/fancy/donut_box,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/classic/normal{
 	dir = 4;
@@ -7962,9 +7975,12 @@
 "axR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sort_type_txt = "21"
 	},
 /turf/simulated/floor/plasteel{
 	heat_capacity = 1e+006
@@ -9292,21 +9308,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
 "aBV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/tiles/department/virology/checker,
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "aBW" = (
@@ -10093,11 +10102,12 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	sort_type_txt = "20";
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
@@ -10221,7 +10231,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
 "aEF" = (
-/obj/effect/turf_decal/delivery/hollow,
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/random/maintenance,
 /obj/item/clothing/mask/breath,
@@ -10281,11 +10290,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction/reversed{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/cloning)
@@ -10484,6 +10493,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "aFi" = (
@@ -11130,15 +11140,6 @@
 /area/station/security/brig)
 "aGZ" = (
 /obj/effect/turf_decal/loading_area,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aHa" = (
@@ -11179,6 +11180,18 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/cloning)
+"aHe" = (
+/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/effect/turf_decal/delivery/hollow,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "aHf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11270,9 +11283,7 @@
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "aHv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aHx" = (
@@ -11337,12 +11348,8 @@
 /turf/simulated/wall,
 /area/station/engineering/break_room)
 "aHC" = (
-/obj/structure/table/wood,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/economy/vending/bardrobe,
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/bar)
 "aHG" = (
@@ -11442,17 +11449,20 @@
 /obj/effect/spawner/random/trash,
 /obj/effect/spawner/random/trash,
 /obj/effect/spawner/random/trash,
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "aHX" = (
 /obj/machinery/economy/vending/genedrobe,
 /obj/machinery/door_control/shutter/east{
 	id = "geneticsbot";
-	name = "Genetics Privacy Shutters"
+	name = "Genetics Privacy Shutters";
+	pixel_y = 6
 	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 5
+	},
+/obj/machinery/light_switch/east{
+	pixel_y = -6
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -11981,8 +11991,12 @@
 /area/station/science/toxins/mixing)
 "aIV" = (
 /obj/machinery/alarm/directional/south,
-/obj/structure/sink/kitchen/directional/south,
 /obj/effect/turf_decal/tiles/dark/checker,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "aIX" = (
@@ -12416,8 +12430,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/turbine)
 "aJU" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -12450,18 +12467,19 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/kitchen)
 "aKc" = (
 /obj/machinery/fishtank/wall{
 	opacity = 1
 	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/wall,
 /area/station/service/kitchen)
 "aKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -12471,6 +12489,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "aKf" = (
@@ -12727,22 +12746,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "aKX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "aKY" = (
 /obj/effect/mapping_helpers/turfs/rust/probably,
@@ -12876,11 +12885,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/department/science/corner,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "aLr" = (
@@ -12892,9 +12901,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 6
@@ -13486,7 +13492,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -13550,9 +13555,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/genetics,
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /obj/effect/turf_decal/tiles/department/science,
@@ -13707,6 +13709,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aNT" = (
@@ -13738,6 +13746,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -13856,22 +13865,28 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "aOl" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp/cmo{
-	pixel_x = 10
-	},
-/obj/machinery/computer/med_data/laptop{
-	dir = 8;
-	pixel_x = -2;
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/item/folder/white{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_y = -4;
+	pixel_x = -4
+	},
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_x = 7;
+	pixel_y = 6
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
@@ -13980,12 +13995,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -13993,6 +14002,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aOG" = (
@@ -14024,15 +14039,17 @@
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aOK" = (
-/obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 4
+	},
 /obj/structure/bed/dogbed/runtime,
 /mob/living/simple_animal/pet/cat/runtime,
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "aOL" = (
@@ -14144,22 +14161,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/glass,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 4;
-	pixel_y = 15
-	},
-/obj/item/folder/white{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = -5
-	},
-/obj/item/toy/plushie/crewmanplushie{
-	pixel_x = 8;
-	pixel_y = -3
-	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "aPa" = (
@@ -14236,9 +14238,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aPg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aPi" = (
@@ -14414,28 +14414,23 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tiles/department/medical/side,
+/obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aPA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/medical{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/turf_decal/tiles/department/command,
-/obj/machinery/door/firedoor{
-	dir = 4
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 10
 	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/medical/morgue)
+/obj/structure/disposalpipe/sortjunction{
+	sort_type_txt = "10"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/storage)
 "aPB" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -14452,10 +14447,6 @@
 /turf/simulated/floor/carpet/black,
 /area/station/procedure/trainer_office)
 "aPD" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/fire{
@@ -14473,6 +14464,12 @@
 	},
 /obj/effect/turf_decal/tiles/department/medical/side,
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/computer/guestpass{
+	pixel_y = -32
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aPF" = (
@@ -14978,10 +14975,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aRo" = (
-/obj/machinery/alarm/directional/south,
-/obj/effect/turf_decal/tiles/department/command/side,
-/obj/machinery/photocopier,
-/obj/machinery/light/directional/south,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "aRs" = (
@@ -15151,9 +15147,6 @@
 "aRZ" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen Coldroom";
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -15721,6 +15714,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "aTM" = (
@@ -15765,8 +15761,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dust,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	sort_type_txt = "24"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "aTQ" = (
@@ -16064,7 +16062,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -16331,14 +16328,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/server)
-"aVH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	icon_state = "freezerfloor"
-	},
-/area/station/service/kitchen)
 "aVJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -16404,12 +16393,23 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
 "aVW" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding,
-/obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	sort_type_txt = "17"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "aVZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16867,10 +16867,10 @@
 /area/station/medical/medbay)
 "aXq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 9
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16915,10 +16915,10 @@
 /turf/simulated/wall,
 /area/station/public/toilet/unisex)
 "aXy" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/structure/bookcase/manuals/medical,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/library)
 "aXz" = (
@@ -16998,15 +16998,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "aXP" = (
-/obj/structure/table,
-/obj/item/defibrillator/loaded{
-	pixel_y = 8
-	},
-/obj/item/defibrillator/loaded,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/suit_storage_unit/cmo/sec_storage/secure,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aXQ" = (
@@ -17030,10 +17026,10 @@
 /obj/item/handheld_defibrillator,
 /obj/item/handheld_defibrillator,
 /obj/item/handheld_defibrillator,
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 5
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aXS" = (
@@ -17095,6 +17091,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tiles/jobs/bar/checker,
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
 "aYh" = (
@@ -17400,6 +17397,7 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "aYZ" = (
@@ -17435,17 +17433,6 @@
 /obj/effect/turf_decal/tiles/department/medical/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
-"aZr" = (
-/obj/structure/dresser,
-/obj/structure/sign/nanotrasen{
-	pixel_y = -32
-	},
-/obj/item/toy/figure/crew/chaplain{
-	pixel_x = 8;
-	pixel_y = 9
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
 "aZt" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -17604,6 +17591,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/medical,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aZG" = (
@@ -17618,6 +17608,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
@@ -17800,13 +17793,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "ban" = (
-/obj/machinery/dnaforensics,
 /obj/effect/turf_decal/delivery/blue/hollow,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/machinery/microscope{
+	pixel_y = 8
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/detective)
@@ -18186,6 +18182,9 @@
 	dir = 5
 	},
 /obj/item/flag/rnd,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
 "bbK" = (
@@ -18365,6 +18364,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
+"bcy" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/chapel/office)
 "bcA" = (
 /obj/machinery/door_control/shutter/west{
 	id = "innerdisposal";
@@ -18379,6 +18386,11 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/maintenance/asmaint)
 "bcE" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/bar)
 "bcG" = (
@@ -18702,7 +18714,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm/directional/west,
-/obj/item/flag/rnd,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel{
 	icon_state = "sepia"
 	},
@@ -19113,9 +19126,6 @@
 /obj/vehicle/janicart,
 /obj/item/storage/bag/trash,
 /obj/item/key/janitor,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -19183,12 +19193,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light_switch/south,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "sepia"
 	},
 /area/station/command/office/rd)
 "bey" = (
-/obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 4
 	},
@@ -19199,6 +19211,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "beA" = (
@@ -19228,6 +19241,9 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "beC" = (
@@ -19241,6 +19257,7 @@
 /area/station/supply/lobby)
 "beD" = (
 /obj/machinery/firealarm/directional/south,
+/obj/item/flag/rnd,
 /turf/simulated/floor/plasteel{
 	icon_state = "sepia"
 	},
@@ -19248,6 +19265,9 @@
 "beE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -19407,6 +19427,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/science/corner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
@@ -19749,26 +19772,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
-"bfT" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/crematorium,
-/obj/effect/landmark/spawner/rev,
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
 "bfU" = (
-/obj/machinery/alarm/directional/east,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/obj/machinery/light/small/directional/south,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
 "bfX" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/landmark/start/assistant,
@@ -19911,25 +19921,6 @@
 /obj/structure/table/wood/fancy,
 /obj/item/nullrod,
 /obj/machinery/light/small/directional/north,
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
-"bgD" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/camera{
-	c_tag = "Crematorium";
-	dir = 4
-	},
-/obj/machinery/crema_switch{
-	pixel_x = -26
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
-"bgE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/office)
 "bgH" = (
@@ -20338,48 +20329,55 @@
 /turf/simulated/floor/engine,
 /area/station/science/xenobiology)
 "bhP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft)
-"bhZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/table,
+/obj/item/lighter{
+	pixel_x = 8;
+	pixel_y = 3
 	},
+/obj/item/cigbutt{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/item/ashtray/glass{
+	pixel_x = -5
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
+"bhW" = (
+/obj/effect/spawner/window/reinforced/tinted/grilled,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/science/genetics)
+"bhZ" = (
+/obj/machinery/light_switch/north,
 /obj/machinery/camera{
 	c_tag = "Chaplain's Quarters"
 	},
-/obj/structure/bed/dogbed/pet,
-/mob/living/simple_animal/pet/cat/black/salem,
-/obj/machinery/light_switch/north,
-/obj/machinery/newscaster/directional/west,
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
-"bic" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/table/wood,
+/obj/item/kirbyplants/small{
+	pixel_y = 10
 	},
 /turf/simulated/floor/wood/fancy/oak,
+/area/station/service/chapel/office)
+"bic" = (
+/obj/machinery/door/airlock/service/glass{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/office)
 "bid" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20393,35 +20391,6 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/wood/fancy/oak,
-/area/station/service/chapel/office)
-"bie" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/camera{
-	c_tag = "Chapel Office"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small/directional/north,
-/turf/simulated/floor/wood/fancy/oak,
-/area/station/service/chapel/office)
-"bif" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel/office)
 "big" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -20605,35 +20574,17 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/cloning)
 "biL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 10
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/obj/machinery/light_switch/south,
-/turf/simulated/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/wood/fancy/oak,
 /area/station/service/chapel/office)
-"biM" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/service/glass,
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/obj/machinery/status_display/directional/north,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel)
 "biN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -20758,18 +20709,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
 "bji" = (
+/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/grimey,
-/area/station/service/chapel/office)
-"bjj" = (
-/obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/lighter/zippo/black{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel/office)
 "bjk" = (
@@ -20869,11 +20813,9 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/ntrep)
 "bjy" = (
-/obj/machinery/alarm/directional/west,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel/office)
 "bjz" = (
@@ -20924,22 +20866,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
 "bjJ" = (
-/obj/machinery/photocopier,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/radio/intercom/directional/west,
-/turf/simulated/floor/carpet/grimey,
-/area/station/service/chapel/office)
-"bjK" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/noticeboard{
-	desc = "A board for remembering the fallen of the station.";
-	dir = 1;
-	name = "memorial board";
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/light/directional/south,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel/office)
 "bjL" = (
@@ -21403,12 +21334,10 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/siding/wood/oak,
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "bne" = (
@@ -21763,6 +21692,19 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
+"buC" = (
+/obj/machinery/conveyor/east{
+	id = "QMLoad3";
+	dir = 8
+	},
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "buH" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/stripes/line,
@@ -21820,6 +21762,13 @@
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"bvu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "bvI" = (
 /obj/item/pickaxe/emergency,
 /turf/simulated/floor/plating/asteroid/airless,
@@ -22188,6 +22137,12 @@
 /obj/effect/turf_decal/tiles/dark/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "bFb" = (
@@ -22225,6 +22180,13 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"bGZ" = (
+/obj/machinery/alarm/directional/south,
+/obj/effect/turf_decal/tiles/department/command/side,
+/obj/machinery/light/directional/south,
+/obj/machinery/papershredder,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "bHl" = (
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
@@ -22555,13 +22517,11 @@
 	pixel_y = 24;
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "bRW" = (
@@ -22743,18 +22703,18 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
 "bXg" = (
-/obj/machinery/door/airlock/service{
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "bXD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -22920,17 +22880,33 @@
 	},
 /turf/simulated/floor/engine/n2,
 /area/station/engineering/atmos)
+"cct" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/light_switch/south,
+/turf/simulated/floor/wood/fancy/oak,
+/area/station/service/chapel/office)
 "ccv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "ccA" = (
-/obj/machinery/alarm/directional/west,
-/obj/machinery/photocopier,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 10
 	},
+/obj/machinery/alarm/directional/west,
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "ccC" = (
@@ -23454,6 +23430,24 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"crE" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/lighter/zippo/black{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/item/paper_bin{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/chapel/office)
 "cse" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
@@ -24230,6 +24224,9 @@
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "cTu" = (
@@ -24277,6 +24274,7 @@
 /obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "cUK" = (
@@ -24770,13 +24768,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "dlY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -24784,6 +24776,12 @@
 	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
@@ -25057,14 +25055,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "dvS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sort_type_txt = "23"
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -25188,6 +25190,7 @@
 	dir = 1
 	},
 /obj/machinery/economy/vending/medidrobe,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "dAY" = (
@@ -25304,12 +25307,15 @@
 "dDQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/junction/reversed,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 2;
+	sort_type_txt = "2"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
@@ -25543,6 +25549,18 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
+"dRS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "Detective"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/detective)
 "dRW" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -25675,14 +25693,10 @@
 /area/station/science/hallway)
 "dWw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/oil/often,
-/obj/structure/closet/crate/engineering/electrical,
-/obj/item/stack/cable_coil/ten,
-/obj/item/stock_parts/cell{
-	maxcharge = 2000
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "QMLoad2"
 	},
-/obj/item/apc_electronics,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "dXv" = (
@@ -26099,6 +26113,14 @@
 "elq" = (
 /turf/simulated/wall,
 /area/station/supply/smith_office)
+"ema" = (
+/obj/machinery/alarm/directional/south,
+/obj/item/reagent_containers/drinks/bottle/holywater,
+/obj/item/reagent_containers/drinks/bottle/holywater,
+/obj/item/reagent_containers/drinks/bottle/holywater,
+/obj/structure/closet/secure_closet/chaplain,
+/turf/simulated/floor/wood/fancy/oak,
+/area/station/service/chapel/office)
 "eme" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Pure to Port"
@@ -26508,6 +26530,7 @@
 "eAn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dust,
+/obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "eAv" = (
@@ -26760,6 +26783,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
+"eIa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/port)
 "eIn" = (
 /obj/effect/turf_decal/tiles/department/command/corner{
 	dir = 8
@@ -26775,15 +26810,15 @@
 	},
 /area/station/service/kitchen)
 "eIG" = (
-/obj/machinery/photocopier/faxmachine/longrange{
-	pixel_y = 4;
-	department = "Quartermaster's Office"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood/oak{
+/obj/machinery/computer/security/mining{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/oak/corner{
 	dir = 8
 	},
-/obj/machinery/light/directional/west,
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "eIH" = (
@@ -26864,25 +26899,15 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/control)
 "eLW" = (
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/computer/supplycomp{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 8
-	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "eMb" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
@@ -27100,6 +27125,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
+"eUn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/barrier/grille_often,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
 "eUD" = (
 /obj/machinery/atmospherics/portable/canister/oxygen,
 /turf/simulated/floor/plasteel,
@@ -27168,6 +27198,22 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
+"eXq" = (
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "eXV" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -27811,6 +27857,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "fsI" = (
@@ -27855,6 +27907,13 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"fts" = (
+/obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 5
+	},
+/turf/simulated/floor/wood/parquet/oak,
+/area/station/security/detective)
 "ftt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28222,10 +28281,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/command/teleporter)
 "fHS" = (
-/obj/structure/filingcabinet/security,
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 6
 	},
+/obj/machinery/economy/vending/detdrobe,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/detective)
 "fHZ" = (
@@ -28292,6 +28351,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/command/office/rd)
 "fIY" = (
@@ -28405,6 +28467,7 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "fNN" = (
@@ -28827,6 +28890,17 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"gak" = (
+/obj/structure/noticeboard{
+	desc = "A board for remembering the fallen of the station.";
+	dir = 1;
+	name = "memorial board";
+	pixel_y = -32
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/photocopier,
+/turf/simulated/floor/carpet/grimey,
+/area/station/service/chapel/office)
 "gam" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -29125,6 +29199,15 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/lawoffice)
+"gmj" = (
+/obj/effect/spawner/window/reinforced/polarized/grilled{
+	id = "CMO"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/command/office/cmo)
 "gml" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery/blue/hollow,
@@ -29307,15 +29390,18 @@
 "grX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/medical{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment/corner{
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/turf_decal/tiles/department/command,
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
 "gsh" = (
@@ -29331,6 +29417,14 @@
 /obj/structure/sign/command/head,
 /turf/simulated/floor/plating,
 /area/station/command/office/hop)
+"gsy" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "gsJ" = (
 /obj/structure/reagent_dispensers/beerkeg/nuke,
 /obj/item/disk/nuclear/training,
@@ -29383,6 +29477,19 @@
 /obj/machinery/alarm/directional/west,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"gug" = (
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/conveyor/east{
+	id = "QMLoad2";
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "gum" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -29858,6 +29965,7 @@
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "gJA" = (
@@ -29874,10 +29982,6 @@
 /area/station/command/office/captain/bedroom)
 "gKe" = (
 /obj/machinery/keycard_auth/directional/west,
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/chief_medical_officer,
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
 	},
@@ -30122,31 +30226,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "gTr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/aft)
 "gUe" = (
 /obj/effect/turf_decal/stripes/line{
@@ -30225,23 +30314,6 @@
 	icon_state = "seadeep"
 	},
 /area/station/maintenance/asmaint)
-"gWr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	sort_type_txt = "25"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft)
 "gWx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30386,6 +30458,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
+"hdG" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "hdQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -30902,10 +30980,15 @@
 	},
 /area/station/hallway/primary/central/north)
 "hxo" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/grimey,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm/directional/west,
+/turf/simulated/floor/wood/fancy/oak,
 /area/station/service/chapel/office)
 "hxz" = (
 /obj/structure/sign/cargo/mail,
@@ -30939,6 +31022,27 @@
 /obj/machinery/light/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
+"hzn" = (
+/obj/machinery/conveyor/east{
+	id = "QMLoad3";
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
+"hzP" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "hzQ" = (
 /obj/structure/table,
 /obj/item/tank/internals/emergency_oxygen,
@@ -31053,6 +31157,18 @@
 /obj/effect/turf_decal/tiles/neutral/corner,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
+"hDx" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/engineering/electrical,
+/obj/effect/spawner/random/oil/often,
+/obj/item/stack/cable_coil/ten,
+/obj/item/stock_parts/cell{
+	maxcharge = 2000
+	},
+/obj/item/apc_electronics,
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "hDK" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -31129,6 +31245,22 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
+"hHy" = (
+/obj/machinery/camera{
+	c_tag = "Chapel Office"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/station/service/chapel/office)
 "hHL" = (
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/junglebush/large,
@@ -31404,6 +31536,9 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "hRA" = (
@@ -31631,6 +31766,23 @@
 /obj/machinery/firealarm/directional/west,
 /turf/simulated/floor/plasteel/dark,
 /area/station/science/storage)
+"hVO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "hWD" = (
 /obj/effect/landmark{
 	icon = 'icons/effects/spawner_icons.dmi';
@@ -31708,6 +31860,11 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
+"hZC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "hZN" = (
 /obj/machinery/shower/directional/west,
 /turf/simulated/floor/plasteel,
@@ -31729,9 +31886,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	sort_type_txt = "13"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/hallway)
@@ -31980,6 +32139,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"ihT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "iiW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm/directional/north,
@@ -32260,6 +32435,12 @@
 	},
 /mob/living/basic/goat/chef,
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -33098,7 +33279,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -33883,6 +34063,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "jCi" = (
@@ -33957,10 +34140,6 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	sort_type_txt = "6"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -33972,6 +34151,10 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	sort_type_txt = "5"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -34085,11 +34268,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/junction/reversed{
-	dir = 8
-	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
@@ -34381,6 +34564,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/service/kitchen)
 "jWP" = (
@@ -34465,7 +34649,7 @@
 	},
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
-	id = "QMLoad2"
+	id = "QMLoad3"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/cargo/corner{
@@ -34524,6 +34708,22 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/misc_lab)
+"kcd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	sort_type_txt = "16"
+	},
+/turf/simulated/floor/carpet,
+/area/station/service/library)
 "kch" = (
 /turf/simulated/wall,
 /area/station/public/mrchangs)
@@ -34789,10 +34989,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/turbine)
 "kjh" = (
-/obj/machinery/light_switch/south,
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "kjM" = (
@@ -34927,6 +35127,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
+"kpk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ash,
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
 "kpn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35343,6 +35551,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"kDL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/machinery/door/airlock/service{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/aft)
 "kDP" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "paramedic"
@@ -35388,6 +35609,18 @@
 	},
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/hop)
+"kFa" = (
+/obj/machinery/camera{
+	c_tag = "Crematorium";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "kFh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hydroponics/soil,
@@ -35557,6 +35790,20 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
+"kNW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	sort_type_txt = "25"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/medical/morgue)
 "kOx" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/checkpoint/secondary)
@@ -35597,6 +35844,17 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/gravitygenerator)
+"kQG" = (
+/obj/structure/dresser,
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/obj/item/toy/figure/crew/chaplain{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood/fancy/oak,
+/area/station/service/chapel/office)
 "kQI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -36024,6 +36282,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
+"ldn" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/crema_switch{
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "ldv" = (
 /obj/machinery/power/apc/directional/west,
 /obj/structure/disposalpipe/segment/corner{
@@ -36466,8 +36734,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "lzT" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash,
+/obj/effect/spawner/random/cobweb/right/frequent,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "lAF" = (
@@ -36715,27 +36983,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"lLF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
-/obj/effect/mapping_helpers/turfs/damage,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft)
 "lLH" = (
 /obj/structure/sink/directional/east,
 /obj/structure/mirror{
@@ -37190,24 +37437,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/command/office/hos)
-"lYV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tiles/department/virology/checker,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft)
 "lZe" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -37271,6 +37500,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/landmark/spawner/nukedisc_respawn,
+/obj/structure/disposalpipe/segment/corner,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -37745,7 +37975,6 @@
 "mwt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -37754,6 +37983,10 @@
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sort_type_txt = "22"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
@@ -37779,6 +38012,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/recharge_station,
+/obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "mxz" = (
@@ -37819,6 +38053,18 @@
 "myQ" = (
 /turf/simulated/wall/mineral/titanium,
 /area/station/maintenance/asmaint)
+"mzm" = (
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 6
+	},
+/obj/machinery/alarm/directional/south,
+/obj/structure/table,
+/obj/item/defibrillator/loaded,
+/obj/item/defibrillator/loaded{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/medical/storage)
 "mzr" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -37949,6 +38195,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
+"mBV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "mCa" = (
 /obj/effect/spawner/random/trash,
 /turf/simulated/floor/plating,
@@ -37974,8 +38237,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
@@ -38120,10 +38384,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction/reversed{
-	dir = 1
-	},
 /obj/structure/bookcase/sop,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/library)
 "mHZ" = (
@@ -38265,11 +38529,11 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/important/directional/south,
 /obj/structure/cable/extra_insulated{
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/power/apc/reinforced/important/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "mOV" = (
@@ -38324,6 +38588,15 @@
 	},
 /turf/simulated/floor/plasteel/side,
 /area/station/supply/lobby)
+"mQs" = (
+/obj/effect/turf_decal/tiles/department/cargo/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "mQE" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -38504,24 +38777,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
-"mYl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/effect/turf_decal/tiles/department/virology/checker,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel/white,
-/area/station/maintenance/aft)
 "mZs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -38535,14 +38790,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
-"mZB" = (
-/obj/machinery/alarm/directional/south,
-/obj/item/reagent_containers/drinks/bottle/holywater,
-/obj/item/reagent_containers/drinks/bottle/holywater,
-/obj/item/reagent_containers/drinks/bottle/holywater,
-/obj/structure/closet/secure_closet/chaplain,
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
 "mZM" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor/preopen{
@@ -38815,9 +39062,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/alarm/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "nhU" = (
@@ -38884,6 +39131,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat)
+"nom" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/turf_decal/tiles/dark/checker,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "nop" = (
 /obj/structure/sign/engineering/materials,
 /turf/simulated/wall/r_wall,
@@ -39761,7 +40017,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/economy/vending/bardrobe,
 /obj/machinery/power/apc/directional/south,
 /obj/structure/cable,
 /turf/simulated/floor/wood/fancy/oak,
@@ -39783,6 +40038,8 @@
 	c_tag = "Cargo Bay Disposal";
 	dir = 10
 	},
+/obj/structure/closet/crate/engineering,
+/obj/item/stack/rods/ten,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
 "oap" = (
@@ -39830,6 +40087,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "ocs" = (
@@ -40083,13 +40341,15 @@
 /turf/simulated/floor/catwalk,
 /area/station/security/permabrig)
 "ooG" = (
-/obj/effect/turf_decal/siding/wood/oak{
-	dir = 9
-	},
-/obj/machinery/computer/security/mining{
-	dir = 4
-	},
 /obj/machinery/light_switch/north,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/machinery/photocopier/faxmachine/longrange{
+	pixel_y = 4;
+	department = "Quartermaster's Office"
+	},
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "ooZ" = (
@@ -40149,6 +40409,10 @@
 /area/station/engineering/control)
 "orP" = (
 /obj/machinery/light/directional/east,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/bar)
 "orY" = (
@@ -40324,9 +40588,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
 "ozP" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -40334,6 +40595,10 @@
 	},
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	sort_type_txt = "1";
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
@@ -40480,8 +40745,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sort_type_txt = "11"
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
@@ -40785,6 +41051,15 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
+"oRV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/poster/ripped/directional/east,
+/turf/simulated/floor/catwalk,
+/area/station/maintenance/fsmaint)
 "oSA" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/delivery/green/hollow,
@@ -41371,6 +41646,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
+"piy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "piB" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 1
@@ -41526,6 +41813,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/expedition)
+"pnV" = (
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 9
+	},
+/obj/structure/filingcabinet,
+/turf/simulated/floor/carpet,
+/area/station/supply/qm)
 "poa" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -41768,7 +42062,7 @@
 "pvF" = (
 /obj/structure/disposalpipe/sortjunction/reversed{
 	dir = 8;
-	sort_type_txt = "5"
+	sort_type_txt = "6"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
@@ -42504,6 +42798,20 @@
 /obj/effect/landmark/start/virologist,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/virology/lab)
+"pTn" = (
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "pTH" = (
 /obj/structure/chair{
 	dir = 8
@@ -42849,6 +43157,9 @@
 "qeF" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tiles/dark/checker,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "qeO" = (
@@ -43393,6 +43704,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/neutral/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "qyH" = (
@@ -43454,6 +43768,19 @@
 /obj/structure/sign/security/perma,
 /turf/simulated/wall/r_wall,
 /area/station/security/armory/secure)
+"qBw" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/computer/supplycomp{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 10
+	},
+/turf/simulated/floor/carpet,
+/area/station/supply/qm)
 "qBH" = (
 /obj/effect/mapping_helpers/turfs/rust/maybe,
 /turf/simulated/wall,
@@ -43573,6 +43900,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/nukedisc_respawn,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
 "qFN" = (
@@ -43810,6 +44139,7 @@
 "qQK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -43846,14 +44176,15 @@
 "qRz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/department/cargo/corner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 4;
+	sort_type_txt = "3"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
@@ -44353,6 +44684,9 @@
 "rmq" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/sign/science/toxins,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/science/toxins/mixing)
 "rmN" = (
@@ -44391,10 +44725,6 @@
 /area/station/public/mrchangs)
 "roU" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -44404,6 +44734,10 @@
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "rpr" = (
@@ -44460,6 +44794,16 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/warden)
+"rqj" = (
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "rqz" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -44712,6 +45056,11 @@
 /obj/effect/turf_decal/tiles/department/security,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/permabrig)
+"rAi" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plasteel,
+/area/station/supply/storage)
 "rAj" = (
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/simulated/floor/plating/asteroid/airless,
@@ -44962,9 +45311,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/storage)
 "rKS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 4
 	},
@@ -45367,6 +45713,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/storage/firstaid/aquatic_kit/full,
 /obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -45399,9 +45746,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/lobby)
 "scX" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/delivery/hollow,
-/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "sdk" = (
@@ -45453,6 +45797,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -46487,7 +46834,7 @@
 "sIK" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
-	id = "QMLoad2"
+	id = "QMLoad3"
 	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 28
@@ -46689,6 +47036,9 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/maintenance/maintcentral)
 "sLx" = (
@@ -47401,9 +47751,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboard)
 "sPe" = (
-/obj/structure/disposalpipe/sortjunction{
-	sort_type_txt = "11"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -47415,6 +47762,7 @@
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "sQH" = (
@@ -47532,10 +47880,10 @@
 /area/station/service/kitchen)
 "sWY" = (
 /obj/machinery/newscaster/directional/east,
-/obj/structure/filingcabinet,
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/carpet,
 /area/station/supply/qm)
 "sXk" = (
@@ -47684,6 +48032,21 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"tav" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/turfs/damage,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "tbd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -47754,8 +48117,24 @@
 "tes" = (
 /turf/simulated/wall,
 /area/station/maintenance/fsmaint)
+"tfn" = (
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "tft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel{
@@ -47822,6 +48201,9 @@
 /area/station/engineering/dronefabricator)
 "tgO" = (
 /obj/structure/closet/secure_closet/freezer/products,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	icon_state = "freezerfloor"
 	},
@@ -48255,14 +48637,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "tBb" = (
-/obj/machinery/microscope{
-	pixel_y = 8
-	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/delivery/blue/hollow,
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 5
 	},
+/obj/machinery/dnaforensics,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/detective)
 "tBo" = (
@@ -48709,11 +49088,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"tRI" = (
-/obj/effect/landmark/spawner/xeno,
-/obj/effect/spawner/random/cobweb/right/frequent,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "tRV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48867,7 +49241,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction/reversed,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "tWm" = (
@@ -48930,6 +49304,10 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/fore_starboard)
+"tYd" = (
+/obj/structure/grille,
+/turf/space,
+/area/space)
 "tYn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49027,6 +49405,15 @@
 /obj/effect/landmark/spawner/carp,
 /turf/space,
 /area/space)
+"tZO" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/structure/bed/dogbed/pet,
+/mob/living/simple_animal/pet/cat/black/salem,
+/obj/machinery/newscaster/directional/west,
+/turf/simulated/floor/wood/fancy/oak,
+/area/station/service/chapel/office)
 "uac" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
@@ -49130,14 +49517,24 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "udS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tiles/department/virology/checker,
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "udT" = (
@@ -49178,6 +49575,13 @@
 /obj/item/radio/intercom/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/launch)
+"uem" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/siding/wood/oak{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/station/supply/qm)
 "ueC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel,
@@ -49401,12 +49805,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
-"ulg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/ripped/directional/east,
-/obj/effect/spawner/random/trash,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
 "ulK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
@@ -50885,7 +51283,7 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
 "vjq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "vjz" = (
@@ -50895,12 +51293,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction/y,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
@@ -51214,12 +51614,14 @@
 "vsf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/sortjunction{
+	sort_type_txt = "19"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
@@ -51420,6 +51822,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -52305,6 +52710,22 @@
 "wcu" = (
 /turf/simulated/floor/wood,
 /area/station/public/mrchangs)
+"wcF" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/service/glass,
+/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel)
 "wdh" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/camera{
@@ -52584,6 +53005,14 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
+"wma" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel{
+	heat_capacity = 1e+006
+	},
+/area/station/hallway/primary/central/sw)
 "wml" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
@@ -52597,6 +53026,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
 /obj/effect/landmark/start/chief_medical_officer,
+/obj/item/toy/plushie/crewmanplushie,
 /turf/simulated/floor/carpet/cyan,
 /area/station/command/office/cmo)
 "wnD" = (
@@ -52613,6 +53043,9 @@
 "wop" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/bar)
@@ -52726,6 +53159,11 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"wvC" = (
+/obj/effect/turf_decal/tiles/dark/checker,
+/obj/structure/sink/kitchen/directional/east,
+/turf/simulated/floor/plasteel/white,
+/area/station/service/kitchen)
 "wvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -53198,8 +53636,7 @@
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 1
 	},
-/obj/structure/closet/crate/engineering,
-/obj/item/stack/rods/ten,
+/obj/structure/closet/secure_closet/cargotech,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/supply/sorting)
@@ -53275,6 +53712,9 @@
 	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/east)
@@ -53761,21 +54201,6 @@
 /obj/machinery/status_display/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
-"xht" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/service/glass{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/service/chapel/office)
 "xhE" = (
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fore2)
@@ -53809,8 +54234,10 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/cmo,
-/obj/item/lighter/zippo/cmo,
 /obj/machinery/light_switch/south,
+/obj/item/storage/firstaid/regular{
+	pixel_y = -5
+	},
 /turf/simulated/floor/carpet/cyan,
 /area/station/command/office/cmo)
 "xiS" = (
@@ -53885,6 +54312,24 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/processing)
+"xlo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8;
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/stamp/cmo{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/item/lighter/zippo/cmo{
+	pixel_y = -6;
+	pixel_x = 10
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "xlp" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id_tag = "engsm2";
@@ -53987,6 +54432,7 @@
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 4
 	},
+/obj/machinery/requests_console/directional/east,
 /turf/simulated/floor/plasteel,
 /area/station/supply/office)
 "xot" = (
@@ -54496,6 +54942,16 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
+"xAD" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/portable/canister/sleeping_agent,
+/obj/machinery/atmospherics/unary/portables_connector,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	sort_type_txt = "6"
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/security/permabrig)
 "xAM" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable{
@@ -54543,14 +54999,14 @@
 "xBN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
@@ -54868,6 +55324,27 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
+"xLv" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
+"xLE" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/crematorium,
+/obj/effect/landmark/spawner/rev,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/service/chapel/office)
 "xLJ" = (
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/autoname,
@@ -55081,8 +55558,25 @@
 	name = "Premium Cozy Chair"
 	},
 /obj/effect/landmark/start/artist,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/simulated/floor/carpet,
 /area/station/service/library)
+"xRZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tiles/department/virology/checker,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/white,
+/area/station/maintenance/aft)
 "xSC" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall,
@@ -55498,9 +55992,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -55509,6 +56000,10 @@
 	},
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sort_type_txt = "9"
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
@@ -81531,7 +82026,7 @@ aqy
 aqy
 aqy
 aqy
-fGl
+xAD
 agC
 hOp
 aqJ
@@ -82618,12 +83113,12 @@ uXX
 uXX
 uXX
 uXX
+uXX
 aiU
 xqd
 xqd
 xqd
 aOP
-aog
 agw
 due
 fVD
@@ -82874,24 +83369,24 @@ wnw
 uXX
 byF
 gKe
+rqj
 iYH
 piP
 aGd
 aQh
 vNt
 xqd
-aKX
+hVO
 uas
 ood
 qRW
 qRW
 qRW
-qRW
 bhZ
+tZO
 biF
-aZr
+kQG
 qRW
-aAp
 aAp
 aAp
 hhM
@@ -83112,7 +83607,7 @@ bhM
 asj
 xrR
 mwt
-ulb
+eIa
 aKe
 ulb
 ulb
@@ -83131,13 +83626,14 @@ nLN
 xqS
 bdW
 aOl
+xlo
 aOQ
 piP
 npH
 wTG
 pYG
 xqd
-aog
+eXq
 aap
 qRW
 bgB
@@ -83146,9 +83642,8 @@ bho
 biG
 tGh
 tOQ
-mZB
+ema
 qRW
-hhM
 hhM
 hhM
 hhM
@@ -83380,7 +83875,7 @@ aPY
 aQY
 nUN
 nUN
-vnk
+kcd
 xRW
 uXX
 qyH
@@ -83389,23 +83884,23 @@ uXX
 aOb
 aPF
 aRo
+bGZ
 piP
 tPJ
 aav
 fFY
 xqd
-lYV
+hVO
 qBH
 qRW
 qRW
 qRW
 qRW
-eqB
+qRW
 eqB
 dMv
 eqB
 qRW
-hhM
 hhM
 hhM
 hhM
@@ -83646,23 +84141,23 @@ uXX
 aOZ
 bey
 aOK
+aHe
 piP
 aeZ
 aSo
 gBW
 xqd
-aKX
 aVW
-qRW
-bgC
-bhp
+kDL
+gsy
+kFa
 bic
 hxo
 bji
 bjy
 bjJ
+bcy
 qRW
-hhM
 hhM
 hhM
 hhM
@@ -83890,7 +84385,7 @@ vDo
 jRA
 whH
 dlY
-aKk
+wma
 haE
 aRU
 aTi
@@ -83902,24 +84397,24 @@ uXX
 uXX
 pic
 aOe
-uXX
+pic
+gmj
 qmS
 aRw
 dyg
 lHj
 xqd
-mYl
+hVO
 due
-qRW
-qRW
-qRW
+xLE
+ldn
+pJM
 bid
 biJ
-bjj
+crE
 bjz
-bjK
+gak
 qRW
-hhM
 hhM
 hhM
 hhM
@@ -84147,7 +84642,7 @@ iWq
 aNj
 dez
 roU
-gtl
+aKk
 uIQ
 aSd
 bWw
@@ -84162,21 +84657,21 @@ cTh
 nhL
 aPA
 grX
+kNW
 aQD
 aDn
 rev
-gWr
+ihT
 due
-bfT
-bgD
-pJM
-bie
+qRW
+qRW
+qRW
+hHy
 fSn
 bjk
 bjA
 bjL
 qRW
-hhM
 hhM
 hhM
 hhM
@@ -84417,23 +84912,23 @@ dAQ
 aPg
 aNS
 aPz
+mzm
 xqd
 aPH
 bfD
 aQL
 xqd
-lLF
 bXg
 bfU
-bgE
-xht
-bif
+qRW
+bgC
+bhp
 biL
+cct
 aDt
 aDt
 aDt
 aDt
-hhM
 hhM
 hhM
 hhM
@@ -84680,17 +85175,17 @@ amx
 amx
 amx
 aog
+pTn
 due
 aDt
 aDt
 aDt
 aDt
-biM
+wcF
 aDt
 blC
 dYE
 blI
-hhM
 hhM
 hhM
 hhM
@@ -84926,7 +85421,7 @@ aLA
 aLq
 fNv
 kjh
-tgm
+bhW
 aXP
 aHv
 dvS
@@ -84936,7 +85431,8 @@ bcd
 bcU
 bdQ
 amx
-aog
+kpk
+tav
 due
 bXb
 bbF
@@ -84947,7 +85443,6 @@ xzU
 blD
 blG
 lsJ
-hhM
 hhM
 hhM
 hhM
@@ -85194,6 +85689,7 @@ tCV
 bdR
 amx
 bhP
+mBV
 aVZ
 bhr
 bgH
@@ -85204,7 +85700,6 @@ aDt
 aDt
 aDt
 aDt
-hhM
 hhM
 hhM
 hhM
@@ -85450,7 +85945,8 @@ bcf
 tTC
 bfF
 amx
-aog
+bvu
+xRZ
 due
 bfX
 aOH
@@ -85458,7 +85954,6 @@ esv
 rtf
 nQT
 bjl
-hhM
 hhM
 hhM
 hhM
@@ -85708,6 +86203,7 @@ wHv
 blf
 amx
 aKX
+xRZ
 due
 wSQ
 bgJ
@@ -85715,7 +86211,6 @@ oNe
 bik
 biQ
 bjl
-hhM
 hhM
 hhM
 hhM
@@ -85965,6 +86460,7 @@ rml
 bfr
 amx
 aog
+xRZ
 due
 bfZ
 bgK
@@ -85972,7 +86468,6 @@ kZr
 apP
 biR
 jfH
-hhM
 hhM
 hhM
 hhM
@@ -86221,7 +86716,8 @@ rzJ
 bch
 kxj
 due
-aog
+hZC
+xRZ
 due
 hJy
 qRR
@@ -86229,7 +86725,6 @@ bhw
 wSQ
 qRs
 aDt
-hhM
 hhM
 hhM
 hhM
@@ -86479,6 +86974,7 @@ whI
 auJ
 aUM
 aBV
+tfn
 due
 bgb
 bgM
@@ -86486,7 +86982,6 @@ bhx
 bin
 biT
 aDt
-aLL
 aLL
 aLL
 aLL
@@ -86735,9 +87230,9 @@ bci
 hIK
 bfG
 due
-wDT
-qBH
+eUn
 due
+qBH
 due
 itd
 mrY
@@ -90825,7 +91320,7 @@ asN
 aYo
 bta
 aLi
-aVH
+aLi
 aXM
 bta
 aPr
@@ -91079,7 +91574,7 @@ rit
 daB
 aIO
 awy
-awy
+nom
 aKb
 qQK
 mDe
@@ -92363,7 +92858,7 @@ iWX
 jbF
 hxE
 aiQ
-asN
+wvC
 fnO
 bta
 aRW
@@ -92612,7 +93107,7 @@ nFG
 nFG
 nFG
 nFG
-fsG
+xLv
 nFG
 bta
 bta
@@ -93099,7 +93594,7 @@ mHZ
 tBx
 mHZ
 mHZ
-mHZ
+oRV
 mHZ
 mHZ
 mHZ
@@ -93355,10 +93850,10 @@ aeV
 aeV
 aeV
 aeV
-tRI
-ulg
-lzT
-hfd
+aeV
+aeV
+aeV
+aeV
 lzT
 aPy
 nvt
@@ -93612,9 +94107,9 @@ rML
 tjE
 rvv
 aeV
-aeV
-aeV
-aeV
+pnV
+uem
+qBw
 aeV
 aeV
 vHO
@@ -94904,7 +95399,7 @@ aeV
 aeV
 sfd
 iqt
-wUL
+rAi
 akQ
 aie
 aiM
@@ -95161,8 +95656,8 @@ aKZ
 aiy
 qdS
 dCG
-aih
-gaj
+hzP
+hzn
 vHO
 aiN
 xrX
@@ -95419,7 +95914,7 @@ aiy
 otl
 bej
 ijE
-gaj
+buC
 vHO
 aiO
 irW
@@ -95675,8 +96170,8 @@ azJ
 mQE
 ozP
 pdo
-iJR
-gaj
+scX
+mQs
 lpz
 fKv
 aoh
@@ -95710,9 +96205,9 @@ diI
 kXv
 diI
 hhM
-jmx
-bcj
-agJ
+dRS
+fts
+akl
 sDK
 any
 qql
@@ -95931,7 +96426,7 @@ jvz
 vHO
 hxz
 cUJ
-auw
+piy
 dWw
 aul
 lpz
@@ -95967,9 +96462,9 @@ sIY
 coa
 diI
 aLL
-aLL
-aLL
-aLL
+jmx
+bcj
+agJ
 sDK
 tBb
 ban
@@ -96189,8 +96684,8 @@ vHO
 aee
 hfO
 auw
-aih
-gaj
+hDx
+gug
 lpz
 xAZ
 hmb
@@ -96225,8 +96720,8 @@ loJ
 diI
 aLL
 aLL
-pZU
-pZU
+aLL
+aLL
 sDK
 sdL
 xal
@@ -96482,8 +96977,8 @@ alH
 vWp
 vWp
 aLL
-aLL
-hhM
+pZU
+tYd
 hhM
 hhM
 hhM
@@ -96703,7 +97198,7 @@ vHO
 sNW
 vjq
 aXq
-ijE
+hdG
 kUv
 lpz
 avj

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -24210,9 +24210,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tiles/department/command/side{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
@@ -24221,6 +24218,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -39012,9 +39012,6 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/station/maintenance/apmaint)
 "nhL" = (
-/obj/effect/turf_decal/tiles/department/medical/side{
-	dir = 8
-	},
 /obj/structure/disposalpipe/sortjunction{
 	sort_type_txt = "10"
 	},
@@ -39029,6 +39026,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command/side{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -3897,9 +3897,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -3908,6 +3905,9 @@
 	location = "8.2-AftSE"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "akU" = (
@@ -12840,6 +12840,7 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "aLm" = (
@@ -16055,9 +16056,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aUK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
 	},
@@ -19168,12 +19166,10 @@
 /area/station/science/robotics)
 "beu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
 "bev" = (
@@ -20254,9 +20250,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
@@ -21924,9 +21922,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "bxY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 1
 	},
@@ -39018,9 +39013,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -39029,6 +39021,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -42871,9 +42866,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "pWx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 4
 	},

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -21068,7 +21068,8 @@
 /obj/effect/mapping_helpers/airlock/windoor/access/any/science/xenobio{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel/dark/telecomms,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/plasteel/dark,
 /area/station/science/xenobiology)
 "blh" = (
 /obj/effect/turf_decal/tiles/department/science/side{

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -20851,7 +20851,6 @@
 "bjI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/door/airlock/mining{
 	dir = 4
@@ -24606,7 +24605,6 @@
 "dez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/service/janitor,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54914,16 +54912,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
-"xAD" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/portable/canister/sleeping_agent,
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	sort_type_txt = "6"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/security/permabrig)
 "xAM" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable{
@@ -81998,7 +81986,7 @@ aqy
 aqy
 aqy
 aqy
-xAD
+fGl
 agC
 hOp
 aqJ
@@ -93390,7 +93378,7 @@ xBU
 tyN
 uHp
 oNi
-wJw
+snF
 aXs
 aXs
 aXs

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -397,6 +397,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
 "abh" = (
@@ -1757,13 +1760,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/security/side,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "aeZ" = (
@@ -5688,9 +5691,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -6860,6 +6860,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
 "auv" = (
@@ -19924,12 +19925,10 @@
 "bgH" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/grimey,
 /area/station/service/chapel)
 "bgJ" = (
@@ -23901,6 +23900,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
 "cKH" = (
@@ -25613,14 +25615,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
@@ -36200,6 +36202,9 @@
 	},
 /obj/item/seeds/ambrosia,
 /obj/item/radio/intercom/locked/prison/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
 "lbX" = (
@@ -38650,9 +38655,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -38661,6 +38663,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
@@ -40784,6 +40789,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
@@ -49738,6 +49746,7 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
+/obj/machinery/atmospherics/unary/outlet_injector/on,
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
 "ukj" = (
@@ -50246,14 +50255,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/machinery/light/directional/south,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/security/side,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "uBk" = (
@@ -51169,6 +51178,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/security/permabrig)
@@ -52815,9 +52827,6 @@
 /turf/simulated/wall,
 /area/station/service/janitor)
 "whI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -52831,6 +52840,7 @@
 	dir = 8;
 	location = "Medbay"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "wie" = (

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -46535,7 +46535,7 @@
 /area/station/science/misc_lab)
 "sEr" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/unary/outlet_injector{
+/obj/machinery/atmospherics/unary/outlet_injector/on{
 	dir = 4
 	},
 /turf/space,

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -852,6 +852,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
 "acE" = (
@@ -1144,9 +1147,11 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/junction/y,
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
@@ -1295,7 +1300,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm/directional/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1975,7 +1979,6 @@
 	name = "Atmospherics Lockdown Blast door";
 	id_tag = "atmoslock"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -3804,6 +3807,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "akD" = (
@@ -3890,9 +3894,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "akR" = (
-/obj/structure/disposalpipe/junction/y{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -3906,6 +3907,7 @@
 	codes_txt = "patrol;next_patrol=8.3-AftSW";
 	location = "8.2-AftSE"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "akU" = (
@@ -5157,7 +5159,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -5176,7 +5177,6 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/maintcentral)
 "apc" = (
@@ -5334,6 +5334,7 @@
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "apH" = (
@@ -6167,9 +6168,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 1;
+	sort_type_txt = "4;5;6"
 	},
 /turf/simulated/floor/plasteel{
 	heat_capacity = 1e+006
@@ -6580,7 +6584,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -6982,6 +6985,9 @@
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "auP" = (
@@ -7281,9 +7287,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "avK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
@@ -7697,7 +7700,6 @@
 "axb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
 	},
@@ -7856,6 +7858,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "axD" = (
@@ -7978,10 +7981,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	sort_type_txt = "21"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel{
 	heat_capacity = 1e+006
 	},
@@ -8045,11 +8045,13 @@
 "ayk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/department/science/side,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "ayl" = (
@@ -8497,7 +8499,7 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
@@ -8736,9 +8738,6 @@
 	name = "Сеньйор";
 	desc = "Мотылёк. Обожает светочи. Знает всю атмосферику, но из-за своего скверного характера не расскажет, даже если бы мог говорить."
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8974,6 +8973,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "aBa" = (
@@ -9237,6 +9239,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "aBL" = (
@@ -9352,7 +9355,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 2
 	},
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
@@ -9578,6 +9581,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "aCN" = (
@@ -9792,6 +9796,12 @@
 /obj/effect/turf_decal/tiles/department/virology/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aDm" = (
@@ -9931,9 +9941,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/bar/atrium)
 "aDK" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -9983,14 +9990,15 @@
 /turf/space,
 /area/space)
 "aDR" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 2;
+	sort_type_txt = "4"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
@@ -10342,19 +10350,17 @@
 	},
 /area/station/engineering/solar/fore_starboard)
 "aEU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction/reversed{
+	sort_type_txt = "12;13;14;24"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "aEV" = (
@@ -10458,9 +10464,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -10477,14 +10480,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/virology/corner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	sort_type_txt = "23"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
@@ -10652,6 +10656,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
 "aFH" = (
@@ -10671,6 +10678,9 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 7
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
@@ -10853,6 +10863,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "aGn" = (
@@ -11283,7 +11294,6 @@
 /turf/simulated/floor/catwalk,
 /area/station/maintenance/storage)
 "aHv" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aHx" = (
@@ -11382,6 +11392,7 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "aHO" = (
@@ -11678,14 +11689,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 1;
+	sort_type_txt = "5"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -11954,9 +11966,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/kitchen)
 "aIP" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
 	},
@@ -12051,21 +12060,15 @@
 /turf/simulated/floor/plating,
 /area/station/command/bridge)
 "aJf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "aJg" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/closet/secure_closet/geneticist,
 /obj/item/folder/white,
 /obj/item/clipboard,
@@ -12219,6 +12222,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aJz" = (
@@ -12234,7 +12238,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "aJA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/requests_console/directional/east,
 /obj/structure/table/glass,
 /obj/item/storage/box/monkeycubes/wolpincubes{
@@ -12378,6 +12381,9 @@
 	icon_state = "o1"
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
 	},
@@ -12888,7 +12894,10 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/department/science/corner,
 /obj/structure/disposalpipe/segment/corner{
-	dir = 2
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -12896,14 +12905,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
@@ -12956,9 +12965,9 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/turf/simulated/floor/plasteel{
-	heat_capacity = 1e+006
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "aLB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13081,6 +13090,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aLW" = (
@@ -13096,6 +13108,9 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13181,6 +13196,9 @@
 	dir = 9
 	},
 /obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "aMh" = (
@@ -13495,6 +13513,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "aNk" = (
@@ -14130,9 +14149,6 @@
 /turf/simulated/floor/plating,
 /area/station/service/bar/atrium)
 "aOX" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -14235,6 +14251,9 @@
 /obj/effect/turf_decal/tiles/department/virology/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aPg" = (
@@ -14254,6 +14273,9 @@
 /obj/effect/turf_decal/tiles/department/virology/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aPk" = (
@@ -14265,6 +14287,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
@@ -14616,6 +14641,7 @@
 /area/station/hallway/primary/central/sw)
 "aPZ" = (
 /obj/effect/turf_decal/tiles/department/science/side,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "aQa" = (
@@ -14971,6 +14997,7 @@
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aRo" = (
@@ -15007,9 +15034,6 @@
 /area/station/science/hallway)
 "aRu" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16160,6 +16184,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "aVf" = (
@@ -16567,9 +16592,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -16751,6 +16773,7 @@
 /obj/structure/janitorialcart,
 /obj/machinery/light/small/directional/east,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "aWX" = (
@@ -16851,6 +16874,9 @@
 	},
 /obj/effect/decal/sign_omegastation{
 	icon_state = "o3"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
@@ -17000,7 +17026,6 @@
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/suit_storage_unit/cmo/sec_storage/secure,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -17170,9 +17195,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -17180,6 +17202,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tiles/department/medical/side{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -17349,7 +17374,10 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	sort_type_txt = "6"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "aYP" = (
@@ -17942,6 +17970,7 @@
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "baL" = (
@@ -17966,6 +17995,7 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "baP" = (
@@ -18512,9 +18542,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19216,7 +19243,6 @@
 "beA" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -19264,9 +19290,6 @@
 "beE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -20167,7 +20190,6 @@
 "bhy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20300,12 +20322,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
@@ -20342,11 +20366,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
-"bhW" = (
-/obj/effect/spawner/window/reinforced/tinted/grilled,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/science/genetics)
 "bhZ" = (
 /obj/machinery/light_switch/north,
 /obj/machinery/camera{
@@ -20545,6 +20564,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "biJ" = (
@@ -22135,9 +22155,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/dark/side{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -24618,6 +24635,7 @@
 /obj/machinery/door/airlock/service{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "deG" = (
@@ -24742,6 +24760,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "dlq" = (
@@ -24752,9 +24771,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "dlH" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
 	},
@@ -24779,7 +24795,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -25063,9 +25079,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	sort_type_txt = "23"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -25335,6 +25350,9 @@
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "dFV" = (
@@ -25494,7 +25512,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "dNc" = (
@@ -26374,18 +26391,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "euC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway";
@@ -26905,9 +26910,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "eNX" = (
@@ -27185,9 +27187,6 @@
 "eWM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
@@ -27691,6 +27690,7 @@
 	pixel_x = 0;
 	pixel_y = -2
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "fng" = (
@@ -28382,9 +28382,11 @@
 	codes_txt = "patrol;next_patrol=9.4-EnteringDorms";
 	location = "9.3-Engi"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
@@ -28451,7 +28453,6 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "fNN" = (
@@ -29322,19 +29323,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "gpl" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/effect/turf_decal/tiles/department/science/side,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "gpn" = (
@@ -29625,9 +29617,6 @@
 /area/station/command/office/hos)
 "gzn" = (
 /obj/effect/landmark/start/security_officer,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
 	},
@@ -30007,6 +29996,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "gLk" = (
@@ -30901,6 +30891,9 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "hvC" = (
@@ -31226,6 +31219,16 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tiles/dark/side{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
@@ -31853,6 +31856,17 @@
 /obj/machinery/shower/directional/west,
 /turf/simulated/floor/plasteel,
 /area/station/science/xenobiology)
+"hZY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/neutral/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft)
 "iaa" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33253,6 +33267,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "iWL" = (
@@ -33427,7 +33444,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33501,6 +33517,9 @@
 /obj/machinery/power/apc/directional/north,
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
@@ -34123,9 +34142,8 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	sort_type_txt = "5"
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -34242,8 +34260,8 @@
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
@@ -34264,7 +34282,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "jJy" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
@@ -34941,6 +34958,10 @@
 /obj/effect/turf_decal/tiles/department/virology/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 8;
+	sort_type_txt = "9;10;11;16;17;25"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "kiw" = (
@@ -34963,7 +34984,6 @@
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
 "kjM" = (
@@ -35142,9 +35162,6 @@
 /turf/simulated/floor/plasteel/freezer,
 /area/station/command/office/cmo)
 "krB" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -35341,6 +35358,7 @@
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "kyt" = (
@@ -35470,18 +35488,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
-"kCG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tiles/department/medical/corner{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel,
-/area/station/hallway/primary/aft)
 "kCQ" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -35511,7 +35517,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "kDz" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/light/directional/east,
@@ -35683,6 +35688,15 @@
 /obj/effect/turf_decal/tiles/department/security/side,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonershuttle)
+"kJq" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/autoname,
+/turf/simulated/floor/plating,
+/area/station/maintenance/maintcentral)
 "kJC" = (
 /obj/structure/railing{
 	dir = 4
@@ -36078,9 +36092,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/meter,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -36371,6 +36382,7 @@
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "lho" = (
@@ -36517,6 +36529,9 @@
 /obj/effect/landmark/start/engineer,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
@@ -36818,9 +36833,6 @@
 /area/station/engineering/atmos)
 "lFm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -37672,9 +37684,6 @@
 "mhT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/plaque/goonplaque,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -37683,6 +37692,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tiles/neutral,
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "mim" = (
@@ -37968,10 +37980,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	sort_type_txt = "22"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "mwT" = (
@@ -38242,6 +38251,18 @@
 /obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plating,
 /area/station/supply/sorting)
+"mDB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tiles/department/medical/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plasteel,
+/area/station/hallway/primary/aft)
 "mDU" = (
 /obj/structure/shelf/science,
 /obj/item/storage/box/beakers{
@@ -38506,9 +38527,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
@@ -38688,21 +38706,6 @@
 /obj/structure/sign/engineering,
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
-"mWA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint)
 "mWX" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "arrivalsmaint_door_int";
@@ -40559,15 +40562,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 4;
-	sort_type_txt = "8"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
@@ -40835,6 +40837,18 @@
 /area/station/service/library)
 "oIH" = (
 /obj/item/kirbyplants/large,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "oIK" = (
@@ -40957,6 +40971,9 @@
 "oOC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -41108,15 +41125,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	sort_type_txt = "4"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/delivery/hollow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
 "oUI" = (
@@ -41264,6 +41280,9 @@
 "oXF" = (
 /obj/structure/sink/directional/east,
 /obj/structure/reagent_dispensers/spacecleanertank/directional/east,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/service/janitor)
 "oYJ" = (
@@ -42046,13 +42065,6 @@
 	dir = 4
 	},
 /area/station/supply/lobby)
-"pvF" = (
-/obj/structure/disposalpipe/sortjunction/reversed{
-	dir = 8;
-	sort_type_txt = "6"
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/engineering/atmos)
 "pvW" = (
 /obj/machinery/economy/vending/chinese,
 /obj/effect/turf_decal/tiles/dark/side{
@@ -42229,6 +42241,9 @@
 "pDg" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
@@ -42421,9 +42436,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
@@ -42539,7 +42551,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/maintcentral)
 "pMh" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -42547,6 +42558,9 @@
 	dir = 8;
 	target_pressure = 303;
 	name = "Air to connector"
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
@@ -42875,6 +42889,7 @@
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "pWx" = (
@@ -43223,11 +43238,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/tiles/department/command/half{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 4;
+	sort_type_txt = "15;18"
 	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
@@ -43376,6 +43392,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "qlr" = (
@@ -43410,6 +43427,9 @@
 	},
 /obj/effect/turf_decal/tiles/department/command/half{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
@@ -43560,9 +43580,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -43599,21 +43616,15 @@
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
 "qvi" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/effect/turf_decal/tiles/dark/side{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/se)
 "qvt" = (
@@ -43687,9 +43698,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/neutral/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "qyH" = (
@@ -43903,6 +43911,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "qGi" = (
@@ -44415,9 +44424,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -44426,6 +44432,10 @@
 	},
 /obj/effect/turf_decal/tiles/department/security/side{
 	dir = 8
+	},
+/obj/structure/disposalpipe/sortjunction/reversed{
+	dir = 1;
+	sort_type_txt = "8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
@@ -44716,10 +44726,11 @@
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sort_type_txt = "22"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/sw)
 "rpr" = (
@@ -47114,14 +47125,14 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/tiles/department/command/half{
 	dir = 1
 	},
 /obj/effect/decal/sign_omegastation{
 	icon_state = "o4"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
@@ -47154,7 +47165,6 @@
 /area/station/turret_protected/ai)
 "sMk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47744,7 +47754,9 @@
 /obj/effect/turf_decal/tiles/department/medical/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/junction/reversed{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "sQH" = (
@@ -49359,6 +49371,9 @@
 /obj/effect/turf_decal/tiles/department/command/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/side{
 	dir = 1
 	},
@@ -50144,6 +50159,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "uxm" = (
@@ -50646,6 +50662,9 @@
 /obj/effect/turf_decal/tiles/department/security/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/security/lobby)
 "uOa" = (
@@ -50696,6 +50715,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/break_room)
 "uPA" = (
@@ -51134,6 +51156,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "vfL" = (
@@ -51262,6 +51285,9 @@
 "viU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
 "vjq" = (
@@ -51375,9 +51401,6 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -51804,9 +51827,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -52245,9 +52265,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -52256,6 +52273,10 @@
 	},
 /obj/effect/turf_decal/tiles/department/virology/side{
 	dir = 1
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	sort_type_txt = "21"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
@@ -52985,14 +53006,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
-"wma" = (
-/obj/structure/disposalpipe/segment/corner{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel{
-	heat_capacity = 1e+006
-	},
-/area/station/hallway/primary/central/sw)
 "wml" = (
 /obj/effect/turf_decal/tiles/white/corner{
 	dir = 8
@@ -53659,7 +53672,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/rnd)
 "wOv" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -54856,6 +54868,7 @@
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "xyM" = (
@@ -55879,9 +55892,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "yce" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -55890,6 +55900,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
@@ -80742,7 +80755,7 @@ afJ
 beA
 eWM
 beM
-pvF
+bnS
 jJy
 kDz
 azB
@@ -82021,7 +82034,7 @@ gum
 obo
 hmD
 tNU
-mWA
+pIx
 avN
 pNa
 hSW
@@ -84347,7 +84360,7 @@ aIl
 vLe
 baL
 dGz
-xLv
+kJq
 jXP
 lWe
 aKP
@@ -84355,7 +84368,7 @@ vDo
 jRA
 whH
 dlY
-wma
+gtl
 haE
 aRU
 aTi
@@ -85391,7 +85404,7 @@ aLA
 aLq
 fNv
 kjh
-bhW
+tgm
 aXP
 aHv
 dvS
@@ -88727,23 +88740,23 @@ kiq
 biI
 aRk
 baO
-bhJ
+mDB
 vft
-bhJ
+mDB
 vft
 qGb
 vft
 baK
 xyC
 aYq
-kCG
+bhJ
 sMk
 jdu
 bhy
 bhy
 bhy
 adV
-poi
+hZY
 aWn
 bgR
 bhE

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -15844,7 +15844,7 @@
 	name = "Server Interior Door";
 	superconductivity = 0
 	},
-/turf/simulated/floor/plasteel/dark/telecomms,
+/turf/simulated/floor/plasteel/dark,
 /area/station/telecomms/chamber)
 "aUb" = (
 /obj/item/radio/intercom/directional/east,

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -19955,7 +19955,6 @@
 /area/station/service/chapel)
 "bgM" = (
 /obj/structure/table/wood,
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/item/storage/fancy/candle_box/eternal{
 	pixel_x = -5;
 	pixel_y = 5
@@ -20181,17 +20180,17 @@
 /area/station/hallway/primary/aft)
 "bhz" = (
 /obj/machinery/alarm/directional/north,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
@@ -20370,9 +20369,6 @@
 /obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -20473,13 +20469,21 @@
 	pixel_y = 3
 	},
 /obj/item/storage/fancy/candle_box/full,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/chapel)
 "bip" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/neutral/corner{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
@@ -32493,19 +32497,9 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/chemistry)
 "itd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/service/glass,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plasteel,
+/obj/structure/sign/service/chapel,
+/obj/effect/spawner/window/reinforced/grilled,
+/turf/simulated/floor/plating,
 /area/station/service/chapel)
 "itm" = (
 /obj/structure/table/wood,
@@ -37889,8 +37883,18 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/ntrep)
 "mrY" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/sign/service/chapel,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/service/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/service/chapel)
 "msb" = (

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -3875,7 +3875,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "akP" = (
 /turf/simulated/wall,
@@ -36820,7 +36820,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "lFE" = (
 /obj/structure/cable{

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -14395,7 +14395,6 @@
 /area/station/hallway/primary/central/se)
 "aPy" = (
 /obj/machinery/light/small/directional/east,
-/obj/effect/landmark/spawner/xeno,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aPz" = (

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -3719,6 +3719,9 @@
 /obj/effect/turf_decal/siding/wood/oak{
 	dir = 6
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
 "akn" = (
@@ -4860,10 +4863,6 @@
 	dir = 1
 	},
 /area/station/supply/lobby)
-"aog" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall,
-/area/station/maintenance/aft)
 "aoh" = (
 /obj/machinery/photocopier,
 /obj/effect/turf_decal/tiles/department/cargo/side{
@@ -22143,9 +22142,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "bFb" = (
@@ -27853,21 +27849,6 @@
 "fsl" = (
 /turf/simulated/wall/mineral/titanium,
 /area/shuttle/arrival/station)
-"fsG" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/maintcentral)
 "fsI" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/chair/office,
@@ -32438,9 +32419,6 @@
 	},
 /mob/living/basic/goat/chef,
 /obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42487,10 +42465,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"pJM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/wall,
-/area/station/service/chapel/office)
 "pJU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -43903,7 +43877,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/spawner/nukedisc_respawn,
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/maintcentral)
@@ -49307,10 +49280,6 @@
 /obj/structure/sign/securearea,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/fore_starboard)
-"tYd" = (
-/obj/structure/grille,
-/turf/space,
-/area/space)
 "tYn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -84380,7 +84349,7 @@ aIl
 vLe
 baL
 dGz
-fsG
+xLv
 jXP
 lWe
 aKP
@@ -84411,7 +84380,7 @@ hVO
 due
 xLE
 ldn
-pJM
+qRW
 bid
 biJ
 crE
@@ -85177,7 +85146,7 @@ amx
 amx
 amx
 amx
-aog
+due
 pTn
 due
 aDt
@@ -86462,7 +86431,7 @@ rml
 rml
 bfr
 amx
-aog
+due
 xRZ
 due
 bfZ
@@ -96979,9 +96948,9 @@ bdV
 alH
 vWp
 vWp
-aLL
 pZU
-tYd
+pZU
+hhM
 hhM
 hhM
 hhM

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -11197,7 +11197,7 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 4
+	dir = 1
 	},
 /obj/machinery/disposal,
 /obj/effect/turf_decal/delivery/hollow,
@@ -13728,10 +13728,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel/white,
@@ -13813,28 +13814,6 @@
 /obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
-"aOe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/effect/mapping_helpers/airlock/polarized{
-	id = "CMO"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/command/cmo/glass{
-	id_tag = "cmoofficedoor"
-	},
-/obj/effect/turf_decal/tiles/department/command,
-/turf/simulated/floor/plasteel/dark,
-/area/station/command/office/cmo)
 "aOf" = (
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
@@ -13884,12 +13863,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "aOl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/item/folder/white{
 	pixel_x = -7;
 	pixel_y = 5
@@ -13907,6 +13880,7 @@
 	pixel_x = 7;
 	pixel_y = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "aOm" = (
@@ -14027,6 +14001,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aOG" = (
@@ -14067,8 +14044,16 @@
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 4
 	},
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "aOL" = (
@@ -14442,7 +14427,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aPA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14450,9 +14434,8 @@
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 10
 	},
-/obj/structure/disposalpipe/sortjunction{
-	sort_type_txt = "10"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aPB" = (
@@ -14497,14 +14480,9 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aPF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/hologram/holopad,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
@@ -15003,6 +14981,15 @@
 "aRo" = (
 /obj/structure/chair/office{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
@@ -19230,14 +19217,9 @@
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/runtime,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "beA" = (
@@ -24226,15 +24208,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "cTh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -24243,6 +24216,12 @@
 	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -25076,11 +25055,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
@@ -29184,15 +29163,6 @@
 	},
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/legal/lawoffice)
-"gmj" = (
-/obj/effect/spawner/window/reinforced/polarized/grilled{
-	id = "CMO"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/command/office/cmo)
 "gml" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery/blue/hollow,
@@ -39043,15 +39013,24 @@
 /turf/simulated/floor/plating/asteroid/airless,
 /area/station/maintenance/apmaint)
 "nhL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/tiles/department/medical/side{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sortjunction{
+	sort_type_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "nhU" = (
@@ -52449,6 +52428,31 @@
 /obj/effect/turf_decal/tiles/white/corner,
 /turf/simulated/floor/plasteel,
 /area/station/public/locker)
+"vSh" = (
+/obj/effect/mapping_helpers/airlock/polarized{
+	id = "CMO"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/machinery/door/airlock/command/cmo/glass{
+	id_tag = "cmoofficedoor"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/turf_decal/tiles/department/command,
+/turf/simulated/floor/plasteel/dark,
+/area/station/command/office/cmo)
 "vSj" = (
 /turf/simulated/wall/r_wall,
 /area/station/science/genetics)
@@ -54305,7 +54309,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/processing)
 "xlo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
 	dir = 8;
@@ -54319,6 +54322,12 @@
 /obj/item/lighter/zippo/cmo{
 	pixel_y = -6;
 	pixel_x = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
@@ -84379,9 +84388,9 @@ rOi
 uXX
 uXX
 pic
-aOe
 pic
-gmj
+vSh
+pic
 qmS
 aRw
 dyg

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -9799,9 +9799,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/south)
 "aDm" = (
@@ -13881,6 +13878,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/office/cmo)
 "aOm" = (

--- a/_maps/map_files220/stations/submaps/omegastation.dmm
+++ b/_maps/map_files220/stations/submaps/omegastation.dmm
@@ -1379,7 +1379,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "oF" = (
 /obj/effect/turf_decal/delivery/hollow,
@@ -2682,7 +2682,7 @@
 	dir = 4
 	},
 /obj/effect/spawner/window/reinforced/plasma/grilled,
-/turf/simulated/floor/plating/asteroid/airless,
+/turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "AY" = (
 /obj/effect/turf_decal/tiles/department/engineering/side{


### PR DESCRIPTION
## Что этот PR делает

Переработка пневмосистемы Георгониса:
- добавлены новые сортировочные точки и байпасс карго;
- добавлены недостающие мусорки на точки, куда можно отправить посылку tagger'ом или через консоль запросов.

Добавление недостающих объектов:
- шкафы для карготехов;
- модсьют для медиков.

Микрофиксы:
- ЛКП в техах над атмосом заменён на изолированный вариант.

Немного расширены офисы СМО и КМ.

## Почему это хорошо для игры

Фиксы и улучшения - всегда хорошо.

## Изображения изменений

Mapdiff

## Тестирование

Локальный сервер.
Посылки доставляются по любым меткам корректно. 
Работает байпасс сортировки карго.

## Changelog

:cl:
add: Георгонис: добавлены шкафы карготехов
add: Георгонис: добавлен modsuit storage на склад мед. отдела
fix: Георгонис: пневмосистема теперь корректно доставляет посылки в любую точку
fix: Георгонис: ЛКП в техах атмосферики больше не бьёт током
/:cl:
