### PR TITLE
HOTFIX: Исправление мультисортировки

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1182,7 +1182,7 @@
 /obj/structure/disposalpipe/sortjunction
 	name = "disposal sort junction"
 	icon_state = "pipe-j1s"
-	var/list/sort_type = list(1)
+	var/list/sort_type = list() //SS220 EDIT - удалено присвоение дефолтной сортировки disposals для корректной работы мультисорта
 	var/posdir = 0
 	var/negdir = 0
 	var/sortdir = 0


### PR DESCRIPTION
## Что этот PR делает

Удаление дефолтного присвоения сортировочным трубам тэга "disposals" для корректной работы мультисортировки через мапперские  хелперы.

## Почему это хорошо для игры

Фиксы - всегда хорошо.

## Тестирование

Локальный сервер.
Все посылки отправляются откуда угодно и куда угодно (в том числе через мультисорт трубы).
Мусор летит куда надо.

## Changelog

:cl:
fix: Мультисортировка пневмотруб снова работает.
/:cl:
