### PR TITLE
Radiation dna fix

### DIFF
--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -270,7 +270,7 @@
 	return TRUE
 
 /datum/mutation/disability/radioactive/on_life(mob/living/carbon/human/H)
-	radiation_pulse(H, 100, BETA_RAD)
+	radiation_pulse(H, 100, BETA_RAD) // SS220 EDIT - 80 ALPHA_RAD -> 100 BETA_RAD для работоспособности
 
 /datum/mutation/disability/radioactive/on_draw_underlays(mob/M, g)
 	return "rads_s"

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -270,7 +270,7 @@
 	return TRUE
 
 /datum/mutation/disability/radioactive/on_life(mob/living/carbon/human/H)
-	radiation_pulse(H, 80, ALPHA_RAD)
+	radiation_pulse(H, 80, BETA_RAD)
 
 /datum/mutation/disability/radioactive/on_draw_underlays(mob/M, g)
 	return "rads_s"

--- a/code/game/dna/mutations/disabilities.dm
+++ b/code/game/dna/mutations/disabilities.dm
@@ -270,7 +270,7 @@
 	return TRUE
 
 /datum/mutation/disability/radioactive/on_life(mob/living/carbon/human/H)
-	radiation_pulse(H, 80, BETA_RAD)
+	radiation_pulse(H, 100, BETA_RAD)
 
 /datum/mutation/disability/radioactive/on_draw_underlays(mob/M, g)
 	return "rads_s"


### PR DESCRIPTION
## Что этот PR делает

Переводит облучение от гена "Радиоактивность" с АЛЬФА на БЕТА-радиацию
Если кратко - Теперь добавляет по 18 облучения (В среднем) в тик

## Почему это хорошо для игры

Болезнь, которая дает -15 Нестабильности, что реально представляет опасность и вынуждает постоянно закидываться противорадиационными реагентами.
До обновления радиации с добавлением её подтипов Альфа, Бета и Гаммы, про ген видимо забыли, а то что он не то чтобы прям опасный, и не замечали. Собсн, правлю это дело.

## Тестирование
Дал кошке ген радиоактивности, кошка с течением времени облысела и даже без бритвы, а после начала загибаться от токсинов и мутировать. Красота.

## Changelog

:cl:
fix: Ген "Радиоактивности" теперь облучает не Альфа-радиацией, а Бета-радиацией, добавляя реальное облучение кукле (В среднем - 18 в тик).
/:cl: