### PR TITLE
REMAP: AllStations | Миграция на хелперы внешних шлюзов

### DIFF
--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -3625,6 +3625,13 @@
 "aqv" = (
 /turf/simulated/wall,
 /area/station/security/warden)
+"aqw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/space,
+/area/space/nearstation)
 "aqx" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -30150,6 +30157,9 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "cqK" = (
@@ -32035,16 +32045,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "cyz" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "1-8"
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "cyA" = (
@@ -32506,6 +32511,13 @@
 	dir = 1;
 	network = list("SS13","MiniSat")
 	},
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/pen/multi,
+/obj/item/radio{
+	pixel_x = 13;
+	pixel_y = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "cAi" = (
@@ -32961,6 +32973,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/access_button/offset/northwest,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "cCi" = (
@@ -40713,6 +40728,9 @@
 /obj/structure/transit_tube/curved{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/space,
 /area/space/nearstation)
 "dgZ" = (
@@ -40997,17 +41015,23 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/hatch{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "diD" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/rack,
-/obj/item/screwdriver,
-/obj/item/radio,
-/obj/machinery/light_switch/north,
-/obj/effect/turf_decal/delivery,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/space,
+/area/space/nearstation)
 "diE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -41023,6 +41047,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "diG" = (
@@ -41782,6 +41807,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
+"dlQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
+/area/space/nearstation)
 "dlR" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -41912,6 +41944,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "dmz" = (
@@ -42310,10 +42345,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/access_button/offset/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "dnW" = (
@@ -42325,6 +42360,9 @@
 /obj/machinery/airlock_controller/air_cycler/directional/north,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "dnY" = (
@@ -42435,12 +42473,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "doy" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/pen/multi,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/ai_transit_tube)
 "doz" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -42855,6 +42892,9 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "dqB" = (
@@ -43235,6 +43275,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "dsI" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/space,
 /area/space/nearstation)
 "dsJ" = (
@@ -44958,6 +45002,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "dTG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/stairs/right{
 	dir = 8
 	},
@@ -46802,6 +46849,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
+"ext" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/space,
+/area/space/nearstation)
 "exu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair/plastic,
@@ -47031,18 +47085,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/xenobiology)
 "eCl" = (
-/obj/machinery/door/firedoor{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
@@ -59067,6 +59116,9 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "ixM" = (
@@ -61577,15 +61629,9 @@
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/public/vacant_office)
 "jqj" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Satellite Antechamber North";
-	dir = 1;
-	network = list("SS13","MiniSat")
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/south,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "jqB" = (
@@ -64436,13 +64482,13 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
 "kla" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
+/obj/effect/turf_decal/arrows/red,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "klh" = (
@@ -65967,6 +66013,9 @@
 /obj/effect/map_effect/dynamic_airlock,
 /obj/machinery/airlock_controller/air_cycler/directional/north,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "kLR" = (
@@ -67849,6 +67898,16 @@
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"ltc" = (
+/obj/machinery/light/directional/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "lte" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/papershredder,
@@ -71071,6 +71130,15 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
+"mqb" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera/motion{
+	c_tag = "AI Satellite Antechamber North";
+	dir = 1;
+	network = list("SS13","MiniSat")
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "mqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -76800,6 +76868,9 @@
 /obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/access_button/offset/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "ojz" = (
@@ -76886,6 +76957,9 @@
 /obj/effect/map_effect/dynamic_airlock/door/interior,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/access_button/offset/northwest,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "okB" = (
@@ -81620,6 +81694,11 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
+"pKZ" = (
+/obj/machinery/light_switch/north,
+/obj/machinery/light/small/directional/north,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "pLa" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -82455,8 +82534,9 @@
 /area/station/supply/warehouse)
 "pYI" = (
 /obj/structure/transit_tube,
+/obj/structure/lattice,
 /turf/space,
-/area/space)
+/area/space/nearstation)
 "pYS" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -88316,9 +88396,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "rTF" = (
@@ -88670,6 +88747,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "rZm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "rZA" = (
@@ -99752,6 +99832,11 @@
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
+"vwl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/space/nearstation)
 "vwn" = (
 /mob/living/simple_animal/cock/clucky,
 /obj/structure/window/reinforced{
@@ -101236,6 +101321,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
@@ -103078,6 +103166,9 @@
 "wym" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
@@ -105100,6 +105191,9 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "xgn" = (
@@ -106213,6 +106307,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
+"xyv" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/space,
+/area/space/nearstation)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -147572,7 +147673,7 @@ dbM
 ogH
 vSI
 rZm
-rZm
+doy
 vSC
 nvN
 aWg
@@ -148618,9 +148719,9 @@ aaa
 aab
 aaa
 aab
-doE
-doE
-doE
+diD
+xyv
+dsI
 doE
 iUc
 dQC
@@ -148858,9 +148959,11 @@ cyJ
 chf
 aab
 doE
-doE
-doE
+ext
+xyv
 dgX
+xyv
+vwl
 doE
 doE
 doE
@@ -148872,10 +148975,8 @@ doE
 doE
 doE
 doE
-doE
-aab
-aab
-doE
+dlQ
+aqw
 cEa
 cCh
 dmB
@@ -149127,11 +149228,11 @@ bvr
 dkZ
 bvr
 dkZ
-dkZ
+bvr
 pYI
 bvo
 doE
-doE
+aab
 doE
 cNv
 dnW
@@ -149384,9 +149485,9 @@ aaa
 aab
 aab
 aab
-dsI
 aab
-doE
+aab
+aab
 cvb
 ajU
 ajU
@@ -149643,14 +149744,14 @@ chf
 aab
 aab
 aab
-doE
+aab
 kKJ
 kYd
 gqn
 hMV
 kla
+ltc
 dnZ
-doy
 diF
 doY
 diI
@@ -149899,8 +150000,8 @@ cyJ
 cAe
 aaa
 aab
-dsI
-doE
+aab
+aab
 kKJ
 uwh
 raN
@@ -150163,9 +150264,9 @@ asU
 mJm
 qmU
 jqj
+mqb
 dnZ
-diD
-diI
+pKZ
 diN
 djH
 cAg

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -8473,6 +8473,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"aGK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/space,
+/area/space/nearstation)
 "aGL" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
@@ -10321,11 +10328,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical)
-"aNl" = (
-/obj/machinery/light_switch/north,
-/obj/machinery/light/small/directional/north,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "aNm" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/spawner/random/cobweb/right/frequent,
@@ -36609,8 +36611,7 @@
 /area/station/engineering/supermatter_room)
 "cRk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+	dir = 8
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
@@ -47215,13 +47216,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
-"eFh" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/space,
-/area/space/nearstation)
 "eFl" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/structure/disposalpipe/segment,
@@ -47562,13 +47556,6 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
-	},
-/turf/space,
-/area/space/nearstation)
-"eKU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -52886,6 +52873,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
+"gvn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/space,
+/area/space/nearstation)
 "gvy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63731,6 +63725,13 @@
 	dir = 4
 	},
 /area/station/service/chapel/funeral)
+"jWp" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/space,
+/area/space/nearstation)
 "jWy" = (
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
@@ -63931,8 +63932,7 @@
 "kaB" = (
 /obj/machinery/atmospherics/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+	dir = 8
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
@@ -68444,6 +68444,11 @@
 	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/security/detective)
+"lBV" = (
+/obj/machinery/light_switch/north,
+/obj/machinery/light/small/directional/north,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "lCk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -79707,13 +79712,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
-"pcG" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/space,
-/area/space/nearstation)
 "pcR" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/storage/bible,
@@ -80255,15 +80253,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
-"pmg" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/camera/motion{
-	c_tag = "AI Satellite Antechamber North";
-	dir = 1;
-	network = list("SS13","MiniSat")
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "pml" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -80545,8 +80534,7 @@
 /area/station/engineering/atmos)
 "ppH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
@@ -84821,11 +84809,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/secure_storage)
-"qGy" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/space,
-/area/space/nearstation)
 "qGD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -86108,6 +86091,11 @@
 "qZN" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/asmaint2)
+"qZT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/space/nearstation)
 "rac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
@@ -87840,12 +87828,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
-"rIH" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/ai_transit_tube)
 "rIV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -90776,6 +90758,12 @@
 /obj/effect/turf_decal/tiles/department/cargo/side,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"sFx" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/ai_transit_tube)
 "sFy" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/plating,
@@ -94917,6 +94905,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/engineering/dronefabricator)
+"tUX" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera/motion{
+	c_tag = "AI Satellite Antechamber North";
+	dir = 1;
+	network = list("SS13","MiniSat")
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "tVd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/east,
@@ -104400,13 +104397,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/arcade)
-"wTL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/space,
-/area/space/nearstation)
 "wTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -107730,6 +107720,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
+"xUj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
+/area/space/nearstation)
 "xUA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -108253,12 +108250,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/public/toilet/unisex)
 "ycj" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
-	},
 /obj/effect/turf_decal/tiles/department/science/side{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
@@ -147679,7 +147675,7 @@ dbM
 ogH
 vSI
 rZm
-rIH
+sFx
 vSC
 nvN
 aWg
@@ -148725,9 +148721,9 @@ aaa
 aab
 aaa
 aab
-eKU
-wTL
-pcG
+jWp
+aGK
+gvn
 doE
 iUc
 dQC
@@ -148966,10 +148962,10 @@ chf
 aab
 doE
 doy
-wTL
+aGK
 dgX
-wTL
-qGy
+aGK
+qZT
 doE
 doE
 doE
@@ -148981,7 +148977,7 @@ doE
 doE
 doE
 doE
-eFh
+xUj
 diD
 cEa
 cCh
@@ -150270,9 +150266,9 @@ asU
 mJm
 qmU
 jqj
-pmg
+tUX
 dnZ
-aNl
+lBV
 diN
 djH
 cAg

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -3625,13 +3625,6 @@
 "aqv" = (
 /turf/simulated/wall,
 /area/station/security/warden)
-"aqw" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/space,
-/area/space/nearstation)
 "aqx" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
@@ -10328,6 +10321,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/electrical)
+"aNl" = (
+/obj/machinery/light_switch/north,
+/obj/machinery/light/small/directional/north,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "aNm" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/spawner/random/cobweb/right/frequent,
@@ -32050,6 +32048,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "cyA" = (
@@ -41028,7 +41029,7 @@
 "diD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -41807,13 +41808,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
-"dlQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/space,
-/area/space/nearstation)
 "dlR" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
@@ -42349,6 +42343,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "dnW" = (
@@ -42473,11 +42470,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/electrical)
 "doy" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/engineering/ai_transit_tube)
+/turf/space,
+/area/space/nearstation)
 "doz" = (
 /obj/effect/spawner/window/shuttle,
 /turf/simulated/floor/plating,
@@ -43275,12 +43273,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "dsI" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/light/directional/south,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/arrows/red{
+	dir = 1
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "dsJ" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -46849,13 +46850,6 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
-"ext" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/space,
-/area/space/nearstation)
 "exu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair/plastic,
@@ -47221,6 +47215,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
+"eFh" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/space,
+/area/space/nearstation)
 "eFl" = (
 /obj/effect/mapping_helpers/turfs/damage,
 /obj/structure/disposalpipe/segment,
@@ -47561,6 +47562,13 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
+	},
+/turf/space,
+/area/space/nearstation)
+"eKU" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/space,
 /area/space/nearstation)
@@ -67898,16 +67906,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
-"ltc" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 1
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "lte" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/papershredder,
@@ -71130,15 +71128,6 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
-"mqb" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/camera/motion{
-	c_tag = "AI Satellite Antechamber North";
-	dir = 1;
-	network = list("SS13","MiniSat")
-	},
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "mqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -79718,6 +79707,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
+"pcG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/space,
+/area/space/nearstation)
 "pcR" = (
 /obj/effect/decal/cleanable/dust,
 /obj/item/storage/bible,
@@ -80259,6 +80255,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
+"pmg" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera/motion{
+	c_tag = "AI Satellite Antechamber North";
+	dir = 1;
+	network = list("SS13","MiniSat")
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "pml" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple{
 	dir = 4
@@ -81694,11 +81699,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry)
-"pKZ" = (
-/obj/machinery/light_switch/north,
-/obj/machinery/light/small/directional/north,
-/turf/simulated/floor/plasteel/dark,
-/area/station/turret_protected/aisat/interior)
 "pLa" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -84821,6 +84821,11 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/secure_storage)
+"qGy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/space,
+/area/space/nearstation)
 "qGD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -87835,6 +87840,12 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
+"rIH" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plasteel,
+/area/station/engineering/ai_transit_tube)
 "rIV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -99832,11 +99843,6 @@
 /obj/machinery/atmospherics/portable/pump,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
-"vwl" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/space,
-/area/space/nearstation)
 "vwn" = (
 /mob/living/simple_animal/cock/clucky,
 /obj/structure/window/reinforced{
@@ -104394,6 +104400,13 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor/plasteel/dark,
 /area/station/public/arcade)
+"wTL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/space,
+/area/space/nearstation)
 "wTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -106307,13 +106320,6 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
-"xyv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/space,
-/area/space/nearstation)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -147673,7 +147679,7 @@ dbM
 ogH
 vSI
 rZm
-doy
+rIH
 vSC
 nvN
 aWg
@@ -148719,9 +148725,9 @@ aaa
 aab
 aaa
 aab
-diD
-xyv
-dsI
+eKU
+wTL
+pcG
 doE
 iUc
 dQC
@@ -148959,11 +148965,11 @@ cyJ
 chf
 aab
 doE
-ext
-xyv
+doy
+wTL
 dgX
-xyv
-vwl
+wTL
+qGy
 doE
 doE
 doE
@@ -148975,8 +148981,8 @@ doE
 doE
 doE
 doE
-dlQ
-aqw
+eFh
+diD
 cEa
 cCh
 dmB
@@ -149493,7 +149499,7 @@ ajU
 ajU
 cyz
 dnV
-dpf
+dmB
 dpf
 doN
 dlb
@@ -149750,7 +149756,7 @@ kYd
 gqn
 hMV
 kla
-ltc
+dsI
 dnZ
 diF
 doY
@@ -150264,9 +150270,9 @@ asU
 mJm
 qmU
 jqj
-mqb
+pmg
 dnZ
-pKZ
+aNl
 diN
 djH
 cAg

--- a/_maps/map_files220/stations/boxstation.dmm
+++ b/_maps/map_files220/stations/boxstation.dmm
@@ -1288,6 +1288,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "ahT" = (
@@ -2664,17 +2667,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "amZ" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button{
-	autolink_id = "fpmaint_btn_ext";
-	req_access = list(13);
-	pixel_y = 24
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "fpmaint_door_ext"
-	},
+/obj/machinery/access_button/offset/northwest,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "anb" = (
@@ -4117,9 +4113,6 @@
 /turf/simulated/floor/plating,
 /area/station/legal/lawoffice)
 "asF" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
 	},
@@ -4199,10 +4192,9 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
 "asU" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/delivery/blue,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "asX" = (
 /obj/machinery/computer/secure_data{
@@ -4338,6 +4330,7 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	filled = 0.1
 	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "atw" = (
@@ -4667,10 +4660,17 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "auK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/fore)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
 "auL" = (
 /obj/item/kirbyplants/large,
 /obj/effect/turf_decal/tiles/department/security/side{
@@ -5152,6 +5152,9 @@
 	pixel_x = 28
 	},
 /obj/item/scissors/barber,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "awA" = (
@@ -5870,6 +5873,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -6663,7 +6669,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
 "aAY" = (
-/obj/effect/mapping_helpers/turfs/burn,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aAZ" = (
@@ -7480,15 +7486,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/fore_port)
 "aDx" = (
-/obj/structure/sign/vacuum/external{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
 /obj/machinery/atmospherics/portable/canister/air{
 	filled = 0.05
 	},
+/obj/structure/sign/vacuum/external{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "aDz" = (
@@ -7785,19 +7792,26 @@
 /obj/structure/chair/stool{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "aED" = (
 /obj/machinery/power/terminal,
-/obj/machinery/light/small/directional/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "aEE" = (
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
@@ -8227,6 +8241,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "aFT" = (
@@ -8475,6 +8490,9 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "aGN" = (
@@ -8528,9 +8546,6 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "aGU" = (
-/obj/structure/sign/vacuum/external{
-	pixel_y = 32
-	},
 /obj/machinery/power/solar_control{
 	name = "Fore Starboard Solar Control"
 	},
@@ -8544,6 +8559,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/portable/canister/air,
+/obj/structure/sign/vacuum/external{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "aGX" = (
@@ -8612,7 +8631,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint2)
 "aHi" = (
 /obj/effect/spawner/random/fungus/maybe,
@@ -8762,19 +8782,26 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "aHJ" = (
 /obj/machinery/power/terminal,
-/obj/machinery/light/small/directional/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "aHK" = (
 /obj/structure/chair/stool{
 	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
@@ -9010,6 +9037,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "aIB" = (
@@ -9344,6 +9372,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "aJK" = (
@@ -9627,13 +9658,13 @@
 /area/station/public/dorms)
 "aKT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tiles/neutral/side{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 8
 	},
 /turf/simulated/floor/plasteel,
@@ -10007,11 +10038,14 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
 "aMi" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -10035,9 +10069,11 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
@@ -10141,6 +10177,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -10355,19 +10394,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aNC" = (
-/obj/structure/sign/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/atmospherics/portable/canister/air{
-	filled = 0.1
+/obj/effect/spawner/window/reinforced/tinted/grilled,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
+/area/station/maintenance/port)
 "aNE" = (
-/obj/machinery/atmospherics/binary/valve,
+/obj/machinery/atmospherics/binary/valve/open,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aNH" = (
@@ -10706,16 +10740,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "apsolar_door_ext"
-	},
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button/directional/north{
-	autolink_id = "apsolar_btn_ext";
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/access_button/offset/northwest,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "aPe" = (
@@ -11612,7 +11640,7 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "aSH" = (
-/obj/machinery/atmospherics/binary/valve/open{
+/obj/machinery/atmospherics/binary/valve{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -12318,6 +12346,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aVb" = (
@@ -13328,6 +13357,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "aYa" = (
@@ -13360,15 +13390,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "aYg" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
+/area/station/maintenance/asmaint)
 "aYh" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
@@ -14390,6 +14416,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bbJ" = (
@@ -14571,6 +14600,9 @@
 /obj/structure/sign/engineering/power{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bcm" = (
@@ -14600,6 +14632,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plasteel,
@@ -14647,6 +14682,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -16803,7 +16841,18 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/starboard/west)
 "bkD" = (
-/obj/effect/spawner/random/barrier/grille_maybe,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bkE" = (
@@ -17076,7 +17125,6 @@
 /area/station/public/storage/emergency/port)
 "blS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -17086,6 +17134,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -19411,23 +19462,21 @@
 /turf/simulated/floor/carpet/black,
 /area/station/procedure/trainer_office)
 "bvo" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/structure/transit_tube/curved/flipped{
+	dir = 1
 	},
-/obj/effect/spawner/random/cobweb/left/rare,
-/turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
+/turf/space,
+/area/space/nearstation)
 "bvq" = (
 /obj/effect/spawner/random/fungus/maybe,
 /turf/simulated/wall,
 /area/station/public/locker)
 "bvr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/engine/reactor)
+/obj/structure/transit_tube,
+/obj/structure/lattice/catwalk,
+/turf/space,
+/area/space/nearstation)
 "bvs" = (
 /turf/simulated/wall,
 /area/station/public/toilet/lockerroom)
@@ -19751,13 +19800,14 @@
 /area/station/command/bridge)
 "bwW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 10
-	},
 /obj/structure/sign/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/meter,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "bxb" = (
@@ -20731,19 +20781,15 @@
 /area/station/maintenance/port)
 "bCo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4;
-	initialize_directions = 11
+/obj/machinery/atmospherics/trinary/tvalve/flipped{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bCp" = (
 /obj/effect/landmark/spawner/nukedisc_respawn,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/binary/valve/open{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "bCq" = (
@@ -22702,7 +22748,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "bKt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -25291,14 +25336,12 @@
 "bWA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "bWC" = (
@@ -28058,6 +28101,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "cij" = (
@@ -29076,16 +29122,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "apsolar_door_int"
-	},
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button/directional/south{
-	autolink_id = "apsolar_btn_int";
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/access_button/offset/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "cmd" = (
@@ -29629,13 +29669,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/miningdock)
 "coi" = (
-/obj/machinery/atmospherics/binary/valve/digital{
-	name = "Main Distro to Aux Distro Valve"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/binary/valve,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint2)
 "cop" = (
@@ -29691,11 +29729,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "coM" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 4
+/obj/effect/spawner/random/barrier/grille_maybe,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/apmaint)
+/area/station/maintenance/asmaint)
 "coP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -30420,6 +30459,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "csb" = (
@@ -30840,11 +30885,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/toxins/mixing)
 "ctN" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/meter,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
+	},
+/obj/effect/spawner/random/cobweb/left/rare,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "ctO" = (
@@ -30914,6 +30961,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"cui" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "cuj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/walllocker/medlocker/directional/north,
@@ -31211,6 +31263,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/transit_tube/diagonal/topleft,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "cvc" = (
@@ -31245,6 +31298,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/public/vacant_store)
+"cvn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "cvp" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/apmaint)
@@ -31627,6 +31687,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "cwU" = (
@@ -31972,25 +32035,15 @@
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
 "cyz" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "aisat_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/access_button{
-	autolink_id = "aisat_btn_int";
-	pixel_y = 24
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/window/reinforced/grilled,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
@@ -32901,12 +32954,15 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/hallway)
 "cCh" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/curved/flipped{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/access_button/offset/northwest,
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "cCi" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -33373,19 +33429,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "cEa" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "aisat_door_ext"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
-/obj/machinery/access_button{
-	autolink_id = "aisat_btn_ext";
-	pixel_y = 24
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/spawner/window/reinforced/grilled,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
@@ -33629,12 +33678,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "cFm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
 	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/aft)
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "cFn" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /obj/machinery/door/poddoor{
@@ -34042,18 +34090,12 @@
 	autolink_id = "scibomb_vent";
 	dir = 8
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "scibomb_btn_ext";
-	ext_door_link_id = "scibomb_door_ext";
-	int_button_link_id = "scibomb_btn_int";
-	int_door_link_id = "scibomb_door_int";
-	pixel_y = -27;
-	req_access = list(13);
-	vent_link_id = "scibomb_vent"
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/effect/map_effect/dynamic_airlock,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "cGY" = (
@@ -34206,6 +34248,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "cHH" = (
@@ -34692,9 +34735,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "cJA" = (
@@ -34918,11 +34958,11 @@
 /area/station/maintenance/asmaint2)
 "cKu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -35119,11 +35159,16 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/hallway)
 "cLy" = (
-/obj/structure/sign/vacuum/external{
-	pixel_x = -32
-	},
 /obj/machinery/atmospherics/unary/portables_connector,
 /obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/camera{
+	c_tag = "Aft Port Solar Control";
+	dir = 2
+	},
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "cLz" = (
@@ -35274,10 +35319,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/aft)
 "cMr" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "cMx" = (
@@ -35488,7 +35535,6 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/chapel)
 "cNt" = (
-/obj/machinery/atmospherics/portable/pump,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -35506,18 +35552,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint2)
 "cNv" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "aisat_vent";
-	dir = 4
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "aisat_btn_ext";
-	ext_door_link_id = "aisat_door_ext";
-	int_button_link_id = "aisat_btn_int";
-	int_door_link_id = "aisat_door_int";
-	pixel_y = 25;
-	vent_link_id = "aisat_vent"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
+/obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "cNw" = (
@@ -35723,6 +35764,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "cOn" = (
@@ -35931,8 +35973,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "cPj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 2
+	},
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "cPk" = (
@@ -36074,11 +36120,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "cPI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port)
 "cPM" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -36677,9 +36724,6 @@
 /area/station/engineering/hallway)
 "cRK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
-	},
 /obj/machinery/alarm/directional/north,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -38724,9 +38768,6 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/utility)
 "cZg" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
@@ -38809,6 +38850,8 @@
 	},
 /obj/effect/map_effect/dynamic_airlock/door/interior,
 /obj/machinery/access_button/offset/east,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
 "cZG" = (
@@ -39425,7 +39468,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "dcn" = (
 /mob/living/simple_animal/parrot/poly,
@@ -39796,14 +39840,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "dea" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
@@ -40069,6 +40113,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "deO" = (
@@ -40156,14 +40201,17 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "dfb" = (
 /obj/structure/chair/stool,
-/obj/machinery/camera{
-	c_tag = "Aft Starboard Solar Control";
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/light/small/directional/west,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "dfc" = (
@@ -40187,10 +40235,10 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/light/small/directional/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/alarm/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "dfn" = (
@@ -40222,13 +40270,18 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/control)
 "dfp" = (
-/obj/structure/sign/vacuum/external{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 8
 	},
 /obj/machinery/atmospherics/portable/canister/air,
+/obj/structure/sign/vacuum/external{
+	pixel_x = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Aft Starboard Solar Control";
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "dfq" = (
@@ -40771,9 +40824,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "dhL" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/maintenance/fpmaint2)
 "dhM" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/spawner/random/maintenance,
@@ -40974,6 +41029,13 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
+"diH" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "diI" = (
 /turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
@@ -42242,15 +42304,28 @@
 /turf/simulated/floor/carpet,
 /area/station/maintenance/aft)
 "dnV" = (
-/obj/structure/sign/securearea{
-	pixel_y = -32
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/access_button/offset/north,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "dnW" = (
-/turf/simulated/floor/plating,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "aisat_vent";
+	dir = 4
+	},
+/obj/machinery/airlock_controller/air_cycler/directional/north,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/all/science/minisat,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "dnY" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -43160,10 +43235,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "dsI" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/curved{
-	dir = 4
-	},
 /turf/space,
 /area/space/nearstation)
 "dsJ" = (
@@ -43228,10 +43299,11 @@
 /area/station/engineering/hallway)
 "dsU" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/effect/landmark/spawner/xeno,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "dsY" = (
@@ -43397,25 +43469,22 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
 "dur" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "arrivalsmaint_door_int";
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external/glass{
 	dir = 4
 	},
+/obj/machinery/access_button/offset/east,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "arrivalsmaint_btn_int";
-	pixel_x = -24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "duF" = (
 /obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -43505,6 +43574,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -44121,6 +44193,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
+"dFF" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "dFG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -44783,7 +44864,6 @@
 /turf/space,
 /area/space/nearstation)
 "dRb" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
@@ -44809,9 +44889,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
@@ -45055,7 +45137,6 @@
 /obj/structure/chair/stool{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "dXn" = (
@@ -45192,12 +45273,11 @@
 /area/station/hallway/secondary/exit)
 "dYX" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "evamaint_door_ext";
 	dir = 4
 	},
+/obj/machinery/access_button/offset/west,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "dZs" = (
@@ -45602,6 +45682,9 @@
 "efN" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c10,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "efU" = (
@@ -45787,7 +45870,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/meter,
-/obj/machinery/light/directional/north,
+/obj/machinery/light/small/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "ehK" = (
@@ -45795,6 +45878,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -46507,22 +46596,16 @@
 /turf/simulated/floor/carpet,
 /area/station/command/office/captain)
 "etR" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "fpsolar_door_int";
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "fpsolar_btn_int";
-	pixel_x = 24;
-	req_access = list(13)
+/obj/machinery/access_button/offset/east,
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "eup" = (
@@ -46994,6 +47077,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "eEb" = (
@@ -47149,6 +47233,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
@@ -47411,13 +47501,11 @@
 /area/station/maintenance/asmaint)
 "eKH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "eKL" = (
@@ -47463,6 +47551,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -47740,6 +47831,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "eOU" = (
@@ -47900,6 +47994,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "eTj" = (
@@ -48037,24 +48134,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
+"eUV" = (
+/obj/machinery/atmospherics/trinary/tvalve/bypass{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "eVw" = (
 /obj/effect/spawner/xmastree,
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
 "eVD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "eVQ" = (
 /obj/structure/chair/comfy/black{
@@ -48175,6 +48271,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
+"eYz" = (
+/obj/machinery/atmospherics/unary/tank/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "eYQ" = (
 /obj/structure/chair/comfy/red{
 	dir = 8
@@ -48238,6 +48341,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
@@ -48667,11 +48773,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "fhE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 2
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
@@ -48805,9 +48914,15 @@
 /turf/simulated/floor/mineral/tranquillite,
 /area/station/service/mime)
 "fke" = (
-/obj/machinery/atmospherics/binary/valve/open,
+/obj/machinery/door/airlock/atmos{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
+/area/station/maintenance/fsmaint)
 "fki" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -48984,8 +49099,8 @@
 /area/station/engineering/supermatter_room)
 "fnP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
@@ -49516,6 +49631,7 @@
 /obj/structure/table,
 /obj/item/toy/crayon/spraycan,
 /obj/item/deck/cards,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "fwa" = (
@@ -49976,12 +50092,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "fDc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -50325,6 +50441,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "fIs" = (
@@ -50419,11 +50536,12 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "fJD" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
+/area/station/maintenance/fpmaint2)
 "fJX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -50463,6 +50581,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -50548,12 +50669,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
 "fMn" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"fMA" = (
+/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "fMG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50684,6 +50810,9 @@
 "fPr" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
@@ -50863,11 +50992,8 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "fSi" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "evamaint_vent";
-	dir = 4
-	},
 /obj/machinery/light/small/directional/west,
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "fSH" = (
@@ -50887,7 +51013,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "fSM" = (
@@ -51066,12 +51194,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "fWu" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/effect/map_effect/dynamic_airlock,
+/obj/structure/sign/securearea{
+	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/asmaint2)
+/turf/simulated/floor/plasteel/dark,
+/area/station/turret_protected/aisat/interior)
 "fWJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51129,6 +51257,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "fXL" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "fXQ" = (
@@ -51297,8 +51432,9 @@
 "gaS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
-	icon_state = "2-8"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "gaY" = (
@@ -51457,8 +51593,10 @@
 /area/station/public/construction)
 "geq" = (
 /obj/effect/turf_decal/trimline/misc/toxins/arrow_cw,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/engine,
@@ -51707,7 +51845,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/solar_maintenance/aft_port)
 "gin" = (
 /obj/structure/railing{
@@ -51936,15 +52077,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "glH" = (
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "departues_btn_ext";
-	ext_door_link_id = "departues_door_ext";
-	int_button_link_id = "departues_btn_int";
-	int_door_link_id = "departues_door_int";
-	req_access = list(13);
-	vent_link_id = "departues_vent";
-	pixel_x = -24
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "departues_vent";
 	dir = 1
@@ -51954,6 +52086,9 @@
 	c_tag = "Departure External Airlock";
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/west,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "glM" = (
@@ -52121,6 +52256,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "gom" = (
@@ -52286,8 +52422,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/morgue)
 "gqn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "gqq" = (
 /obj/structure/cable{
@@ -52510,6 +52648,12 @@
 	},
 /obj/effect/decal/cleanable/dust,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "gug" = (
@@ -52716,14 +52860,14 @@
 /area/station/maintenance/apmaint)
 "gwo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -52837,6 +52981,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dust,
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "gzU" = (
@@ -52850,9 +53000,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/equipmentstorage)
 "gAb" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "gAk" = (
@@ -52928,10 +53080,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
 "gBh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint2)
 "gBB" = (
 /obj/machinery/atmospherics/binary/valve{
 	name = "Hot Loop - Cold Loop Bridge Valve"
@@ -53524,6 +53677,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
+"gLn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "gLu" = (
 /obj/effect/spawner/window/reinforced/grilled,
 /turf/simulated/floor/plating,
@@ -53759,6 +53919,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "gNs" = (
@@ -53936,8 +54099,10 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "gQg" = (
@@ -54159,6 +54324,9 @@
 	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
@@ -54476,6 +54644,9 @@
 	dir = 4
 	},
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "gYf" = (
@@ -54783,6 +54954,15 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/surgery/observation)
+"hbo" = (
+/obj/machinery/atmospherics/unary/tank/air{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "hbq" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -55371,7 +55551,9 @@
 /area/station/engineering/engine/reactor)
 "hme" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "hmf" = (
@@ -55379,15 +55561,10 @@
 	autolink_id = "fpmaint_vent";
 	dir = 4
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "fpmaint_btn_ext";
-	ext_door_link_id = "fpmaint_door_ext";
-	int_button_link_id = "fpmaint_btn_int";
-	int_door_link_id = "fpmaint_door_int";
-	req_access = list(13);
-	vent_link_id = "fpmaint_vent";
-	pixel_y = 24
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
+/obj/machinery/light/small/directional/south,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "hmj" = (
@@ -55406,14 +55583,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "hmu" = (
-/obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
+"hmA" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "hmR" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -55947,6 +56133,9 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/effect/decal/cleanable/dust,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "hvR" = (
@@ -56192,6 +56381,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
@@ -56961,16 +57153,12 @@
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/command/office/ntrep)
 "hMV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/effect/turf_decal/delivery/white/hollow,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "hNd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57023,6 +57211,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -57211,6 +57402,11 @@
 /area/station/maintenance/apmaint)
 "hRS" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "hRW" = (
@@ -57368,6 +57564,9 @@
 	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
@@ -57774,11 +57973,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
 "ibt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
 	},
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "ibL" = (
@@ -58075,18 +58273,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "fssolar_door_ext";
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/external/glass{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "fssolar_btn_ext";
-	pixel_x = -24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/access_button/offset/northeast,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "iip" = (
@@ -58226,7 +58418,6 @@
 	c_tag = "South-West External Airlock";
 	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
 /obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
@@ -58660,6 +58851,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "itH" = (
@@ -58759,14 +58953,19 @@
 /obj/machinery/camera{
 	c_tag = "North-East External Airlock"
 	},
+/obj/machinery/airlock_controller/air_cycler/directional/north,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "iws" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
@@ -58920,6 +59119,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/bar)
+"iym" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/northwest,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "iyp" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/effect/turf_decal/siding/wood/oak{
@@ -59080,10 +59286,6 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
 "iCq" = (
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Control";
-	dir = 1
-	},
 /obj/structure/cable/extra_insulated,
 /obj/machinery/power/apc/reinforced/directional/south,
 /turf/simulated/floor/plating,
@@ -59132,20 +59334,12 @@
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/public/vacant_office)
 "iDk" = (
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "secmaint_btn_ext";
-	ext_door_link_id = "secmaint_door_ext";
-	int_button_link_id = "secmaint_btn_int";
-	int_door_link_id = "secmaint_door_int";
-	pixel_y = -25;
-	req_access = list(13);
-	vent_link_id = "secmaint_vent"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "secmaint_vent";
 	dir = 8
 	},
 /obj/machinery/light/small/directional/south,
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "iDu" = (
@@ -59768,13 +59962,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "iNf" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = -1;
-	pixel_y = 5
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
 	},
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "iNn" = (
@@ -59823,11 +60016,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
 "iOQ" = (
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/apmaint)
 "iOV" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
@@ -60226,6 +60420,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plasteel/white,
 /area/station/maintenance/assembly_line)
+"iWx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "iWy" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/south,
@@ -60857,6 +61064,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "jgm" = (
@@ -61378,7 +61586,7 @@
 	dir = 4
 	},
 /obj/item/radio/intercom/directional/south,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "jqB" = (
 /obj/structure/table/wood,
@@ -61493,6 +61701,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/aft)
+"jsb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
 "jsn" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/structure/cable/extra_insulated{
@@ -61538,6 +61752,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "jsR" = (
@@ -61726,6 +61941,9 @@
 /obj/effect/decal/cleanable/glass,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
@@ -61983,7 +62201,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint2)
 "jza" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -62321,6 +62539,14 @@
 	icon_state = "seadeep"
 	},
 /area/station/command/bridge)
+"jEe" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "jEi" = (
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
@@ -62396,13 +62622,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "jFh" = (
-/obj/effect/decal/cleanable/dust,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/asmaint)
 "jFo" = (
 /obj/machinery/bodyscanner{
 	dir = 2
@@ -62418,13 +62643,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/port2)
 "jFA" = (
 /obj/structure/table,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "jFF" = (
@@ -62536,11 +62761,11 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
@@ -63050,7 +63275,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "jQD" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
@@ -63079,15 +63303,10 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	initialize_directions = 11
-	},
-/obj/machinery/atmospherics/meter,
-/obj/machinery/alarm/directional/west,
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "jRb" = (
@@ -63477,18 +63696,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "jXg" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "arrivalsmaint_door_ext";
+/obj/machinery/door/airlock/external/glass{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "arrivalsmaint_btn_ext";
-	pixel_x = -24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/northeast,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "jXI" = (
@@ -63592,10 +63805,10 @@
 /turf/simulated/floor/wood/fancy,
 /area/station/legal/courtroom/gallery)
 "jZu" = (
-/obj/effect/spawner/window/reinforced/tinted/grilled,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/barrier/grille_maybe,
 /turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/area/station/maintenance/fsmaint)
 "jZx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63735,12 +63948,11 @@
 /area/station/maintenance/turbine)
 "kcx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "kcJ" = (
@@ -64224,11 +64436,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/reception)
 "kla" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/portable/canister/air,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "klh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -64317,6 +64532,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics)
+"kmK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "kmW" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/turf_decal/tiles/neutral,
@@ -64581,6 +64805,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "krV" = (
@@ -64697,6 +64922,7 @@
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/machinery/access_button/offset/northwest,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
 "ktF" = (
@@ -65257,11 +65483,9 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "kCH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/asmaint)
 "kCM" = (
 /obj/item/flag/cult,
 /obj/effect/spawner/random/cobweb/left/frequent,
@@ -65736,21 +65960,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "kLp" = (
+/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	autolink_id = "eng_sm_vent";
 	dir = 8
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "eng_sm_btn_ext";
-	ext_door_link_id = "eng_sm_door_ext";
-	int_button_link_id = "eng_sm_btn_int";
-	int_door_link_id = "eng_sm_door_int";
-	pixel_y = 25;
-	vent_link_id = "eng_sm_vent";
-	req_access = list(10)
-	},
-/obj/machinery/light/small/directional/south,
-/turf/simulated/floor/plating,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "kLR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65929,10 +66146,10 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "kPF" = (
@@ -66033,15 +66250,28 @@
 /obj/machinery/firealarm/directional/south,
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/command/office/hop)
-"kQw" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
+"kQv" = (
+/obj/effect/turf_decal/trimline/misc/toxins/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
+"kQw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/aft)
 "kQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -66421,17 +66651,17 @@
 /area/station/hallway/primary/starboard/east)
 "kWL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/extra_insulated{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "kXd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -66499,8 +66729,11 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
 "kYd" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
+/obj/structure/transit_tube/curved{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "kYr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -66511,19 +66744,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "assolar_door_int";
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external/glass{
 	dir = 4
 	},
+/obj/effect/map_effect/dynamic_airlock/door/interior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "assolar_btn_int";
-	pixel_x = -24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/access_button/offset/northeast,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "kYz" = (
@@ -66792,10 +67019,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "ldf" = (
-/obj/machinery/atmospherics/binary/valve{
-	dir = 4
-	},
 /obj/machinery/light/directional/north,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "ldl" = (
@@ -66833,7 +67062,10 @@
 	dir = 6
 	},
 /obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -66865,6 +67097,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -67058,9 +67293,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -67070,6 +67302,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port2)
 "ljr" = (
@@ -67366,15 +67599,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/fore)
 "lpt" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "departues_door_ext"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/access_button/directional/west{
-	req_access = list(13);
-	autolink_id = "departues_btn_ext"
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/machinery/access_button/offset/southwest,
+/obj/machinery/door/airlock/external{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -67466,6 +67695,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/mapping_helpers/sortjunc_helper/library,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "lqw" = (
@@ -67934,7 +68166,7 @@
 	dir = 10
 	},
 /obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -68188,18 +68420,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "assolar_door_ext";
+/obj/machinery/door/airlock/external/glass{
 	dir = 4
 	},
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "assolar_btn_ext";
-	pixel_x = -24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/access_button/offset/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "lCQ" = (
@@ -68430,6 +68656,12 @@
 	},
 /turf/simulated/floor/carpet/grimey,
 /area/station/security/detective)
+"lFQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port2)
 "lGd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -68578,10 +68810,7 @@
 "lIQ" = (
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable/extra_insulated{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -68850,8 +69079,18 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery/hollow,
 /obj/item/storage/toolbox/mechanical,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding/white,
+/obj/item/clothing/head/welding/white{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -3;
+	pixel_y = 11
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 6;
+	pixel_y = 11
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "lNE" = (
@@ -69781,11 +70020,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
@@ -69921,6 +70160,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "mcH" = (
@@ -70100,6 +70340,9 @@
 "mfO" = (
 /obj/effect/map_effect/dynamic_airlock,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
 "mfS" = (
@@ -70671,8 +70914,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
+"mnd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "mnh" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -71078,6 +71329,15 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/service/kitchen)
+"muz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "muA" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable/extra_insulated{
@@ -71181,8 +71441,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "mxz" = (
-/obj/machinery/space_heater,
 /obj/effect/spawner/random/cobweb/left/rare,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/atmospherics/portable/canister/air{
+	filled = 0.1
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "mxA" = (
@@ -71381,21 +71647,13 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos/control)
 "mAZ" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "scibomb_door_ext"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button/directional/west{
-	autolink_id = "scibomb_btn_ext";
-	pixel_y = -24;
-	req_access = list(13);
-	pixel_x = 0
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/access_button/offset/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "mBl" = (
@@ -71476,6 +71734,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "mCH" = (
@@ -71617,12 +71876,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "mEx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/wire_splicing/thirty,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/asmaint)
 "mEF" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/portable/scrubber,
@@ -71851,11 +72115,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "mJm" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/structure/sign/electricshock{
 	pixel_x = 32
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "mJp" = (
 /obj/machinery/door/poddoor/preopen{
@@ -71961,6 +72227,9 @@
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "mMk" = (
@@ -72053,6 +72322,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "mNd" = (
@@ -72068,6 +72340,9 @@
 /obj/effect/decal/cleanable/dust,
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -72504,7 +72779,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -72512,6 +72786,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "mXS" = (
@@ -72676,6 +72951,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -73012,6 +73290,9 @@
 "ngO" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
@@ -73650,6 +73931,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "npF" = (
@@ -73852,18 +74136,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/smith_office)
 "nrM" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
+/area/station/maintenance/apmaint)
 "nrP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
@@ -74572,10 +74850,12 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/aft)
 "nDI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
@@ -74587,6 +74867,14 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
+"nEf" = (
+/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white/hollow,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "nEA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74828,8 +75116,8 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
@@ -74841,18 +75129,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "nJV" = (
-/obj/machinery/access_button{
-	autolink_id = "evamaint_btn_ext";
-	pixel_x = 25;
-	req_access = list(13)
-	},
 /obj/machinery/door/airlock/external{
-	id_tag = "evamaint_door_ext";
 	dir = 4
 	},
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "nKq" = (
@@ -75442,6 +75723,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"nUM" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "nUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 10
@@ -75449,11 +75734,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "nVg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel{
+	icon_state = "showroomfloor"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/port)
+/area/station/maintenance/asmaint)
 "nVh" = (
 /turf/simulated/wall,
 /area/station/engineering/atmos)
@@ -75538,10 +75824,24 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/port)
 "nWF" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/effect/spawner/airlock/e_to_w,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/maintenance/fsmaint)
 "nWM" = (
 /obj/machinery/camera{
 	c_tag = "Engine Fabrication";
@@ -75648,6 +75948,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"nXM" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "nXN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -75961,6 +76268,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/mapping_helpers/sortjunc_helper/hydroponics,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "oca" = (
@@ -76406,6 +76716,9 @@
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
 "oiQ" = (
@@ -76483,18 +76796,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/supply/storage)
 "ojt" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_sm_door_ext"
-	},
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button{
-	autolink_id = "eng_sm_btn_ext";
-	pixel_y = 24;
-	req_access = list(10)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/simulated/floor/plating,
+/obj/machinery/access_button/offset/north,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "ojz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -76566,20 +76872,9 @@
 /turf/simulated/floor/plating,
 /area/station/public/arcade)
 "okj" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "eng_sm_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/access_button{
-	autolink_id = "eng_sm_btn_int";
-	pixel_y = 24;
-	req_access = list(10)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "open";
@@ -76587,7 +76882,11 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/access_button/offset/northwest,
+/turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "okB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -76962,24 +77261,17 @@
 /turf/simulated/floor/plating,
 /area/station/command/meeting_room)
 "oqL" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "secmaint_door_int"
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
 	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button/offset/south,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "secmaint_btn_int";
-	name = "interior access button";
-	pixel_y = -24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "oqQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -76989,6 +77281,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port2)
@@ -77064,15 +77359,9 @@
 	autolink_id = "apsolar_vent";
 	dir = 4
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "apsolar_btn_ext";
-	ext_door_link_id = "apsolar_door_ext";
-	int_button_link_id = "apsolar_btn_int";
-	int_door_link_id = "apsolar_door_int";
-	pixel_y = -25;
-	req_access = list(13);
-	vent_link_id = "apsolar_vent"
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "osz" = (
@@ -77129,12 +77418,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/xenobiology)
 "otr" = (
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 1
+/obj/effect/spawner/window/reinforced/tinted/grilled,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
-/obj/machinery/atmospherics/portable/canister/air,
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/maintenance/fsmaint)
 "otv" = (
 /obj/structure/mecha_wreckage/ripley,
 /turf/simulated/floor/plating,
@@ -77176,6 +77465,15 @@
 	},
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/command/office/hop)
+"otQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
 "otV" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4
@@ -77372,9 +77670,11 @@
 /area/station/procedure/trainer_office)
 "oxe" = (
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	autolink_id = "evamaint_vent";
+	dir = 2
 	},
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "oxf" = (
@@ -77487,10 +77787,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/port)
 "ozS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "ozX" = (
@@ -77911,12 +78209,18 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
 "oGl" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/effect/spawner/wire_splicing/thirty,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
+/area/station/maintenance/aft)
 "oGm" = (
 /obj/effect/spawner/window/reinforced/polarized/grilled{
 	id = "HoS"
@@ -78341,6 +78645,13 @@
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/brig)
+"oNZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "oOe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -78468,9 +78779,6 @@
 /area/station/command/meeting_room)
 "oPX" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/atmospherics/unary/portables_connector,
-/obj/machinery/atmospherics/portable/canister/air,
-/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/asmaint)
 "oPY" = (
@@ -78486,17 +78794,10 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "oQd" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "secmaint_door_ext"
-	},
+/obj/machinery/door/airlock/external,
+/obj/machinery/access_button/offset/north,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "secmaint_btn_ext";
-	req_access = list(13);
-	pixel_y = 24
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "oQe" = (
@@ -78545,6 +78846,9 @@
 /obj/structure/sign/poster/contraband/missing_gloves/directional/north,
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -79015,7 +79319,8 @@
 /obj/machinery/atmospherics/unary/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/catwalk,
+/obj/effect/turf_decal/delivery/white/hollow,
+/turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "oXN" = (
 /obj/structure/cable/extra_insulated{
@@ -79140,10 +79445,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "oZe" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "oZh" = (
@@ -79219,6 +79527,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
@@ -79464,8 +79778,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
 "pgD" = (
-/obj/structure/girder,
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/atmospherics/meter,
+/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "pgE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -80904,6 +81221,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"pBK" = (
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "pBP" = (
 /obj/effect/spawner/random/barrier/grille_often,
 /turf/simulated/floor/plating,
@@ -80974,9 +81298,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "pDz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/effect/spawner/random/barrier/grille_often,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/asmaint2)
 "pDK" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/carpet/black,
@@ -81112,6 +81439,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -81586,9 +81916,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
 /obj/item/stack/rods,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/port)
 "pOK" = (
@@ -81920,12 +82247,14 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/dorms)
 "pTK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
-/area/station/maintenance/fpmaint2)
+/area/station/maintenance/asmaint)
 "pTX" = (
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/plasteel/dark,
@@ -82007,15 +82336,9 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "pVq" = (
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "arrivalsmaint_btn_ext";
-	ext_door_link_id = "arrivalsmaint_door_ext";
-	int_button_link_id = "arrivalsmaint_btn_int";
-	int_door_link_id = "arrivalsmaint_door_int";
-	pixel_x = 25;
-	req_access = list(13);
-	vent_link_id = "arrivalsmaint_vent"
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/airlock_controller/air_cycler/directional/east,
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "pVs" = (
@@ -82130,6 +82453,10 @@
 /obj/effect/turf_decal/tiles/department/cargo,
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
+"pYI" = (
+/obj/structure/transit_tube,
+/turf/space,
+/area/space)
 "pYS" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -82985,9 +83312,10 @@
 /area/station/engineering/supermatter_room)
 "qmv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-4"
 	},
+/obj/machinery/power/apc/reinforced/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "qmw" = (
@@ -83030,13 +83358,10 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "qmU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "qmW" = (
 /obj/machinery/power/apc/directional/west,
@@ -83527,6 +83852,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "qup" = (
@@ -83883,6 +84211,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
+"qzS" = (
+/obj/machinery/light/small/directional/west,
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "qAg" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -84094,17 +84426,11 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/supermatter)
 "qCO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/extra_insulated{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
-/obj/effect/turf_decal/tiles/neutral/side{
-	dir = 8
-	},
-/turf/simulated/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "qCZ" = (
 /obj/machinery/light/small/directional/north,
@@ -85024,11 +85350,10 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/procedure/trainer_office)
 "qOP" = (
-/obj/machinery/door/airlock/atmos,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
 	},
+/obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "qOQ" = (
@@ -85413,8 +85738,20 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/area/station/maintenance/fpmaint2)
 "qUQ" = (
 /obj/machinery/kitchen_machine/microwave,
 /obj/structure/table,
@@ -85743,8 +86080,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "raN" = (
-/obj/machinery/light/floor,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/effect/turf_decal/loading_area,
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "raP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86039,12 +86382,18 @@
 /turf/simulated/floor/wood/parquet/oak,
 /area/station/command/office/hop)
 "rfB" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/curved{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/aft)
 "rgl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -86748,6 +87097,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
+"rwf" = (
+/obj/effect/turf_decal/trimline/misc/toxins/line,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "rwo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -86782,6 +87141,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
@@ -87400,6 +87762,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plasteel/dark,
 /area/station/ai_monitored/storage/eva)
+"rJk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/apmaint)
 "rJo" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/decal/cleanable/dirt,
@@ -87424,6 +87793,13 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/central/nw)
+"rJY" = (
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine/reactor)
 "rKe" = (
 /obj/effect/turf_decal/delivery/hollow,
 /obj/machinery/atmospherics/unary/portables_connector{
@@ -87586,18 +87962,12 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "fpsolar_vent"
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "fpsolar_btn_ext";
-	ext_door_link_id = "fpsolar_door_ext";
-	int_button_link_id = "fpsolar_btn_int";
-	int_door_link_id = "fpsolar_door_int";
-	pixel_x = 25;
-	req_access = list(13);
-	vent_link_id = "fpsolar_vent"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/airlock_controller/air_cycler/directional/east,
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "rMX" = (
@@ -87678,6 +88048,16 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/sleeper)
+"rPg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/sign/vacuum/external{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "rPi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/hologram/holopad,
@@ -87701,10 +88081,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "rPQ" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
 "rPS" = (
@@ -87820,9 +88202,6 @@
 /area/station/engineering/utility)
 "rRx" = (
 /obj/effect/decal/cleanable/dust,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -87937,7 +88316,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "rTF" = (
 /obj/structure/grille,
@@ -88044,6 +88426,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment/corner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -88382,6 +88767,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "sbR" = (
@@ -88693,6 +89081,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -89037,6 +89431,13 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
+"snn" = (
+/obj/machinery/alarm/directional/west,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "snx" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -89287,6 +89688,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "sqG" = (
@@ -89460,14 +89862,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/entry/south)
 "sug" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/area/station/maintenance/apmaint)
 "suo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -89547,6 +89952,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -89719,7 +90127,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/portable/pump,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "syQ" = (
@@ -89753,6 +90163,9 @@
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -89976,11 +90389,7 @@
 /obj/item/tank/internals/air{
 	pixel_x = 7
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "0-8"
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/reinforced/directional/east,
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 4
 	},
@@ -90211,7 +90620,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/extra_insulated{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -90568,6 +90977,16 @@
 /obj/effect/spawner/random/fungus/frequent,
 /turf/simulated/wall,
 /area/station/medical/patients_rooms)
+"sKV" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/north,
+/turf/simulated/floor/plating,
+/area/station/maintenance/storage)
 "sLe" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
@@ -90709,21 +91128,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/storage)
 "sOr" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "fpsolar_door_ext";
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "fpsolar_btn_ext";
-	pixel_x = 24;
-	req_access = list(13)
+/obj/machinery/door/airlock/external/glass{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/access_button/offset/northeast,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_port)
 "sOE" = (
@@ -90792,6 +91205,7 @@
 	c_tag = "North-West External Airlock";
 	dir = 4
 	},
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "sPs" = (
@@ -90893,20 +91307,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/public/storage/tools)
 "sRg" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 8
 	},
-/obj/machinery/access_button{
-	autolink_id = "fpmaint_btn_int";
-	req_access = list(13);
-	pixel_y = 24
-	},
-/obj/machinery/door/airlock/external{
-	id_tag = "fpmaint_door_int"
-	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/north,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint2)
 "sRi" = (
@@ -90948,6 +91355,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -91048,19 +91458,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "assolar_btn_ext";
-	ext_door_link_id = "assolar_door_ext";
-	int_button_link_id = "assolar_btn_int";
-	int_door_link_id = "assolar_door_int";
-	pixel_x = 25;
-	req_access = list(13);
-	vent_link_id = "assolar_vent"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "assolar_vent";
 	dir = 1
 	},
+/obj/effect/map_effect/dynamic_airlock,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/airlock_controller/air_cycler/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_starboard)
 "sTQ" = (
@@ -91178,11 +91582,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "sUD" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -91452,15 +91858,12 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "sZJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/decal/cleanable/dust,
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/aft)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/fsmaint)
 "sZP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -91724,6 +92127,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
+"tdP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "tdT" = (
 /obj/machinery/atmospherics/binary/volume_pump{
 	dir = 8;
@@ -91866,6 +92273,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "tga" = (
@@ -91874,12 +92284,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "tgb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plasteel,
-/area/station/maintenance/aft)
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint2)
 "tgh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -92533,7 +92948,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "tqZ" = (
@@ -92840,6 +93257,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "arrivalsmaint_vent"
 	},
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "twi" = (
@@ -93062,6 +93480,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "tzW" = (
@@ -93098,10 +93519,10 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/machinery/alarm/directional/north,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/aft_port)
 "tAp" = (
@@ -93119,10 +93540,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
 "tAz" = (
@@ -93694,12 +94115,10 @@
 /area/station/security/evidence)
 "tKA" = (
 /obj/machinery/door/airlock/external{
-	id_tag = "evamaint_door_int";
 	dir = 4
 	},
+/obj/effect/map_effect/dynamic_airlock/door/interior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "tKL" = (
@@ -93803,17 +94222,32 @@
 /turf/simulated/floor/engine,
 /area/station/science/misc_lab)
 "tMm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
 "tMq" = (
 /obj/effect/spawner/window/reinforced/plasma/grilled,
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/station/engineering/supermatter_room)
+"tMr" = (
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fsmaint)
 "tMs" = (
 /obj/machinery/computer/nonfunctional{
 	dir = 1
@@ -94094,8 +94528,8 @@
 /turf/simulated/floor/plating,
 /area/station/science/toxins/launch)
 "tQa" = (
-/obj/machinery/atmospherics/binary/valve/open{
-	name = "Maintenance Air Supply"
+/obj/machinery/atmospherics/trinary/tvalve/flipped/bypass{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/apmaint)
@@ -94268,19 +94702,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	id_tag = "fssolar_door_int";
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/external/glass{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "fssolar_btn_int";
-	pixel_x = 24;
-	req_access = list(13)
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "tTh" = (
@@ -94327,12 +94755,12 @@
 /turf/simulated/floor/plasteel,
 /area/station/hallway/primary/aft)
 "tTv" = (
-/obj/structure/grille,
-/obj/structure/cable/extra_insulated{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/fsmaint)
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/asmaint)
 "tTx" = (
 /obj/effect/mapping_helpers/turfs/rust,
 /turf/simulated/wall,
@@ -94465,7 +94893,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint2)
 "tWh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -94523,9 +94951,6 @@
 "tWI" = (
 /obj/effect/spawner/random/barrier/grille_maybe,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
@@ -94561,13 +94986,18 @@
 /turf/simulated/floor/plating,
 /area/station/turret_protected/aisat/interior)
 "tXx" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 8
+/obj/structure/chair/comfy/brown{
+	color = "#514E58";
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/turf/simulated/floor/plasteel/dark,
 /area/station/maintenance/fsmaint)
 "tXD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -94743,6 +95173,9 @@
 /obj/structure/table,
 /obj/item/toy/crayon/spraycan,
 /obj/item/restraints/handcuffs/cable/random,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "tZx" = (
@@ -95144,6 +95577,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "ufw" = (
@@ -95257,14 +95693,14 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/paramedic)
 "uhA" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
@@ -95302,6 +95738,9 @@
 /obj/effect/spawner/wire_splicing/thirty,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
@@ -95366,11 +95805,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ujG" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/door/airlock/wood,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/storage)
+/area/station/maintenance/asmaint)
 "ujR" = (
 /obj/effect/turf_decal/tiles/department/command/side{
 	dir = 10
@@ -95397,9 +95838,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/abandonedbar)
 "uki" = (
-/obj/effect/spawner/random/barrier/grille_maybe,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plasteel,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 6
+	},
+/obj/machinery/atmospherics/meter,
+/turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "ukl" = (
 /obj/machinery/door/window/classic/reversed,
@@ -95492,6 +95936,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -95623,6 +96070,9 @@
 	icon_state = "0-4"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -95945,15 +96395,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	autolink_id = "fssolar_vent"
 	},
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "fssolar_btn_ext";
-	ext_door_link_id = "fssolar_door_ext";
-	int_button_link_id = "fssolar_btn_int";
-	int_door_link_id = "fssolar_door_int";
-	pixel_x = 25;
-	req_access = list(13);
-	vent_link_id = "fssolar_vent"
-	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/effect/map_effect/dynamic_airlock,
+/obj/machinery/airlock_controller/air_cycler/directional/east,
 /turf/simulated/floor/plating,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "utu" = (
@@ -96061,6 +96505,9 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "uvc" = (
@@ -96157,17 +96604,20 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "uwh" = (
-/obj/structure/transit_tube/station/reverse/flipped{
-	dir = 8
-	},
 /obj/structure/transit_tube_pod{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/end,
-/turf/simulated/floor/plating,
+/obj/structure/transit_tube/station/reverse,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel/dark,
 /area/station/turret_protected/aisat/interior)
 "uwi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -96216,13 +96666,17 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/gravitygenerator)
 "uwH" = (
-/obj/effect/map_effect/dynamic_airlock,
-/obj/machinery/atmospherics/unary/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/portable/canister/air,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine/reactor)
+/area/station/maintenance/port2)
 "uwJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -96994,19 +97448,13 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fpmaint)
 "uJB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/external{
-	id_tag = "evamaint_door_int";
 	dir = 4
 	},
+/obj/machinery/access_button/offset/east,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button{
-	autolink_id = "evamaint_btn_int";
-	req_access = list(13);
-	pixel_x = 24
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "uJF" = (
@@ -97043,9 +97491,11 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/binary/valve,
 /obj/effect/turf_decal/tiles/neutral/side{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
@@ -97094,6 +97544,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "uLo" = (
@@ -97127,12 +97578,9 @@
 /turf/simulated/floor/plasteel,
 /area/station/engineering/atmos)
 "uLw" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "secmaint_door_ext"
-	},
+/obj/machinery/door/airlock/external,
+/obj/effect/map_effect/dynamic_airlock/door/exterior,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "uLD" = (
@@ -97564,15 +98012,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "uTo" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "secmaint_door_int"
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fore)
 "uTu" = (
@@ -97947,6 +98392,10 @@
 /area/station/science/xenobiology)
 "vaz" = (
 /obj/machinery/alarm/directional/south,
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "vaH" = (
@@ -98025,6 +98474,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -98284,6 +98736,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "vfa" = (
@@ -98524,13 +98979,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
 "vim" = (
@@ -98822,6 +99275,12 @@
 	color = "gray"
 	},
 /area/station/command/bridge)
+"vnV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint)
 "vnY" = (
 /obj/structure/chair{
 	dir = 8
@@ -99748,6 +100207,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "vDX" = (
@@ -99798,8 +100260,9 @@
 /obj/effect/decal/cleanable/dust,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/extra_insulated{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "vEr" = (
@@ -100157,9 +100620,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/science/robotics/chargebay)
 "vKa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine/reactor)
@@ -100353,6 +100818,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "vMV" = (
@@ -100394,6 +100860,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
@@ -100643,6 +101112,9 @@
 "vRd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "vRp" = (
@@ -100743,7 +101215,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/portable/canister/air,
-/obj/effect/turf_decal/delivery/hollow,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/engineering/ai_transit_tube)
 "vSH" = (
@@ -100882,6 +101354,12 @@
 	},
 /turf/simulated/floor/plasteel,
 /area/station/supply/warehouse)
+"vUY" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "vUZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/virology/side{
@@ -101449,7 +101927,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "wdm" = (
+/obj/machinery/atmospherics/unary/tank/air,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "wdO" = (
@@ -101519,6 +102001,13 @@
 /obj/effect/turf_decal/tiles/department/science/side,
 /turf/simulated/floor/plasteel/white,
 /area/station/science/genetics)
+"wfg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/fpmaint2)
 "wfP" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
@@ -101545,6 +102034,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/sortjunc_helper/chapel,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "wgt" = (
@@ -101993,6 +102485,7 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "wpR" = (
@@ -102484,19 +102977,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint2)
 "wwc" = (
-/obj/machinery/airlock_controller/air_cycler{
-	ext_button_link_id = "evamaint_btn_ext";
-	ext_door_link_id = "evamaint_door_ext";
-	int_button_link_id = "evamaint_btn_int";
-	int_door_link_id = "evamaint_door_int";
-	name = "EVA Airlock Console";
-	pixel_x = 25;
-	req_access = list(1,5,11,18,24);
-	vent_link_id = "evamaint_vent"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/airlock_controller/air_cycler/directional/east,
+/obj/effect/map_effect/dynamic_airlock,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "wwL" = (
@@ -102766,7 +103252,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/medical/cloning)
 "wBH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -102777,6 +103262,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -103558,12 +104046,10 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint2)
 "wPX" = (
@@ -103713,6 +104199,11 @@
 	},
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay2)
+"wRL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/barrier/grille_often,
+/turf/simulated/floor/plasteel,
+/area/station/maintenance/port2)
 "wRN" = (
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -103841,8 +104332,8 @@
 /obj/machinery/atmospherics/portable/canister/air{
 	filled = 0.1
 	},
-/obj/effect/turf_decal/delivery/hollow,
 /obj/effect/turf_decal/tiles/neutral,
+/obj/effect/turf_decal/delivery/white/hollow,
 /turf/simulated/floor/plasteel,
 /area/station/hallway/secondary/exit)
 "wVi" = (
@@ -104012,6 +104503,7 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/solar_maintenance/fore_starboard)
 "wXC" = (
@@ -104049,6 +104541,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "wYi" = (
@@ -104557,6 +105050,12 @@
 	icon_state = "cult"
 	},
 /area/station/maintenance/fsmaint)
+"xeW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/port)
 "xfi" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/button/windowtint/north{
@@ -105285,6 +105784,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/mapping_helpers/sortjunc_helper/kitchen,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fsmaint)
 "xrI" = (
@@ -105449,6 +105951,9 @@
 /area/station/maintenance/aft)
 "xtZ" = (
 /mob/living/basic/pet/penguin/baby,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/carpet,
 /area/station/maintenance/asmaint)
 "xub" = (
@@ -106329,17 +106834,13 @@
 /turf/simulated/floor/carpet,
 /area/station/service/chapel)
 "xJf" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "departues_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/access_button/directional/west{
-	req_access = list(13);
-	autolink_id = "departues_btn_int"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/machinery/access_button/offset/west,
+/obj/machinery/door/airlock/external{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "xJi" = (
@@ -106612,12 +107113,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/medical/virology)
 "xML" = (
-/obj/effect/spawner/window/reinforced/tinted/grilled,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/asmaint)
+/area/station/maintenance/asmaint2)
 "xNr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -106671,6 +107176,9 @@
 /obj/structure/disposalpipe/segment/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/fsmaint)
 "xOM" = (
@@ -106685,8 +107193,8 @@
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint)
@@ -107087,6 +107595,12 @@
 /obj/item/trash/semki,
 /turf/simulated/floor/plating,
 /area/station/maintenance/aft)
+"xTM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/station/maintenance/asmaint)
 "xTV" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -107319,16 +107833,12 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/command/bridge)
 "xXe" = (
-/obj/effect/spawner/window/reinforced/grilled,
-/obj/structure/transit_tube,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/turret_protected/aisat/interior)
+/turf/simulated/floor/engine,
+/area/station/engineering/engine/reactor)
 "xXt" = (
 /obj/structure/railing{
 	dir = 1
@@ -107374,6 +107884,7 @@
 "xXP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/fpmaint2)
 "xYc" = (
@@ -107718,6 +108229,14 @@
 /obj/effect/turf_decal/tiles/neutral,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/prisonlockers)
+"ydF" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/asmaint)
 "ydH" = (
 /obj/effect/turf_decal/tiles/dark/side{
 	dir = 8
@@ -107747,7 +108266,8 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
-/turf/simulated/wall/r_wall,
+/obj/effect/spawner/window/reinforced/plasma/grilled,
+/turf/simulated/floor/plating,
 /area/station/engineering/engine/reactor)
 "yfa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -108168,24 +108688,16 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/execution)
 "yjR" = (
-/obj/machinery/door/airlock/external{
-	id_tag = "scibomb_door_int"
-	},
-/obj/effect/mapping_helpers/airlock/autoname,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
-/obj/machinery/access_button/directional/east{
-	autolink_id = "scibomb_btn_int";
-	pixel_y = -24;
-	req_access = list(13);
-	pixel_x = 0
-	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/map_effect/dynamic_airlock/door/interior,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/access_button/offset/northwest,
 /turf/simulated/floor/plating,
 /area/station/maintenance/asmaint)
 "yko" = (
@@ -119989,7 +120501,7 @@ aII
 aII
 aII
 aII
-aHl
+rPg
 aHl
 vPw
 aPR
@@ -120246,7 +120758,7 @@ jXg
 pVq
 tvQ
 dur
-pTK
+eyB
 xtv
 aGn
 aPR
@@ -120503,8 +121015,8 @@ aII
 aII
 aII
 aII
-aNC
-aHS
+aNx
+aHl
 aGn
 ctl
 aSf
@@ -121274,7 +121786,7 @@ aGn
 bat
 aGn
 aGn
-aNB
+nXM
 flm
 aKW
 aGn
@@ -121530,8 +122042,8 @@ aHR
 pql
 aGn
 blL
-aHl
-aHS
+fJD
+dhL
 aHl
 aHS
 aTh
@@ -121787,7 +122299,7 @@ aHM
 aIJ
 aKW
 aKb
-aHS
+jjl
 aGn
 aKW
 aGn
@@ -122044,7 +122556,7 @@ sve
 erj
 aGn
 aDD
-aHl
+dyw
 aGn
 aOT
 fcQ
@@ -122555,7 +123067,7 @@ aED
 aFR
 aHg
 aIw
-aKa
+jEe
 aGn
 aLu
 jwb
@@ -122593,10 +123105,10 @@ bnS
 bnS
 bLJ
 gGr
-mBH
+uwH
+jsb
 cyp
-cyp
-rvc
+wRL
 vLl
 mJy
 bXG
@@ -122815,7 +123327,7 @@ hCz
 aKa
 aGn
 fRo
-iOQ
+jEV
 aGn
 aOU
 jSe
@@ -123072,7 +123584,7 @@ aHS
 aGn
 aGn
 aGn
-oGl
+miW
 aKW
 aOW
 dyw
@@ -123894,7 +124406,7 @@ bKv
 bKv
 sXB
 fPh
-dQE
+gBh
 mCD
 fIr
 mnc
@@ -124131,7 +124643,7 @@ rvc
 oDv
 rvc
 tEG
-gGr
+lFQ
 ljo
 cyj
 bXG
@@ -125635,7 +126147,7 @@ aaa
 aaa
 bat
 mLH
-mLH
+hbo
 plj
 aEL
 dRb
@@ -126185,8 +126697,8 @@ msU
 dIP
 blM
 wRz
-nVg
-jZu
+wRz
+blQ
 bKt
 wBH
 qLt
@@ -126414,12 +126926,12 @@ uKQ
 jjl
 aHS
 aHS
-aHl
+wfg
 aHS
 aLt
 aKW
 qky
-aHS
+nUM
 uii
 aVi
 aWm
@@ -126955,8 +127467,8 @@ bng
 blM
 blM
 bvq
-blQ
 nqv
+aNC
 blQ
 svp
 iAM
@@ -127191,7 +127703,7 @@ lpV
 aHl
 aHS
 aLu
-jKr
+qUw
 aVi
 aWr
 vbF
@@ -127214,8 +127726,8 @@ fcH
 blQ
 bET
 hme
-bnK
-bnK
+qzS
+xeW
 faB
 kPN
 bxb
@@ -127528,7 +128040,7 @@ bXa
 oZe
 wkt
 pqE
-wkt
+muz
 qwW
 wkt
 wkt
@@ -127779,13 +128291,13 @@ aaa
 aaa
 aaa
 eLt
-sbl
+snz
 jVI
 bXa
-lYF
+dFF
 xhg
 fmZ
-mKH
+xXe
 fmZ
 jvr
 jvr
@@ -128016,7 +128528,7 @@ cgQ
 kSp
 jsz
 vZX
-qSB
+rJk
 qSB
 vUq
 vZX
@@ -128036,13 +128548,13 @@ aaa
 aaa
 aaa
 eLt
-snz
-sbl
+rJY
+tMm
 cZF
 vKa
-tMm
+hcy
 tAu
-uAr
+kQv
 uJK
 hft
 eIV
@@ -128293,12 +128805,12 @@ aaa
 aaa
 aaa
 eLt
-uwH
+sbl
 mfO
 bXa
 jsC
-hcy
-diq
+cvn
+rwf
 egM
 egM
 nRi
@@ -128554,7 +129066,7 @@ bXa
 bXa
 bXa
 nDI
-bvr
+hcy
 geq
 egM
 egM
@@ -129006,7 +129518,7 @@ kTx
 bnz
 bnw
 asI
-svp
+cPI
 sDJ
 bnK
 qTC
@@ -129054,7 +129566,7 @@ nXK
 gfC
 cvp
 cgQ
-oMc
+rbX
 daY
 cgQ
 aab
@@ -129311,7 +129823,7 @@ cgQ
 wsD
 gYs
 sKs
-cCo
+vKe
 cdG
 cgQ
 aaa
@@ -129569,7 +130081,7 @@ euD
 cgQ
 cLF
 nJz
-lNb
+iOQ
 gzN
 aaa
 aaa
@@ -130066,8 +130578,8 @@ cGE
 esD
 pzr
 cam
-gzN
-cgQ
+aaa
+aab
 cgQ
 hIY
 vOy
@@ -130323,8 +130835,8 @@ eKd
 rWn
 cqA
 cam
-bvo
-coM
+gzN
+cgQ
 cgQ
 oZr
 ggr
@@ -130626,8 +131138,8 @@ ayk
 ayk
 pqn
 dcq
-ddr
-nWF
+iym
+dgc
 aab
 aaa
 aaa
@@ -131140,7 +131652,7 @@ ayk
 ayk
 ayk
 dcq
-ddr
+sKV
 dgc
 dgc
 aab
@@ -131397,8 +131909,8 @@ ayk
 eZi
 wPu
 dcq
-ujG
-uOG
+gKF
+nEf
 dgc
 rLy
 aaa
@@ -131654,7 +132166,7 @@ bXa
 bXa
 bXa
 dcq
-ujG
+ddr
 rmu
 xvS
 dgS
@@ -132132,8 +132644,8 @@ mCA
 cqs
 gYs
 xOA
-aai
-cqs
+sug
+nrM
 iFh
 tGO
 cKb
@@ -132168,9 +132680,9 @@ kvn
 jVD
 rLy
 ddt
-gKF
-dhL
-otr
+ddr
+ddr
+uOG
 dzg
 ncY
 irV
@@ -134128,7 +134640,7 @@ aPA
 aRQ
 aEl
 xOQ
-aPi
+vnV
 aRw
 aRw
 aRw
@@ -143186,7 +143698,7 @@ cyJ
 uWP
 chf
 nBN
-cyJ
+ibt
 vih
 wHh
 cAe
@@ -146954,7 +147466,7 @@ awl
 awl
 awl
 awl
-avq
+att
 avq
 atG
 atG
@@ -147211,8 +147723,8 @@ avq
 asf
 atw
 atT
-auK
 qtm
+avq
 atG
 aup
 avq
@@ -147497,7 +148009,7 @@ aXi
 kua
 aUQ
 leL
-sCE
+pBK
 xrq
 aSR
 fEN
@@ -148109,7 +148621,7 @@ aab
 doE
 doE
 doE
-aab
+doE
 iUc
 dQC
 jfW
@@ -148269,7 +148781,7 @@ aUQ
 aUQ
 aUQ
 mAX
-aVA
+nWF
 beb
 beb
 beb
@@ -148361,12 +148873,12 @@ doE
 doE
 doE
 doE
-aaa
 aab
-aYg
+aab
+doE
 cEa
+cCh
 dmB
-dpf
 iUc
 rTy
 wbr
@@ -148508,12 +149020,12 @@ aaa
 aHN
 xnb
 sCE
-bkD
+hCG
 aGX
 wdm
-pIY
+snn
 uki
-aGY
+fke
 ozS
 iTC
 jKA
@@ -148526,7 +149038,7 @@ aJw
 hsm
 aUQ
 aGY
-aVA
+nWF
 bfB
 bhu
 nTn
@@ -148607,23 +149119,23 @@ aab
 aab
 aab
 seH
+bvr
+dkZ
+bvr
+dkZ
+bvr
+dkZ
+bvr
 dkZ
 dkZ
-dkZ
-dkZ
-dkZ
-dkZ
-dkZ
-cCh
-aab
-aaa
+pYI
+bvo
 doE
-aab
-aab
-wlF
+doE
+doE
 cNv
 dnW
-dpf
+fWu
 iUc
 iUc
 nzm
@@ -148765,12 +149277,12 @@ aaa
 aHN
 aUK
 hkN
-sCE
-kCH
-pIY
+lPR
+aGX
+eYz
 pgD
-aHb
-hkN
+eUV
+aGX
 qmv
 aGY
 aLc
@@ -148877,7 +149389,7 @@ aab
 doE
 cvb
 ajU
-nrM
+ajU
 cyz
 dnV
 dpf
@@ -149021,15 +149533,15 @@ aHN
 aHN
 aGX
 aGX
-aGX
-bmH
-hCG
-aQL
+jZu
+cui
 aGX
 aGX
+aGX
+otr
 aGX
 qOP
-aGX
+aGY
 aHP
 aUQ
 aQC
@@ -149117,7 +149629,7 @@ jpi
 cjd
 cjd
 dRk
-kcx
+cAv
 chf
 chf
 chf
@@ -149129,7 +149641,7 @@ chf
 chf
 chf
 aab
-rfB
+aab
 aab
 doE
 kKJ
@@ -149280,13 +149792,13 @@ naG
 mcF
 vMN
 vMN
-kWL
-qCO
+jQW
+jQW
 jQW
 uKn
 aKT
 aMi
-ikx
+aGY
 aYK
 aUQ
 aUQ
@@ -149374,7 +149886,7 @@ cAB
 chf
 dhQ
 csa
-sZJ
+cyJ
 chf
 yjA
 xlg
@@ -149387,9 +149899,9 @@ cyJ
 cAe
 aaa
 aab
-seH
-dkZ
-xXe
+dsI
+doE
+kKJ
 uwh
 raN
 eVD
@@ -149538,8 +150050,8 @@ aGX
 bmH
 hhl
 sCd
-kQw
-tXx
+ikx
+hCG
 aQL
 bwW
 cKu
@@ -149631,7 +150143,7 @@ ufC
 chf
 ctZ
 eGC
-sug
+wtp
 vbQ
 wtp
 wtp
@@ -150109,7 +150621,7 @@ oum
 gYq
 bWf
 jDB
-fke
+ckL
 wGj
 cQk
 cQk
@@ -150144,8 +150656,8 @@ cJv
 msm
 chf
 ctZ
-csa
-mEx
+oGl
+cep
 chf
 chf
 hNr
@@ -150403,9 +150915,9 @@ chf
 ctZ
 fhE
 gaS
-sCR
-lxE
-lxE
+gaS
+kcx
+otQ
 hzN
 chf
 vpS
@@ -150609,7 +151121,7 @@ rcD
 trp
 aDR
 bGG
-dlD
+mnd
 pIx
 bWd
 bWd
@@ -150658,12 +151170,12 @@ cep
 pWW
 chf
 dbq
-ibt
-gBh
-gBh
-pDz
-tgb
-hKw
+csK
+cAv
+cAv
+cep
+cAv
+kQw
 chf
 chf
 chf
@@ -150866,7 +151378,7 @@ qVK
 nmN
 qyT
 wvQ
-sTX
+tgb
 bWA
 rkb
 hpR
@@ -150919,7 +151431,7 @@ cxO
 cxO
 cxO
 cxO
-cPI
+cep
 nDq
 otV
 cep
@@ -151094,7 +151606,7 @@ aGX
 aGX
 aGX
 aGY
-bkF
+sZJ
 vDW
 aGY
 aGX
@@ -151124,7 +151636,7 @@ bYA
 cbs
 wfS
 kds
-fWu
+bAS
 eUT
 eUT
 jtF
@@ -151176,8 +151688,8 @@ qig
 qig
 dbR
 cxO
-cFm
-bop
+cAv
+auK
 chf
 cOq
 cTB
@@ -151433,8 +151945,8 @@ cJK
 cJK
 gGQ
 cxO
-cPI
-hKw
+cep
+kQw
 chf
 cAz
 cDm
@@ -151654,7 +152166,7 @@ qZN
 qZN
 qZN
 qZN
-pBP
+pDz
 qzh
 cuQ
 cuQ
@@ -151690,7 +152202,7 @@ cJK
 cJK
 cJK
 cxO
-cFm
+cAv
 rwI
 chf
 cyJ
@@ -151911,7 +152423,7 @@ rEv
 xrP
 psU
 psU
-xrP
+xML
 xBP
 rgZ
 bDA
@@ -151947,8 +152459,8 @@ sUZ
 gyS
 jdZ
 cxO
-cPI
-hbP
+cep
+rfB
 rTF
 cyJ
 uqE
@@ -152884,7 +153396,7 @@ aGY
 hrS
 aKV
 efN
-aNj
+tXx
 lPR
 heL
 aQO
@@ -153916,11 +154428,11 @@ xiA
 amW
 fDc
 wpN
-jFh
+vEo
 vEo
 gtV
-xCs
-xCs
+qCO
+kmK
 dxa
 aGX
 aHO
@@ -154177,7 +154689,7 @@ aGX
 jFA
 gzS
 aGX
-aGY
+hmA
 sGs
 baz
 baz
@@ -154431,7 +154943,7 @@ hsz
 vmH
 sBN
 aGX
-tTv
+cqC
 six
 aGX
 aHb
@@ -154500,7 +155012,7 @@ cMS
 enO
 lPL
 mXz
-dlD
+gLn
 cQs
 qZN
 cSf
@@ -154688,7 +155200,7 @@ ton
 mDv
 wAP
 aOC
-qUw
+aGY
 ehK
 bhA
 bhA
@@ -154935,7 +155447,7 @@ aDY
 aEW
 aCP
 aAY
-uvk
+tdP
 aGX
 ktP
 lPp
@@ -155289,8 +155801,8 @@ nIF
 vIW
 oJr
 bUx
-ayQ
-csL
+kWL
+vUY
 ciY
 ciY
 ciY
@@ -155459,7 +155971,7 @@ bPR
 inm
 aGX
 vgm
-ulv
+tMr
 bhA
 jJU
 aXk
@@ -155546,7 +156058,7 @@ oJr
 oJr
 oJr
 kMc
-uAg
+iWx
 csL
 djP
 cKF
@@ -156060,7 +156572,7 @@ gPb
 ciY
 csL
 jPx
-uAg
+iWx
 ciY
 ciY
 ciY
@@ -156488,7 +157000,7 @@ aKZ
 qYO
 woV
 lIQ
-ehK
+bkD
 bhA
 aYz
 dDI
@@ -156831,7 +157343,7 @@ dci
 ciY
 cKF
 csL
-fyM
+mEx
 cBQ
 fpO
 cBQ
@@ -157001,7 +157513,7 @@ aGX
 aGX
 aGX
 aJM
-qUw
+aGY
 gXX
 bhA
 aYB
@@ -157088,7 +157600,7 @@ ugC
 cBe
 cga
 cga
-fyM
+mEx
 dSu
 aaa
 ciY
@@ -157344,8 +157856,8 @@ ciY
 uuH
 ePu
 hyk
-cga
-fyM
+jFh
+mEx
 ciY
 ciY
 ciY
@@ -157850,15 +158362,15 @@ lZw
 oph
 nwG
 nwG
-gWv
-gWv
 gOE
+gWv
+gWv
 qxd
 ciY
 bUx
 csL
 csL
-bVd
+nSH
 cga
 ePu
 ePu
@@ -158107,15 +158619,15 @@ tqd
 ciY
 kMc
 jjs
-csL
-hyk
 hFz
+hyk
+csL
 ugC
 ciY
 ciY
 ciY
 dSu
-bVd
+nSH
 ePu
 vMe
 cKF
@@ -158364,9 +158876,9 @@ mtx
 ciY
 cDo
 csL
-ugC
+coM
 ciY
-xML
+ciY
 dSu
 ciY
 rVK
@@ -158623,13 +159135,13 @@ cDo
 ePu
 ugC
 ciY
-ofq
-osq
+csL
+csL
 dXm
 dXm
-mxJ
+csL
 cQw
-bVd
+nSH
 ePu
 djC
 djQ
@@ -158884,8 +159396,8 @@ csL
 csL
 tZu
 fvV
-fJD
-slp
+osq
+pTK
 eSz
 duF
 cOm
@@ -159110,8 +159622,8 @@ crK
 cgs
 cgs
 bRs
-csL
-hFz
+aYg
+kCH
 rSS
 cAP
 poC
@@ -159144,7 +159656,7 @@ dfU
 baZ
 ciY
 cBe
-csL
+hFz
 lrL
 deE
 deZ
@@ -159401,7 +159913,7 @@ ciY
 dSu
 ciY
 rID
-csL
+hFz
 ciY
 djQ
 djQ
@@ -159639,7 +160151,7 @@ lhy
 wvz
 pfF
 hes
-osq
+cFm
 osq
 igV
 hyk
@@ -159658,7 +160170,7 @@ csL
 csL
 ugp
 csL
-cga
+oNZ
 ciY
 kgc
 ciY
@@ -159896,7 +160408,7 @@ ciY
 cDo
 cga
 csL
-ePu
+tTv
 cga
 hFz
 csL
@@ -159915,7 +160427,7 @@ iMG
 ciY
 ciY
 ciY
-dZA
+ujG
 ciY
 ciY
 ciY
@@ -160142,7 +160654,7 @@ ciY
 cwS
 ciY
 ciY
-csL
+hFz
 ofP
 ciY
 ciY
@@ -160172,7 +160684,7 @@ ciY
 ciY
 fxN
 kEe
-kju
+xTM
 ibW
 jtP
 cBQ
@@ -160399,7 +160911,7 @@ jwr
 fPr
 mMk
 ciY
-dci
+ydF
 ciY
 ciY
 smL
@@ -160653,10 +161165,10 @@ doK
 nBc
 cgs
 vDX
-bVd
+nSH
 ctq
 ciY
-csL
+hFz
 raL
 ciY
 dci
@@ -160913,9 +161425,9 @@ qCZ
 sRw
 vaz
 ciY
-csL
-fmn
-qth
+ofq
+nVg
+diH
 csL
 oXK
 isD
@@ -161426,7 +161938,7 @@ cgs
 oPX
 jQD
 asF
-csL
+fMA
 ciY
 qup
 ciY
@@ -161937,8 +162449,8 @@ xhR
 fDJ
 aab
 ciY
-ciY
 cBQ
+ciY
 yjR
 ciY
 ciY
@@ -162195,7 +162707,7 @@ fDJ
 aaa
 aaa
 aab
-cBQ
+ciY
 cGW
 ciY
 kMc
@@ -162452,7 +162964,7 @@ fDJ
 aab
 aaa
 aab
-cBQ
+ciY
 mAZ
 ciY
 ciY

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -12957,7 +12957,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aLz" = (
@@ -13069,14 +13068,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13091,14 +13090,14 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13109,15 +13108,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/effect/turf_decal/tiles/department/engineering/corner,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13322,9 +13321,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
 "aMv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -13794,6 +13790,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOb" = (
@@ -13816,15 +13813,14 @@
 	dir = 8;
 	network = list("SS13","Engineering")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
 /obj/machinery/alarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOf" = (
@@ -13999,6 +13995,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOE" = (
@@ -14021,13 +14018,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aOG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc/critical/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOH" = (
@@ -14522,6 +14518,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPK" = (
@@ -14555,7 +14552,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPO" = (
@@ -14868,9 +14864,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aQU" = (
@@ -15106,6 +15099,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aRI" = (
@@ -15472,11 +15466,17 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSS" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -15499,22 +15499,16 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
 "aSV" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -16075,9 +16069,6 @@
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -18066,6 +18057,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "bbh" = (
@@ -18782,7 +18774,7 @@
 /area/station/maintenance/asmaint)
 "bdC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -25232,9 +25224,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "dBo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -33941,12 +33930,11 @@
 /turf/space,
 /area/station/science/toxins/mixing)
 "jxf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "jxp" = (
@@ -43985,6 +43973,13 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/procedure/trainer_office)
+"qHX" = (
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/supermatter_room)
 "qIe" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer,
 /turf/simulated/floor/plasteel,
@@ -44381,9 +44376,6 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/library)
 "qZy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -45995,6 +45987,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "shu" = (
@@ -54946,9 +54941,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "xAq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -77722,7 +77714,7 @@ aIf
 aJp
 aKy
 aLM
-soc
+qHX
 aNY
 aOz
 aPI
@@ -77991,7 +77983,7 @@ ajj
 iRv
 aOc
 bQk
-bQk
+tgh
 tgh
 htu
 aSa
@@ -78248,7 +78240,7 @@ aTa
 vsM
 gsh
 yfB
-yfB
+fwt
 fwt
 bwO
 aEQ

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -570,9 +570,6 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/ntrep)
 "abF" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/structure/reflector/box{
 	anchored = 1;
 	dir = 1
@@ -5019,9 +5016,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/meter{
-	autolink_id = "sm_sen_cold"
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
@@ -5264,6 +5258,10 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "apz" = (
@@ -5890,13 +5888,6 @@
 /obj/structure/rack,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
-"arp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/space,
-/area/space/nearstation)
 "arr" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
@@ -6126,6 +6117,9 @@
 	},
 /obj/machinery/atmospherics/binary/pump{
 	name = "Loop to Freezer"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -8131,6 +8125,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
 "ayA" = (
@@ -9509,12 +9506,14 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "aCE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+/obj/machinery/atmospherics/binary/valve/open{
+	name = "Filter to Space"
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/supermatter_room)
 "aCF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -12176,6 +12175,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aJv" = (
@@ -12950,9 +12952,12 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aLz" = (
@@ -13322,6 +13327,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -14298,6 +14309,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
 "aPq" = (
@@ -14530,25 +14544,18 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPN" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPO" = (
@@ -14566,9 +14573,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/rnd)
 "aPP" = (
-/obj/machinery/atmospherics/binary/valve/open{
-	name = "Filter to Space"
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPR" = (
@@ -14789,6 +14800,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aQK" = (
@@ -14845,11 +14859,18 @@
 "aQS" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aQU" = (
@@ -15447,14 +15468,15 @@
 /turf/simulated/floor/plating/asteroid,
 /area/station/maintenance/fpmaint2)
 "aSR" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -15484,6 +15506,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSY" = (
@@ -15497,14 +15522,15 @@
 	dir = 4;
 	name = "Gas to Loop"
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aTa" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 4
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -16008,13 +16034,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/bar)
 "aUD" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/trinary/filter/flipped{
-	dir = 4;
-	filter_type = -1
-	},
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aUE" = (
@@ -16055,7 +16076,12 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aUK" = (
@@ -16385,12 +16411,10 @@
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
 "aVR" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
+/obj/machinery/atmospherics/binary/volume_pump/on,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aVV" = (
@@ -16652,11 +16676,9 @@
 /area/station/service/library)
 "aWI" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aWJ" = (
@@ -17373,11 +17395,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "aYQ" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 4;
 	filter_type = 2
 	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aYS" = (
@@ -18764,6 +18786,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -21824,6 +21849,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "bxc" = (
@@ -24726,6 +24754,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "dli" = (
@@ -25207,11 +25238,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -28031,8 +28062,9 @@
 /area/station/supply/qm)
 "fwt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
@@ -32435,9 +32467,8 @@
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
 "isT" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -35420,6 +35451,10 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "kBq" = (
@@ -39782,11 +39817,10 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "nQo" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 1;
-	name = "Gas to Cooling Loop"
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
 	},
-/obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "nQp" = (
@@ -44356,6 +44390,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "rae" = (
@@ -46652,11 +46689,11 @@
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
 "sGA" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 4;
 	filter_type = -1
 	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "sGC" = (
@@ -47073,9 +47110,6 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/hop)
 "sLM" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/status_display/directional/south,
-/obj/effect/turf_decal/tiles/department/engineering/side,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -48598,12 +48632,8 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology/lab)
 "tAE" = (
-/obj/effect/turf_decal/tiles/department/engineering/side{
-	dir = 10
-	},
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Gas to Cooling Loop"
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "tBb" = (
@@ -50092,10 +50122,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "uwt" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/status_display/directional/south,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tiles/department/engineering/side,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/supermatter_room)
 "uwJ" = (
 /obj/machinery/door/airlock/public/glass{
 	dir = 4
@@ -54924,6 +54955,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "xAB" = (
@@ -56062,9 +56096,10 @@
 /area/station/engineering/atmos)
 "yfB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "yfI" = (
@@ -77695,12 +77730,12 @@ bbf
 aRF
 sht
 tAE
+aVR
 vsM
-jNT
-aUh
-uwt
-uwt
-moP
+wNR
+bwO
+ixe
+bwO
 aSa
 rEY
 syv
@@ -77950,14 +77985,14 @@ aMP
 dkn
 aQJ
 arY
+aSR
 xkQ
 ajj
 iRv
-wIy
-uTb
-arp
-jNT
-hll
+aOc
+bQk
+bQk
+tgh
 htu
 aSa
 sOk
@@ -78207,15 +78242,15 @@ xJB
 xJB
 tMw
 yin
-aSR
+aSS
 nQo
+aTa
 vsM
 gsh
-wNR
-tmP
-bQk
-wIy
-moP
+yfB
+yfB
+fwt
+bwO
 aEQ
 gnK
 bkd
@@ -78466,13 +78501,13 @@ tMw
 aRI
 aSS
 isT
+aUD
 bSg
-jYt
-bwO
-jYt
-tmP
-arp
-aCE
+ixe
+fwt
+yfB
+yfB
+kbe
 htu
 tdQ
 fwW
@@ -78723,11 +78758,11 @@ tMw
 qIT
 bdC
 aYQ
+ajj
 bSg
 bQk
 tgh
-fwt
-yfB
+bQk
 tgh
 aSa
 aSa
@@ -78980,11 +79015,11 @@ iyj
 apt
 aMv
 sGA
+ajj
 bSg
+tgh
 bQk
 tgh
-jYt
-tmP
 tgh
 fuo
 fVR
@@ -79237,11 +79272,11 @@ aQO
 abF
 aSV
 sLM
+uwt
 iRv
+bQk
 tgh
-tgh
-aso
-bwO
+bQk
 tgh
 aSa
 aSa
@@ -79493,14 +79528,14 @@ arT
 xDx
 kBe
 aMv
-aUD
+sGA
+soc
 bSg
-bQk
-tgh
-jYt
-tmP
 aso
+fwt
 yfB
+yfB
+bwO
 aSa
 lWl
 hJd
@@ -79750,14 +79785,14 @@ aJi
 tMw
 lWg
 qZy
-aUD
+sGA
+soc
 bSg
-bQk
-tgh
+jYt
+yfB
 fwt
-gsh
-bwO
-bQk
+yfB
+tmP
 htu
 nKo
 gnK
@@ -80007,14 +80042,14 @@ bcI
 tMw
 aRI
 aSY
-aWI
+sLM
+soc
 bSg
-bQk
-tgh
-aLL
-jYt
-kbe
-bQk
+aso
+fwt
+yfB
+fwt
+bwO
 aSa
 vDy
 lcv
@@ -80264,14 +80299,14 @@ ads
 tMw
 aDB
 xAq
-aWI
+sLM
+soc
 iRv
-bQk
-aso
+jYt
 yfB
 fwt
-bwO
-bQk
+yfB
+tmP
 jAE
 bhj
 bbm
@@ -80521,14 +80556,14 @@ aPM
 aQS
 aLx
 dBo
-aVR
+sLM
+soc
 iRv
 aso
+fwt
+yfB
+fwt
 bwO
-aso
-wNR
-kbe
-tgh
 jAE
 aiV
 vGV
@@ -80776,16 +80811,16 @@ aOd
 aOG
 aPN
 aUJ
+aWI
 fuT
-aTa
 aPP
+aCE
 plZ
 wyK
-fwt
-gsh
-gsh
-gsh
+aso
 tmP
+aso
+kbe
 jAE
 bbl
 aOM

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -656,11 +656,11 @@
 				supermatter_zap(src, range, clamp(power*2, 4000, 20000), flags)
 
 		if(prob(5))
-			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 7))
+			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 7)) // SS220 EDIT - уменьшение максимальной дальности спавна аномалий, чтоб не выходили за отсек СМа: rand(5, 10) -> rand (5, 7)
 		if((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || prob(1))
-			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 7))
+			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 7)) // SS220 EDIT - уменьшение максимальной дальности спавна аномалий, чтоб не выходили за отсек СМа: rand(5, 10) -> rand (5, 7)
 		if(((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (prob(0.3) && (power * gas_coefficient) > POWER_PENALTY_THRESHOLD))
-			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 7))
+			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 7)) // SS220 EDIT - уменьшение максимальной дальности спавна аномалий, чтоб не выходили за отсек СМа: rand(5, 10) -> rand (5, 7)
 
 	if(prob(15))
 		supermatter_pull(loc, min(power / 850, 3)) //850, 1700, 2550

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -656,11 +656,11 @@
 				supermatter_zap(src, range, clamp(power*2, 4000, 20000), flags)
 
 		if(prob(5))
-			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
+			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 7))
 		if((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || prob(1))
-			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 10))
+			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 7))
 		if(((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (prob(0.3) && (power * gas_coefficient) > POWER_PENALTY_THRESHOLD))
-			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 10))
+			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 7))
 
 	if(prob(15))
 		supermatter_pull(loc, min(power / 850, 3)) //850, 1700, 2550


### PR DESCRIPTION
## Что этот PR делает

Мигрирует все внешние станционные шлюзы на систему с хелперами.
Плюсом минорные исправления/доработки тех. тоннелей.

## Почему это хорошо для игры

Приведение нескольких вариантов реализации к единой системе через хелперы.
Ну и фиксы - всегда хорошо.

## Изображения изменений

mapdiff

## Тестирование

BoxStation: все внешние шлюзы протыканы - работают корректно. Других проблем не замечено.
DeltaStation: WIP
MetaStation: WIP
OmegaStation: WIP

## Changelog

:cl:
tweak: Все карты: внешние шлюзы перестроены с использованием хелперов.
tweak: Все карты: минорные доработки и фиксы технических тоннелей.
/:cl:
