### PR TITLE
Antidrop_melee

### DIFF
--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -25,3 +25,12 @@
 #include "code/species/machine.dm"
 #include "code/species/skrell.dm"
 #include "code/species/kidan_nymph.dm"
+// BEGIN_INTERNALS
+// END_INTERNALS
+// BEGIN_FILE_DIR
+#define FILE_DIR .
+// END_FILE_DIR
+// BEGIN_PREFERENCES
+// END_PREFERENCES
+// BEGIN_INCLUDE
+// END_INCLUDE

--- a/modular_ss220/balance/_balance.dme
+++ b/modular_ss220/balance/_balance.dme
@@ -25,12 +25,3 @@
 #include "code/species/machine.dm"
 #include "code/species/skrell.dm"
 #include "code/species/kidan_nymph.dm"
-// BEGIN_INTERNALS
-// END_INTERNALS
-// BEGIN_FILE_DIR
-#define FILE_DIR .
-// END_FILE_DIR
-// BEGIN_PREFERENCES
-// END_PREFERENCES
-// BEGIN_INCLUDE
-// END_INCLUDE

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -233,13 +233,11 @@
 
 /obj/item/push_broom/traitor/wield(obj/item/source, mob/living/carbon/user)
 	set_nodrop(TRUE, user)
-	to_chat(user, SPAN_NOTICE("Вы прочно взяли [src] в обе руки."))
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(sweep))
+	. = ..()
 
 /obj/item/push_broom/traitor/unwield(obj/item/source, mob/living/carbon/user)
 	set_nodrop(FALSE, user)
-	to_chat(user, SPAN_NOTICE("Вы расслабили хватку на [src]."))
-	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+	. = ..()
 
 
 

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -25,9 +25,6 @@
 	return FALSE
 
 
-
-
-
 /obj/item/melee/energy
 	var/sharpening_allowed = FALSE
 
@@ -121,14 +118,14 @@
 	is_breaching = TRUE
 
 	user.visible_message(
-		SPAN_DANGER("[user] заносит [src] для удара по [wall]!"),
-		SPAN_DANGER("Вы готовитесь нанести мощный удар по [wall].")
+		SPAN_WARNING("[user] заносит [src] для удара по [wall]!"),
+		SPAN_WARNING("Вы готовитесь нанести мощный удар по [wall].")
 	)
 
 	if(!do_after(user, 2 SECONDS, needhand = TRUE, target = wall, progress = TRUE))
 		user.visible_message(
-			SPAN_DANGER("[user] бросает затею ломать [wall]."),
-			SPAN_DANGER("Вы бросаете затею ломать [wall].")
+			SPAN_WARNING("[user] бросает затею ломать [wall]."),
+			SPAN_WARNING("Вы бросаете затею ломать [wall].")
 		)
 
 		is_breaching = FALSE
@@ -248,13 +245,13 @@
 
 /obj/item/melee/breach_cleaver
 	restricted_species = list(/datum/species/unathi)
-	restriction_message = "Мышцы пронзает сильный холод и выбросаете попытку взять [src] в обе руки. Только истинный Воин \
+	restriction_message = "Мышцы пронзает сильный холод и выбросаете попытку взять Тесак Прорыва в обе руки. Только истинный Воин \
 	достоин иметь столь сильный клинок!"
-
+/*
 /obj/item/melee/breach_cleaver/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_try_wield))
-
+*/
 /obj/item/melee/breach_cleaver/proc/on_try_wield(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 	if(can_use(user))
@@ -287,11 +284,11 @@
 		user.Confused(4 SECONDS)
 		return FINISH_ATTACK
 
-/obj/item/melee/breach_cleaver/throw_at(atom/target, range, speed, mob/living/user, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)
-	if(user && !can_use(user))
-		to_chat(user, SPAN_DANGER("Клинок слишком тяжёлый, чтобы его можно было так просто кинуть! Вы не рассчитываете \
+/obj/item/melee/breach_cleaver/throw_at(atom/target, range, speed, mob/living/thrower, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)
+	if(thrower && !can_use(thrower))
+		to_chat(thrower, SPAN_DANGER("Клинок слишком тяжёлый, чтобы его можно было так просто кинуть! Вы не рассчитываете \
 		свои силы и в момент броска с треском падаете."))
-		user.KnockDown(1 SECONDS)
+		thrower.KnockDown(1 SECONDS)
 		range = min(range, 2)
 	return ..()
 

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -247,11 +247,11 @@
 	restricted_species = list(/datum/species/unathi)
 	restriction_message = "Мышцы пронзает сильный холод и выбросаете попытку взять Тесак Прорыва в обе руки. Только истинный Воин \
 	достоин иметь столь сильный клинок!"
-/*
+
 /obj/item/melee/breach_cleaver/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_try_wield))
-*/
+
 /obj/item/melee/breach_cleaver/proc/on_try_wield(datum/source, mob/living/user)
 	SIGNAL_HANDLER
 	if(can_use(user))
@@ -282,6 +282,7 @@
 			Воинов Могеса. Вы не рассчитываете свои силы, роняете [src] на пол и падаете вместе с ним."))
 		user.KnockDown(3 SECONDS)
 		user.Confused(4 SECONDS)
+		user.drop_item_to_ground(src, force = TRUE)
 		return FINISH_ATTACK
 
 /obj/item/melee/breach_cleaver/throw_at(atom/target, range, speed, mob/living/thrower, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -1,6 +1,6 @@
 /obj/item/melee
 	var/list/restricted_species = null
-	var/restriction_message = "This weapon does not recognise your biology and refuses to be wielded!"
+	var/restriction_message = "Непонятная сила мешает вам овладеть оружием!"
 
 /obj/item/melee/proc/can_use(mob/living/user)
 	if(!restricted_species || !length(restricted_species))
@@ -8,18 +8,6 @@
 	if(!user.dna?.species)
 		return FALSE
 	return is_type_in_list(user.dna.species, restricted_species)
-
-/*
-/obj/item/melee/proc/can_use(mob/living/user)
-	if(!restricted_species)
-		return TRUE
-	if(!ishuman(user))
-		return FALSE
-	var/mob/living/carbon/human/human_user = user
-	if(is_type_in_list(human_user.dna.species, restricted_species))
-		return TRUE
-	return FALSE
-*/
 
 /obj/item/melee/proc/get_restriction_message(mob/living/user)
 	return restriction_message
@@ -35,6 +23,10 @@
 		return TRUE
 	to_chat(user, SPAN_DANGER(get_restriction_message(user)))
 	return FALSE
+
+
+
+
 
 /obj/item/melee/energy
 	var/sharpening_allowed = FALSE
@@ -249,21 +241,20 @@
 
 /obj/item/push_broom/traitor/unwield(obj/item/source, mob/living/carbon/user)
 	set_nodrop(FALSE, user)
-	to_chat(user, SPAN_NOTICE("Вы расслабили хватку [src]."))
+	to_chat(user, SPAN_NOTICE("Вы расслабили хватку на [src]."))
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 
 
 
 /obj/item/melee/breach_cleaver
 	restricted_species = list(/datum/species/unathi)
-	restriction_message = "Мышцы пронзает сильный холод и вы с ужасом бросаете клинок на землю. Только истинный Воин\
-	 достоин иметь столь сильный клинок!"
+	restriction_message = "Мышцы пронзает сильный холод и выбросаете попытку взять [src] в обе руки. Только истинный Воин \
+	достоин иметь столь сильный клинок!"
 
 /obj/item/melee/breach_cleaver/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_try_wield))
 
-/// Блокирует сам вилд компонента до того как он выставит wielded/оффхенд — сюда не долетают не-унатхи в принципе
 /obj/item/melee/breach_cleaver/proc/on_try_wield(datum/source, mob/living/user)
 	SIGNAL_HANDLER  // COMSIG_TWOHANDED_WIELD
 	if(can_use(user))
@@ -275,7 +266,7 @@
 	to_chat(user, SPAN_NOTICE("Прочно взяв [src] в обе лапы, вы чувствуете, как от когтей и до хвоста, по всему телу начинает \
 	расходится поток странного тепла, который переполняет мысли и чувства. Вас больше не остановят преграды, а враги \
 	навсегда запомнят вас как Вершителя судеб. Теперь вы поистине сильны и готовы. Никто не остановит вас от \
-	великого КХАААААРА во имя Хасали Могеса!"))
+	великого КХАААААРА во славу Хасали Могеса!"))
 	set_nodrop(TRUE, user)
 	user.apply_status_effect(STATUS_EFFECT_BREACH_AND_CLEAVE)
 	update_icon(UPDATE_ICON_STATE)
@@ -285,7 +276,6 @@
 	user.remove_status_effect(STATUS_EFFECT_BREACH_AND_CLEAVE)
 	update_icon(UPDATE_ICON_STATE)
 
-/// Ловит ЛЮБОЙ одноручный удар не-унатха — по мобу, по стене, по двери, по чему угодно
 /obj/item/melee/breach_cleaver/pre_attack(atom/target, mob/living/user, params)
 	if(..())
 		return FINISH_ATTACK
@@ -295,13 +285,12 @@
 			Воинов Могеса. Вы не рассчитываете свои силы, роняете [src] на пол и падаете вместе с ним."))
 		user.KnockDown(3 SECONDS)
 		user.Confused(4 SECONDS)
-		user.drop_item_to_ground(src, force = TRUE) // safety-net, нокдаун и так роняет не-антидропное
 		return FINISH_ATTACK
 
-/// Не-унатх не может нормально размахнуться и кинуть — клинок улетает не дальше 2 тайлов, а бросающего валит с ног
 /obj/item/melee/breach_cleaver/throw_at(atom/target, range, speed, mob/living/user, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)
 	if(user && !can_use(user))
-		to_chat(user, SPAN_DANGER("Клинок слишком тяжёлый, чтобы его можно было так просто кинуть! Вы не рассчитываете свои силы и в момент броска с треском падаете."))
+		to_chat(user, SPAN_DANGER("Клинок слишком тяжёлый, чтобы его можно было так просто кинуть! Вы не рассчитываете \
+		свои силы и в момент броска с треском падаете."))
 		user.KnockDown(1 SECONDS)
 		range = min(range, 2)
 	return ..()

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -1,3 +1,41 @@
+/obj/item/melee
+	var/list/restricted_species = null
+	var/restriction_message = "This weapon does not recognise your biology and refuses to be wielded!"
+
+/obj/item/melee/proc/can_use(mob/living/user)
+	if(!restricted_species || !length(restricted_species))
+		return TRUE
+	if(!user.dna?.species)
+		return FALSE
+	return is_type_in_list(user.dna.species, restricted_species)
+
+/*
+/obj/item/melee/proc/can_use(mob/living/user)
+	if(!restricted_species)
+		return TRUE
+	if(!ishuman(user))
+		return FALSE
+	var/mob/living/carbon/human/human_user = user
+	if(is_type_in_list(human_user.dna.species, restricted_species))
+		return TRUE
+	return FALSE
+*/
+
+/obj/item/melee/proc/get_restriction_message(mob/living/user)
+	return restriction_message
+
+/obj/item/melee/proc/check_restricted(mob/living/user)
+	if(can_use(user))
+		return TRUE
+	to_chat(user, SPAN_DANGER(get_restriction_message(user)))
+	return FALSE
+
+/obj/item/melee/proc/check_twohanded_restricted(mob/living/user)
+	if(can_use(user))
+		return TRUE
+	to_chat(user, SPAN_DANGER(get_restriction_message(user)))
+	return FALSE
+
 /obj/item/melee/energy
 	var/sharpening_allowed = FALSE
 
@@ -91,14 +129,14 @@
 	is_breaching = TRUE
 
 	user.visible_message(
-		SPAN_WARNING("[user] заносит [src] для удара по [wall]!"),
-		SPAN_WARNING("Вы готовитесь нанести мощный удар по [wall].")
+		SPAN_DANGER("[user] заносит [src] для удара по [wall]!"),
+		SPAN_DANGER("Вы готовитесь нанести мощный удар по [wall].")
 	)
 
 	if(!do_after(user, 2 SECONDS, needhand = TRUE, target = wall, progress = TRUE))
 		user.visible_message(
-			SPAN_WARNING("[user] бросает затею ломать [wall]."),
-			SPAN_WARNING("Вы бросаете затею ломать [wall].")
+			SPAN_DANGER("[user] бросает затею ломать [wall]."),
+			SPAN_DANGER("Вы бросаете затею ломать [wall].")
 		)
 
 		is_breaching = FALSE
@@ -183,3 +221,89 @@
 		_parryable_attack_types = ALL_ATTACK_TYPES, \
 		_parry_cooldown = 0.9 SECONDS, \
 		_requires_two_hands = TRUE)
+
+
+
+/obj/item/kitchen/knife/butcher/meatcleaver/
+	var/gripped = FALSE
+
+/obj/item/kitchen/knife/butcher/meatcleaver/attack_self__legacy__attackchain(mob/user)
+	if(!gripped)
+		gripped = TRUE
+		to_chat(user, SPAN_NOTICE("Вы крепко сжали рукоять [src], чтобы не выронить его."))
+		set_nodrop(TRUE, user)
+	else
+		gripped = FALSE
+		to_chat(user, SPAN_NOTICE("Вы ослабили хватку на [src]."))
+		set_nodrop(FALSE, user)
+
+/obj/item/kitchen/knife/butcher/meatcleaver/dropped(mob/user, silent)
+	. = ..()
+	gripped = FALSE
+	set_nodrop(FALSE, user)
+
+/obj/item/push_broom/traitor/wield(obj/item/source, mob/living/carbon/user)
+	set_nodrop(TRUE, user)
+	to_chat(user, SPAN_NOTICE("Вы прочно взяли [src] в обе руки."))
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(sweep))
+
+/obj/item/push_broom/traitor/unwield(obj/item/source, mob/living/carbon/user)
+	set_nodrop(FALSE, user)
+	to_chat(user, SPAN_NOTICE("Вы расслабили хватку [src]."))
+	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+
+
+
+/obj/item/melee/breach_cleaver
+	restricted_species = list(/datum/species/unathi)
+	restriction_message = "Мышцы пронзает сильный холод и вы с ужасом бросаете клинок на землю. Только истинный Воин\
+	 достоин иметь столь сильный клинок!"
+
+/obj/item/melee/breach_cleaver/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_try_wield))
+
+/// Блокирует сам вилд компонента до того как он выставит wielded/оффхенд — сюда не долетают не-унатхи в принципе
+/obj/item/melee/breach_cleaver/proc/on_try_wield(datum/source, mob/living/user)
+	SIGNAL_HANDLER  // COMSIG_TWOHANDED_WIELD
+	if(can_use(user))
+		return NONE
+	to_chat(user, SPAN_DANGER("[get_restriction_message(user)]"))
+	return COMPONENT_TWOHANDED_BLOCK_WIELD
+
+/obj/item/melee/breach_cleaver/wield(obj/item/source, mob/living/carbon/human/user)
+	to_chat(user, SPAN_NOTICE("Прочно взяв [src] в обе лапы, вы чувствуете, как от когтей и до хвоста, по всему телу начинает \
+	расходится поток странного тепла, который переполняет мысли и чувства. Вас больше не остановят преграды, а враги \
+	навсегда запомнят вас как Вершителя судеб. Теперь вы поистине сильны и готовы. Никто не остановит вас от \
+	великого КХАААААРА во имя Хасали Могеса!"))
+	set_nodrop(TRUE, user)
+	user.apply_status_effect(STATUS_EFFECT_BREACH_AND_CLEAVE)
+	update_icon(UPDATE_ICON_STATE)
+
+/obj/item/melee/breach_cleaver/unwield(obj/item/source, mob/living/carbon/user)
+	set_nodrop(FALSE, user)
+	user.remove_status_effect(STATUS_EFFECT_BREACH_AND_CLEAVE)
+	update_icon(UPDATE_ICON_STATE)
+
+/// Ловит ЛЮБОЙ одноручный удар не-унатха — по мобу, по стене, по двери, по чему угодно
+/obj/item/melee/breach_cleaver/pre_attack(atom/target, mob/living/user, params)
+	if(..())
+		return FINISH_ATTACK
+	if(!can_use(user) && !HAS_TRAIT(src, TRAIT_WIELDED))
+		user.visible_message(SPAN_DANGER("[user] не справляется с весом [src] и роняет клинок!"), \
+			SPAN_DANGER("[src] слишком громоздкий, чтобы им мог владеть одной рукой кто-угодно, кроме истинных \
+			Воинов Могеса. Вы не рассчитываете свои силы, роняете [src] на пол и падаете вместе с ним."))
+		user.KnockDown(3 SECONDS)
+		user.Confused(4 SECONDS)
+		user.drop_item_to_ground(src, force = TRUE) // safety-net, нокдаун и так роняет не-антидропное
+		return FINISH_ATTACK
+
+/// Не-унатх не может нормально размахнуться и кинуть — клинок улетает не дальше 2 тайлов, а бросающего валит с ног
+/obj/item/melee/breach_cleaver/throw_at(atom/target, range, speed, mob/living/user, spin = 1, diagonals_first = 0, datum/callback/callback, force, dodgeable)
+	if(user && !can_use(user))
+		to_chat(user, SPAN_DANGER("Клинок слишком тяжёлый, чтобы его можно было так просто кинуть! Вы не рассчитываете свои силы и в момент броска с треском падаете."))
+		user.KnockDown(1 SECONDS)
+		range = min(range, 2)
+	return ..()
+
+

--- a/modular_ss220/balance/code/items/melee.dm
+++ b/modular_ss220/balance/code/items/melee.dm
@@ -256,7 +256,7 @@
 	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_try_wield))
 
 /obj/item/melee/breach_cleaver/proc/on_try_wield(datum/source, mob/living/user)
-	SIGNAL_HANDLER  // COMSIG_TWOHANDED_WIELD
+	SIGNAL_HANDLER
 	if(can_use(user))
 		return NONE
 	to_chat(user, SPAN_DANGER("[get_restriction_message(user)]"))


### PR DESCRIPTION
## Что этот PR делает
Теперь Тесак Прорыва, нож Мясника и Титановая швабра имеют антидроп. У клевера допом блок по расе.
## Почему это хорошо для игры
Теперь оружие, что стоит как машина, не будет так просто выбиваться телескопичкой и переворачивать бой на 180.
Это не перевесит баланс, тк в критах нельзя атаковать, как и в наручниках
## Тестирование
1-Унатх одноручка
Как и раньше
2- Унатх двуручка
Как и раньше, но с антидропом
3- Унатх бросок
Как раньше
3- Другая раса и одноручка
Попытка ударить обрушит владельца с сообщением, что он слишком тяжёлый для одной руки неподготовленного воина
4- Другая раса двуручка 
Отключена. Клинок достоин лишь сильных воинов!
5- Другая раса бросок
Роняет на секунду с сообщением, что он слишком тяжёлый для одноручного броска
6- Антидроп ножа
На z делается / убирается
7- Антидроп метлы
Как и раньше, но в двуручном режиме теперь антидроп
## Changelog

:cl:
add: Тесак Прорыва, Титановая метла и Нож мясника получили свои антидроп режимы при активации на z.
add: Тесак Прорыва теперь имеет ограничение по расе
/:cl: