### PR TITLE
MAPFIX: BoxStation | Moved smith's shutters button + CC-level fixes

### DIFF
--- a/_maps/map_files220/generic/centcomm.dmm
+++ b/_maps/map_files220/generic/centcomm.dmm
@@ -337,14 +337,14 @@
 /turf/simulated/floor/carpet/black,
 /area/centcom/ss220/admin2)
 "alh" = (
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/hatch/syndicate{
 	name = "Oneway Syndicate Hatch";
 	auto_close_time = 16;
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/plating,
 /area/ghost_bar/indoor)
 "als" = (
 /obj/structure/table/wood,
@@ -22583,9 +22583,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/syndicate_mothership)
-"kcY" = (
-/turf/simulated/floor/plating,
-/area/vox_base)
 "kdg" = (
 /obj/structure/table/abductor,
 /obj/effect/spawner/random/ccfood/dessert,
@@ -27071,7 +27068,7 @@
 /turf/simulated/floor/wood/ebonite,
 /area/syndicate_mothership/infteam)
 "lYu" = (
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/plating,
 /area/ghost_bar/outdoor)
 "lZc" = (
 /obj/structure/holowindow{
@@ -42945,12 +42942,12 @@
 /turf/simulated/floor/transparent/glass/titanium/plasma,
 /area/centcom/ss220/admin2)
 "too" = (
+/obj/structure/fans/tiny/invisible,
 /obj/machinery/door/airlock/hatch{
 	name = "тебе сюда нельзя";
 	dir = 4
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/simulated/floor/plating/airless,
+/turf/simulated/floor/plating,
 /area/ghost_bar/outdoor)
 "top" = (
 /obj/item/flag/nt,
@@ -104815,8 +104812,8 @@ xzf
 eRV
 hhJ
 hhJ
-kcY
-kcY
+mzr
+mzr
 hhJ
 oCR
 enh

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -82260,6 +82260,12 @@
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 5
 	},
+/obj/machinery/door_control{
+	id = "smithdesk";
+	name = "Smith's Desk Shutters Control";
+	pixel_y = 24;
+	req_access = list(49)
+	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
 "qat" = (
@@ -92578,13 +92584,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "trR" = (
-/obj/machinery/door_control{
-	id = "smithdesk";
-	name = "Smith's Desk Shutters Control";
-	pixel_x = 24;
-	pixel_y = 23;
-	req_access = list(49)
-	},
 /obj/structure/chair/office/dark{
 	dir = 4
 	},

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -82260,12 +82260,6 @@
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 5
 	},
-/obj/machinery/door_control{
-	id = "smithdesk";
-	name = "Smith's Desk Shutters Control";
-	pixel_y = 24;
-	req_access = list(49)
-	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
 "qat" = (
@@ -92589,6 +92583,13 @@
 	},
 /obj/effect/turf_decal/tiles/department/cargo/side{
 	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "smithdesk";
+	name = "Smith's Desk Shutters Control";
+	pixel_y = 32;
+	req_access = list(49);
+	pixel_x = -16
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)


### PR DESCRIPTION
## Что этот PR делает

Фикс данных тикетов трекера:
- https://discord.com/channels/1097181193939730453/1531719718480777267
- https://discord.com/channels/1097181193939730453/1531722699141943316

## Почему это хорошо для игры

Фиксы - всегда хорошо.

## Изображения изменений

MapDiff

## Тестирование

Локальный сервер.
Все работает корректно.

## Changelog

:cl:
fix: Силами НТ была ликвидирована разгерма на базе вокиксов-рейдеров.
fix: Проход в синди-зону гостбара больше не наносит урон.
fix: Кибериада: кнопка шаттеров лавки кузнеца перенесена.
/:cl: