### PR TITLE
TWEAK: Уменьшение радиуса спауна аномалий СМом

### DIFF
--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -12957,7 +12957,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aLz" = (
@@ -13069,14 +13068,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13091,14 +13090,14 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment/corner{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment/corner{
-	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13109,15 +13108,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/effect/turf_decal/tiles/department/engineering/corner,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -13322,9 +13321,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/hydroponics)
 "aMv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -13794,6 +13790,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOb" = (
@@ -13816,15 +13813,14 @@
 	dir = 8;
 	network = list("SS13","Engineering")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
 /obj/machinery/alarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOf" = (
@@ -13999,6 +13995,7 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOE" = (
@@ -14021,13 +14018,12 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/storage)
 "aOG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc/critical/directional/east,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aOH" = (
@@ -14522,6 +14518,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPK" = (
@@ -14555,7 +14552,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPO" = (
@@ -14868,9 +14864,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aQU" = (
@@ -15106,6 +15099,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aRI" = (
@@ -15472,11 +15466,17 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSS" = (
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -15499,22 +15499,16 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/science/toxins/mixing)
 "aSV" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -16075,9 +16069,6 @@
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -18066,6 +18057,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "bbh" = (
@@ -18782,7 +18774,7 @@
 /area/station/maintenance/asmaint)
 "bdC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -25232,9 +25224,6 @@
 /turf/simulated/floor/plasteel,
 /area/station/maintenance/apmaint)
 "dBo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -33941,12 +33930,11 @@
 /turf/space,
 /area/station/science/toxins/mixing)
 "jxf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "jxp" = (
@@ -43985,6 +43973,13 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/procedure/trainer_office)
+"qHX" = (
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/supermatter_room)
 "qIe" = (
 /obj/machinery/atmospherics/unary/thermomachine/freezer,
 /turf/simulated/floor/plasteel,
@@ -44381,9 +44376,6 @@
 /turf/simulated/floor/wood/fancy/oak,
 /area/station/service/library)
 "qZy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -45995,6 +45987,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "shu" = (
@@ -54946,9 +54941,6 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "xAq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 8
 	},
@@ -77722,7 +77714,7 @@ aIf
 aJp
 aKy
 aLM
-soc
+qHX
 aNY
 aOz
 aPI
@@ -77991,7 +77983,7 @@ ajj
 iRv
 aOc
 bQk
-bQk
+tgh
 tgh
 htu
 aSa
@@ -78248,7 +78240,7 @@ aTa
 vsM
 gsh
 yfB
-yfB
+fwt
 fwt
 bwO
 aEQ

--- a/_maps/map_files220/stations/omegastation.dmm
+++ b/_maps/map_files220/stations/omegastation.dmm
@@ -570,9 +570,6 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/ntrep)
 "abF" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/structure/reflector/box{
 	anchored = 1;
 	dir = 1
@@ -5019,9 +5016,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/meter{
-	autolink_id = "sm_sen_cold"
-	},
 /obj/structure/cable/extra_insulated{
 	icon_state = "4-8"
 	},
@@ -5264,6 +5258,10 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "apz" = (
@@ -5890,13 +5888,6 @@
 /obj/structure/rack,
 /turf/simulated/floor/plasteel/dark,
 /area/station/security/armory/secure)
-"arp" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/space,
-/area/space/nearstation)
 "arr" = (
 /obj/machinery/atmospherics/trinary/filter{
 	dir = 8;
@@ -6126,6 +6117,9 @@
 	},
 /obj/machinery/atmospherics/binary/pump{
 	name = "Loop to Freezer"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -8131,6 +8125,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
 "ayA" = (
@@ -9509,12 +9506,14 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/atmos)
 "aCE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 9
+/obj/machinery/atmospherics/binary/valve/open{
+	name = "Filter to Space"
 	},
-/turf/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 6
+	},
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/supermatter_room)
 "aCF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -12176,6 +12175,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aJv" = (
@@ -12950,9 +12952,12 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aLz" = (
@@ -13322,6 +13327,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -14298,6 +14309,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine/supermatter)
 "aPq" = (
@@ -14530,25 +14544,18 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPN" = (
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPO" = (
@@ -14566,9 +14573,13 @@
 /turf/simulated/floor/plating,
 /area/station/science/rnd)
 "aPP" = (
-/obj/machinery/atmospherics/binary/valve/open{
-	name = "Filter to Space"
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tiles/department/engineering/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aPR" = (
@@ -14789,6 +14800,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aQK" = (
@@ -14845,11 +14859,18 @@
 "aQS" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aQU" = (
@@ -15447,14 +15468,15 @@
 /turf/simulated/floor/plating/asteroid,
 /area/station/maintenance/fpmaint2)
 "aSR" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -15484,6 +15506,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aSY" = (
@@ -15497,14 +15522,15 @@
 	dir = 4;
 	name = "Gas to Loop"
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aTa" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 4
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -16008,13 +16034,8 @@
 /turf/simulated/floor/plasteel/dark,
 /area/station/service/bar)
 "aUD" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/trinary/filter/flipped{
-	dir = 4;
-	filter_type = -1
-	},
+/obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/effect/turf_decal/tiles/department/engineering/corner,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aUE" = (
@@ -16055,7 +16076,12 @@
 /obj/effect/turf_decal/tiles/department/engineering/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aUK" = (
@@ -16385,12 +16411,10 @@
 /turf/simulated/floor/plating/airless,
 /area/station/science/toxins/test)
 "aVR" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
+/obj/effect/turf_decal/tiles/department/engineering/side{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 9
-	},
+/obj/machinery/atmospherics/binary/volume_pump/on,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aVV" = (
@@ -16652,11 +16676,9 @@
 /area/station/service/library)
 "aWI" = (
 /obj/effect/turf_decal/tiles/department/engineering/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aWJ" = (
@@ -17373,11 +17395,11 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/medical/medbay)
 "aYQ" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 4;
 	filter_type = 2
 	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "aYS" = (
@@ -18764,6 +18786,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -21824,6 +21849,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/tiles/department/engineering/side,
+/obj/machinery/atmospherics/meter{
+	autolink_id = "sm_sen_cold"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "bxc" = (
@@ -24726,6 +24754,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "dli" = (
@@ -25207,11 +25238,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
+	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -28031,8 +28062,9 @@
 /area/station/supply/qm)
 "fwt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 10
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/structure/lattice,
 /turf/space,
 /area/space/nearstation)
@@ -32435,9 +32467,8 @@
 /turf/simulated/floor/carpet/red,
 /area/station/command/office/hos)
 "isT" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
@@ -35420,6 +35451,10 @@
 /obj/effect/turf_decal/tiles/department/engineering/side{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/delivery/red,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "kBq" = (
@@ -39782,11 +39817,10 @@
 /turf/simulated/floor/plasteel/white,
 /area/station/service/kitchen)
 "nQo" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 1;
-	name = "Gas to Cooling Loop"
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
 	},
-/obj/effect/turf_decal/tiles/department/engineering/corner,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "nQp" = (
@@ -44356,6 +44390,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "rae" = (
@@ -46652,11 +46689,11 @@
 /turf/simulated/floor/bluegrid,
 /area/station/turret_protected/ai_upload)
 "sGA" = (
-/obj/effect/turf_decal/tiles/department/engineering/corner,
 /obj/machinery/atmospherics/trinary/filter/flipped{
 	dir = 4;
 	filter_type = -1
 	},
+/obj/effect/turf_decal/delivery/hollow,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "sGC" = (
@@ -47073,9 +47110,6 @@
 /turf/simulated/floor/carpet/grimey,
 /area/station/command/office/hop)
 "sLM" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/status_display/directional/south,
-/obj/effect/turf_decal/tiles/department/engineering/side,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -48598,12 +48632,8 @@
 /turf/simulated/floor/plating,
 /area/station/medical/virology/lab)
 "tAE" = (
-/obj/effect/turf_decal/tiles/department/engineering/side{
-	dir = 10
-	},
-/obj/machinery/atmospherics/binary/pump/on{
-	name = "Gas to Cooling Loop"
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/meter,
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "tBb" = (
@@ -50092,10 +50122,11 @@
 /turf/simulated/floor/plasteel,
 /area/station/security/permabrig)
 "uwt" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/space,
-/area/space/nearstation)
+/obj/machinery/status_display/directional/south,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tiles/department/engineering/side,
+/turf/simulated/floor/plasteel/dark,
+/area/station/engineering/supermatter_room)
 "uwJ" = (
 /obj/machinery/door/airlock/public/glass{
 	dir = 4
@@ -54924,6 +54955,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
+/obj/structure/cable/extra_insulated{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plasteel/dark,
 /area/station/engineering/supermatter_room)
 "xAB" = (
@@ -56062,9 +56096,10 @@
 /area/station/engineering/atmos)
 "yfB" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging,
+/obj/structure/lattice/catwalk,
 /turf/space,
 /area/space/nearstation)
 "yfI" = (
@@ -77695,12 +77730,12 @@ bbf
 aRF
 sht
 tAE
+aVR
 vsM
-jNT
-aUh
-uwt
-uwt
-moP
+wNR
+bwO
+ixe
+bwO
 aSa
 rEY
 syv
@@ -77950,14 +77985,14 @@ aMP
 dkn
 aQJ
 arY
+aSR
 xkQ
 ajj
 iRv
-wIy
-uTb
-arp
-jNT
-hll
+aOc
+bQk
+bQk
+tgh
 htu
 aSa
 sOk
@@ -78207,15 +78242,15 @@ xJB
 xJB
 tMw
 yin
-aSR
+aSS
 nQo
+aTa
 vsM
 gsh
-wNR
-tmP
-bQk
-wIy
-moP
+yfB
+yfB
+fwt
+bwO
 aEQ
 gnK
 bkd
@@ -78466,13 +78501,13 @@ tMw
 aRI
 aSS
 isT
+aUD
 bSg
-jYt
-bwO
-jYt
-tmP
-arp
-aCE
+ixe
+fwt
+yfB
+yfB
+kbe
 htu
 tdQ
 fwW
@@ -78723,11 +78758,11 @@ tMw
 qIT
 bdC
 aYQ
+ajj
 bSg
 bQk
 tgh
-fwt
-yfB
+bQk
 tgh
 aSa
 aSa
@@ -78980,11 +79015,11 @@ iyj
 apt
 aMv
 sGA
+ajj
 bSg
+tgh
 bQk
 tgh
-jYt
-tmP
 tgh
 fuo
 fVR
@@ -79237,11 +79272,11 @@ aQO
 abF
 aSV
 sLM
+uwt
 iRv
+bQk
 tgh
-tgh
-aso
-bwO
+bQk
 tgh
 aSa
 aSa
@@ -79493,14 +79528,14 @@ arT
 xDx
 kBe
 aMv
-aUD
+sGA
+soc
 bSg
-bQk
-tgh
-jYt
-tmP
 aso
+fwt
 yfB
+yfB
+bwO
 aSa
 lWl
 hJd
@@ -79750,14 +79785,14 @@ aJi
 tMw
 lWg
 qZy
-aUD
+sGA
+soc
 bSg
-bQk
-tgh
+jYt
+yfB
 fwt
-gsh
-bwO
-bQk
+yfB
+tmP
 htu
 nKo
 gnK
@@ -80007,14 +80042,14 @@ bcI
 tMw
 aRI
 aSY
-aWI
+sLM
+soc
 bSg
-bQk
-tgh
-aLL
-jYt
-kbe
-bQk
+aso
+fwt
+yfB
+fwt
+bwO
 aSa
 vDy
 lcv
@@ -80264,14 +80299,14 @@ ads
 tMw
 aDB
 xAq
-aWI
+sLM
+soc
 iRv
-bQk
-aso
+jYt
 yfB
 fwt
-bwO
-bQk
+yfB
+tmP
 jAE
 bhj
 bbm
@@ -80521,14 +80556,14 @@ aPM
 aQS
 aLx
 dBo
-aVR
+sLM
+soc
 iRv
 aso
+fwt
+yfB
+fwt
 bwO
-aso
-wNR
-kbe
-tgh
 jAE
 aiV
 vGV
@@ -80776,16 +80811,16 @@ aOd
 aOG
 aPN
 aUJ
+aWI
 fuT
-aTa
 aPP
+aCE
 plZ
 wyK
-fwt
-gsh
-gsh
-gsh
+aso
 tmP
+aso
+kbe
 jAE
 bbl
 aOM

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -656,11 +656,11 @@
 				supermatter_zap(src, range, clamp(power*2, 4000, 20000), flags)
 
 		if(prob(5))
-			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 7))
+			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 7)) // SS220 EDIT - уменьшение максимальной дальности спавна аномалий, чтоб не выходили за отсек СМа: rand(5, 10) -> rand (5, 7)
 		if((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || prob(1))
-			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 7))
+			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 7)) // SS220 EDIT - уменьшение максимальной дальности спавна аномалий, чтоб не выходили за отсек СМа: rand(5, 10) -> rand (5, 7)
 		if(((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (prob(0.3) && (power * gas_coefficient) > POWER_PENALTY_THRESHOLD))
-			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 7))
+			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 7)) // SS220 EDIT - уменьшение максимальной дальности спавна аномалий, чтоб не выходили за отсек СМа: rand(5, 10) -> rand (5, 7)
 
 	if(prob(15))
 		supermatter_pull(loc, min(power / 850, 3)) //850, 1700, 2550

--- a/code/modules/power/engines/supermatter/supermatter.dm
+++ b/code/modules/power/engines/supermatter/supermatter.dm
@@ -656,11 +656,11 @@
 				supermatter_zap(src, range, clamp(power*2, 4000, 20000), flags)
 
 		if(prob(5))
-			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
+			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 7))
 		if((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(5) || prob(1))
-			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 10))
+			supermatter_anomaly_gen(src, GRAVITATIONAL_ANOMALY, rand(5, 7))
 		if(((power * gas_coefficient) > SEVERE_POWER_PENALTY_THRESHOLD && prob(2)) || (prob(0.3) && (power * gas_coefficient) > POWER_PENALTY_THRESHOLD))
-			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 10))
+			supermatter_anomaly_gen(src, BLUESPACE_ANOMALY, rand(5, 7))
 
 	if(prob(15))
 		supermatter_pull(loc, min(power / 850, 3)) //850, 1700, 2550


### PR DESCRIPTION
## Что этот PR делает

Уменьшение максимального радиуса спавна аномалий СМом 10 -> 7, чтобы на всех картах они спавнились в пределах комнаты СМа.
Минорное изменение комнаты СМа на Георгонисе.

## Почему это хорошо для игры

СМ перестанет грав и бс аномалиями "разносить" половину инженерного отсека.
На Георгонисе аномалии не будут спавниться в техах и коридорах.

## Изображения изменений

mapdiff

## Тестирование

Локальный сервер.
Аномалии спавнятся в пределах комнаты СМа.

## Changelog

:cl:
tweak: Аномалии теперь не спавнятся за пределами отсека СМа.
/:cl:
