### PR TITLE
Исправление кривой разметки чертежами

### DIFF
--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -244,8 +244,10 @@
 /obj/item/areaeditor/proc/check_tile_is_border(turf/T2, dir)
 	if(isspaceturf(T2))
 		return BORDER_SPACE //omg hull breach we all going to die here
-	if(get_area_type(T2.loc)!=AREA_SPACE)
-		return BORDER_BETWEEN
+	// SS220 EDIT START - Исправление кривой разметки, убрана проверка на зоны
+	//if(get_area_type(T2.loc)!=AREA_SPACE)
+	//return BORDER_BETWEEN
+	// SS220 EDIT END
 	if(iswallturf(T2))
 		return BORDER_2NDTILE
 	if(ismineralturf(T2))

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -188,7 +188,6 @@
 	A.powernet.lighting_powered = FALSE
 	A.powernet.environment_powered = FALSE
 	A.always_unpowered = FALSE
-	A.set_dynamic_lighting()
 
 	for(var/i in 1 to length(turfs))
 		var/turf/thing = turfs[i]
@@ -206,6 +205,8 @@
 	message_admins("A new room was made by [key_name_admin(usr)] at [ADMIN_VERBOSEJMP(usr)] with the name [str]")
 	log_game("A new room was made by [key_name(usr)] at [AREACOORD(usr)] with the name [str]")
 	area_created = TRUE
+	A.set_dynamic_lighting(DYNAMIC_LIGHTING_DISABLED)
+	A.set_dynamic_lighting(DYNAMIC_LIGHTING_ENABLED)
 	return area_created
 
 /obj/item/areaeditor/proc/edit_area()

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -188,6 +188,7 @@
 	A.powernet.lighting_powered = FALSE
 	A.powernet.environment_powered = FALSE
 	A.always_unpowered = FALSE
+	// SS220 EDIT - FIX: Прок изменения динамического освещения перенесён ниже. Удалено: A.set_dynamic_lighting()
 
 	for(var/i in 1 to length(turfs))
 		var/turf/thing = turfs[i]
@@ -205,8 +206,12 @@
 	message_admins("A new room was made by [key_name_admin(usr)] at [ADMIN_VERBOSEJMP(usr)] with the name [str]")
 	log_game("A new room was made by [key_name(usr)] at [AREACOORD(usr)] with the name [str]")
 	area_created = TRUE
+
+	// SS220 EDIT START - FIX: Прок сброса и установки динамического освещения новой зоны для избежания конфликта освещения между территориями.
 	A.set_dynamic_lighting(DYNAMIC_LIGHTING_DISABLED)
 	A.set_dynamic_lighting(DYNAMIC_LIGHTING_ENABLED)
+	//SS220 EDIT END
+
 	return area_created
 
 /obj/item/areaeditor/proc/edit_area()


### PR DESCRIPTION
## Что этот PR делает

Убирает проверку на зоны при поиске границ разметки, тем самым разрешает перезапись. Поиск ведется только на стены/стёкла/шлюзы.
Также для новой зоны идет переустановка динамического освещения.

## Почему это хорошо для игры

Фиксы - всегда хорошо.

## Тестирование

Локальный сервер.
Сделал отсек в космосе не пересечении нескольких зон (asteroid, near-station, outer space). 
Оградил стенами, окнами, шлюзами.
На зоне космоса внутри отсека создал новую зону - весь отсек корректно разметился и произошла перезапись других зон внутри. Изменение всех подзон изменилось корректно.

## Changelog

:cl:
fix: Исправлена разметка чертежами.
/:cl:
