### PR TITLE
Мозг МЁРТВ

### DIFF
--- a/code/game/objects/items/devices/healthanalyzer.dm
+++ b/code/game/objects/items/devices/healthanalyzer.dm
@@ -236,7 +236,7 @@
 	var/obj/item/organ/internal/brain = H.get_int_organ(/obj/item/organ/internal/brain)
 	if(brain)
 		if(H.check_brain_threshold(BRAIN_DAMAGE_RATIO_CRITICAL)) // 100
-			msgs += SPAN_WARNING("Мозг субъекта отмирает.")
+			msgs += SPAN_WARNING("Мозг субъекта мёртв.")
 		else if(H.check_brain_threshold(BRAIN_DAMAGE_RATIO_MODERATE)) // 60
 			msgs += SPAN_WARNING("Обнаружено серьезное повреждение мозга. Возможно, у пациента слабоумие.")
 		else if(H.check_brain_threshold(BRAIN_DAMAGE_RATIO_MINOR)) // 10


### PR DESCRIPTION
## Что этот PR делает

Возвращает правильный перевод "Мозг субъекта мёртв", вместо непонятного "отмирает".

## Почему это хорошо для игры

Потому что мозг УЖЕ умер, у него статус DEAD. То, что мозг с текущим шизокодом единственный кто может подняться - это ег оособенность. Мы же не говорим о трупах, что они Отмирающие, да??? Это особенность трупов, что их можно лазарем поднять.

## Тестирование

1-Видно на медсканах/гостсканах?
Да

## Changelog

:cl:
tweak: Вернул правильный перевод
/:cl: